### PR TITLE
Progress Updates from New Threads

### DIFF
--- a/base/bootstrap/include/motis/bootstrap/import_status.h
+++ b/base/bootstrap/include/motis/bootstrap/import_status.h
@@ -7,6 +7,7 @@
 #include "cista/reflection/comparable.h"
 
 #include "motis/module/message.h"
+#include "motis/module/progress_listener.h"
 
 namespace motis::bootstrap {
 
@@ -18,13 +19,22 @@ struct state {
   std::string error_;
 };
 
-struct import_status {
+struct import_status : public module::progress_listener {
   bool update(motis::module::msg_ptr const&);
   void print();
 
+  void update_progress(std::string const& task_name,
+                       unsigned progress) override;
+  void report_error(std::string const& task_name,
+                    std::string const& what) override;
+
+  bool silent_{false};
+
+private:
+  bool update(std::string const& task_name, state const& new_state);
+
   unsigned last_print_height_{0U};
   std::map<std::string, state> status_;
-  bool silent_{false};
 };
 
 }  // namespace motis::bootstrap

--- a/base/bootstrap/src/motis_instance.cc
+++ b/base/bootstrap/src/motis_instance.cc
@@ -66,7 +66,7 @@ void motis_instance::import(module_settings const& module_opt,
   registry_.subscribe("/import", import_osm);
 
   std::make_shared<event_collector>(
-      import_opt.data_directory_, "schedule", registry_,
+      status, import_opt.data_directory_, "schedule", registry_,
       [&](std::map<std::string, msg_ptr> const& dependencies) {
         import_schedule(module_opt, dataset_opt, dependencies.at("SCHEDULE"),
                         *this);
@@ -98,7 +98,7 @@ void motis_instance::import(module_settings const& module_opt,
   for (auto const& module : modules_) {
     if (module_opt.is_module_active(module->module_name())) {
       module->set_data_directory(import_opt.data_directory_);
-      module->import(registry_);
+      module->import(status, registry_);
     }
   }
 

--- a/base/module/include/motis/module/clog_redirect.h
+++ b/base/module/include/motis/module/clog_redirect.h
@@ -5,11 +5,13 @@
 
 #include "motis/module/ctx_data.h"
 #include "motis/module/dispatcher.h"
+#include "motis/module/progress_listener.h"
 
 namespace motis::module {
 
 struct clog_redirect : public std::streambuf {
-  clog_redirect(std::string name, char const* log_file_path);
+  clog_redirect(progress_listener&, std::string name,
+                char const* log_file_path);
 
   clog_redirect(clog_redirect const&) = delete;
   clog_redirect(clog_redirect&&) = delete;
@@ -23,7 +25,6 @@ struct clog_redirect : public std::streambuf {
   static void disable();
 
 private:
-  void publish(msg_ptr const&);
   void update_error(std::string const& error);
   void update_progress(int progress);
 
@@ -38,9 +39,7 @@ private:
   std::string name_;
   std::streambuf* backup_clog_;
   std::string error_;
-  dispatcher* dispatcher_;
-  unsigned op_id_;
-  ctx_data op_data_;
+  progress_listener& progress_listener_;
   static bool disabled_;
 };
 

--- a/base/module/include/motis/module/clog_redirect.h
+++ b/base/module/include/motis/module/clog_redirect.h
@@ -3,6 +3,9 @@
 #include <fstream>
 #include <streambuf>
 
+#include "motis/module/ctx_data.h"
+#include "motis/module/dispatcher.h"
+
 namespace motis::module {
 
 struct clog_redirect : public std::streambuf {
@@ -20,6 +23,10 @@ struct clog_redirect : public std::streambuf {
   static void disable();
 
 private:
+  void publish(msg_ptr const&);
+  void update_error(std::string const& error);
+  void update_progress(int progress);
+
   enum class output_state {
     NORMAL,
     MODE_SELECT,
@@ -31,6 +38,9 @@ private:
   std::string name_;
   std::streambuf* backup_clog_;
   std::string error_;
+  dispatcher* dispatcher_;
+  unsigned op_id_;
+  ctx_data op_data_;
   static bool disabled_;
 };
 

--- a/base/module/include/motis/module/event_collector.h
+++ b/base/module/include/motis/module/event_collector.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "motis/module/message.h"
+#include "motis/module/progress_listener.h"
 #include "motis/module/registry.h"
 
 namespace motis::module {
@@ -32,8 +33,8 @@ struct event_collector : std::enable_shared_from_this<event_collector> {
   using dependencies_map_t = std::map<std::string, msg_ptr>;
   using import_op_t = std::function<void(dependencies_map_t const&)>;
 
-  event_collector(std::string data_dir, std::string name, registry& reg,
-                  import_op_t op);
+  event_collector(progress_listener&, std::string data_dir, std::string name,
+                  registry& reg, import_op_t op);
 
   void require(std::string const& name, std::function<bool(msg_ptr)>);
 
@@ -47,6 +48,7 @@ private:
   dependencies_map_t dependencies_;
   std::set<std::string> waiting_for_;
   std::set<dependency_matcher> matchers_;
+  progress_listener& progress_listener_;
   bool executed_{false};
 };
 

--- a/base/module/include/motis/module/module.h
+++ b/base/module/include/motis/module/module.h
@@ -10,8 +10,8 @@
 #include "conf/configuration.h"
 
 #include "motis/core/schedule/synced_schedule.h"
-
 #include "motis/module/message.h"
+#include "motis/module/progress_listener.h"
 #include "motis/module/registry.h"
 
 namespace motis::module {
@@ -34,7 +34,7 @@ struct module : public conf::configuration {
   void set_data_directory(std::string const&);
   void set_context(motis::schedule& schedule);
 
-  virtual void import(registry&) {}
+  virtual void import(progress_listener&, registry&) {}
   virtual void init(registry&) {}
 
   virtual bool import_successful() const { return true; }

--- a/base/module/include/motis/module/progress_listener.h
+++ b/base/module/include/motis/module/progress_listener.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace motis::module {
+
+struct progress_listener {
+  virtual void update_progress(std::string const& task_name,
+                               unsigned progress) = 0;
+  virtual void report_error(std::string const& task_name,
+                            std::string const& what) = 0;
+};
+
+}  // namespace motis::module

--- a/base/module/src/clog_redirect.cc
+++ b/base/module/src/clog_redirect.cc
@@ -5,39 +5,16 @@
 
 namespace motis::module {
 
-void update_error(std::string const& name, std::string const& error) {
-  message_creator fbb;
-  fbb.create_and_finish(
-      MsgContent_StatusUpdate,
-      motis::import::CreateStatusUpdate(
-          fbb, fbb.CreateString(name),
-          fbb.CreateVector(
-              std::vector<flatbuffers::Offset<flatbuffers::String>>{}),
-          motis::import::Status::Status_ERROR, fbb.CreateString(error), 0)
-          .Union(),
-      "/import", DestinationType_Topic);
-  ctx::await_all(motis_publish(make_msg(fbb)));
-}
-
-void update_progress(std::string const& name, int const progress) {
-  message_creator fbb;
-  fbb.create_and_finish(
-      MsgContent_StatusUpdate,
-      motis::import::CreateStatusUpdate(
-          fbb, fbb.CreateString(name),
-          fbb.CreateVector(
-              std::vector<flatbuffers::Offset<flatbuffers::String>>{}),
-          motis::import::Status::Status_RUNNING, fbb.CreateString(""), progress)
-          .Union(),
-      "/import", DestinationType_Topic);
-  ctx::await_all(motis_publish(make_msg(fbb)));
-}
-
 clog_redirect::clog_redirect(std::string name, char const* log_file_path)
-    : name_{std::move(name)}, backup_clog_{std::clog.rdbuf()} {
+    : name_{std::move(name)},
+      backup_clog_{std::clog.rdbuf()},
+      dispatcher_{ctx::current_op<ctx_data>()->data_.dispatcher_},
+      op_id_{ctx::current_op<ctx_data>()->id_.index},
+      op_data_{ctx::current_op<ctx_data>()->data_} {
   if (disabled_) {
     return;
   }
+
   sink_.exceptions(std::ios_base::badbit | std::ios_base::failbit);
   sink_.open(log_file_path, std::ios_base::app);
   std::clog.rdbuf(this);
@@ -75,7 +52,7 @@ clog_redirect::int_type clog_redirect::overflow(clog_redirect::int_type c) {
 
     case output_state::PERCENT:
       if (traits_type::to_char_type(c) == PROGRESS_MARKER) {
-        update_progress(name_, percent_);
+        update_progress(percent_);
         state_ = output_state::NORMAL;
       } else {
         percent_ *= 10;
@@ -85,7 +62,7 @@ clog_redirect::int_type clog_redirect::overflow(clog_redirect::int_type c) {
 
     case output_state::ERR:
       if (traits_type::to_char_type(c) == PROGRESS_MARKER) {
-        update_error(name_, error_);
+        update_error(error_);
         error_.clear();
         state_ = output_state::NORMAL;
       } else {
@@ -95,6 +72,40 @@ clog_redirect::int_type clog_redirect::overflow(clog_redirect::int_type c) {
 
     default: return c;
   }
+}
+
+void clog_redirect::publish(msg_ptr const& msg) {
+  auto id = ctx::op_id(CTX_LOCATION);
+  id.parent_index = op_id_;
+  ctx::await_all(dispatcher_->publish(msg, op_data_, id));
+}
+
+void clog_redirect::update_error(std::string const& error) {
+  message_creator fbb;
+  fbb.create_and_finish(
+      MsgContent_StatusUpdate,
+      motis::import::CreateStatusUpdate(
+          fbb, fbb.CreateString(name_),
+          fbb.CreateVector(
+              std::vector<flatbuffers::Offset<flatbuffers::String>>{}),
+          motis::import::Status::Status_ERROR, fbb.CreateString(error), 0)
+          .Union(),
+      "/import", DestinationType_Topic);
+  publish(make_msg(fbb));
+}
+
+void clog_redirect::update_progress(int const progress) {
+  message_creator fbb;
+  fbb.create_and_finish(
+      MsgContent_StatusUpdate,
+      motis::import::CreateStatusUpdate(
+          fbb, fbb.CreateString(name_),
+          fbb.CreateVector(
+              std::vector<flatbuffers::Offset<flatbuffers::String>>{}),
+          motis::import::Status::Status_RUNNING, fbb.CreateString(""), progress)
+          .Union(),
+      "/import", DestinationType_Topic);
+  publish(make_msg(fbb));
 }
 
 void clog_redirect::disable() { disabled_ = true; }

--- a/base/module/src/event_collector.cc
+++ b/base/module/src/event_collector.cc
@@ -12,12 +12,14 @@ namespace fs = boost::filesystem;
 
 namespace motis::module {
 
-event_collector::event_collector(std::string data_dir, std::string name,
+event_collector::event_collector(progress_listener& progress_listener,
+                                 std::string data_dir, std::string name,
                                  registry& reg, import_op_t op)
     : data_dir_{std::move(data_dir)},
       module_name_{std::move(name)},
       reg_{reg},
-      op_{std::move(op)} {}
+      op_{std::move(op)},
+      progress_listener_{progress_listener} {}
 
 void event_collector::update_status(motis::import::Status const status,
                                     uint8_t const progress) {
@@ -46,7 +48,7 @@ void event_collector::require(std::string const& name,
         auto const logs_path = fs::path{data_dir_} / "log";
         fs::create_directories(logs_path);
         clog_redirect redirect{
-            module_name_,
+            progress_listener_, module_name_,
             (logs_path / (module_name_ + ".txt")).generic_string().c_str()};
 
         // Dummy message asking for initial status.

--- a/modules/address/include/motis/address/address.h
+++ b/modules/address/include/motis/address/address.h
@@ -14,7 +14,8 @@ struct address : public motis::module::module {
   address(address&&) = delete;
   address& operator=(address&&) = delete;
 
-  void import(motis::module::registry& reg) override;
+  void import(motis::module::progress_listener&,
+              motis::module::registry&) override;
   void init(motis::module::registry&) override;
 
   bool import_successful() const override { return import_successful_; }

--- a/modules/address/src/address.cc
+++ b/modules/address/src/address.cc
@@ -125,9 +125,10 @@ std::string address::db_file() const {
   return (get_data_directory() / "address" / "address_db.raw").generic_string();
 }
 
-void address::import(motis::module::registry& reg) {
+void address::import(progress_listener& progress_listener,
+                     motis::module::registry& reg) {
   std::make_shared<event_collector>(
-      get_data_directory().generic_string(), "address", reg,
+      progress_listener, get_data_directory().generic_string(), "address", reg,
       [this](std::map<std::string, msg_ptr> const& dependencies) {
         using import::OSMEvent;
 

--- a/modules/osrm/include/motis/osrm/osrm.h
+++ b/modules/osrm/include/motis/osrm/osrm.h
@@ -20,7 +20,8 @@ public:
   osrm(osrm&&) = delete;
   osrm& operator=(osrm&&) = delete;
 
-  void import(motis::module::registry&) override;
+  void import(motis::module::progress_listener&,
+              motis::module::registry&) override;
   void init(motis::module::registry&) override;
   void init_async();
 

--- a/modules/osrm/src/osrm.cc
+++ b/modules/osrm/src/osrm.cc
@@ -40,12 +40,14 @@ osrm::osrm() : module("OSRM Options", "osrm") {
 
 osrm::~osrm() = default;
 
-void osrm::import(motis::module::registry& reg) {
+void osrm::import(progress_listener& progress_listener,
+                  motis::module::registry& reg) {
   for (auto const& p : profiles_) {
     auto const profile_name =
         boost::filesystem::path{p}.stem().generic_string();
     std::make_shared<event_collector>(
-        get_data_directory().generic_string(), "osrm-" + profile_name, reg,
+        progress_listener, get_data_directory().generic_string(),
+        "osrm-" + profile_name, reg,
         [this, profile_name, p, data_dir = get_data_directory()](
             std::map<std::string, msg_ptr> const& dependencies) {
           using import::OSMEvent;


### PR DESCRIPTION
Since in new spawned threads `ctx::current_op` is not available (uses `thread_local` variable and the stacks are wrong), progress updates should not need to go through `ctx::call`. This PR implements a direct way to update the progress through `motis::module::progress_listener` which is implemented in `motis::bootstrap::import_status`.