### PR TITLE
Fix Windows Web Build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,8 @@ jobs:
         if: matrix.mode == 'Release'
         run: |
           cd .\ui\web
-          .\node_modules\elm\binwrappers\elm-make --yes src\Main.elm --output elm.js
+          move .\node_modules\elm\binwrappers\elm-make .\elm-make
+          elm-make --yes src\Main.elm --output elm.js
           Remove-Item -Recurse -Force .\node_modules
 
       - name: Create Distribution


### PR DESCRIPTION
"elm-make" call does nothing:

> Der Befehl "node_modules\elm\binwrappers\elm-make" ist entweder falsch geschrieben oder
> konnte nicht gefunden werden.

Copying it to the current directory seems to work:

    move .\node_modules\elm\binwrappers\elm-make .
    elm-make .\src\Main.elm --output elm.js
    Some new packages are needed. Here is the upgrade plan.
    [...]