### PR TITLE
rt single

### DIFF
--- a/modules/rt/add_train.py
+++ b/modules/rt/add_train.py
@@ -1,0 +1,65 @@
+#!/bin/env python3
+
+import argparse
+import json
+import requests
+import time
+
+
+def make_query(dep, arr, t = int(time.time())):
+  return {
+    'destination': {
+      'type': 'Module',
+      'target': '/rt/single',
+    }, 
+    'content_type': 'Message',
+    'content': {
+      'earliest': 0,
+      'latest': 0,
+      'timestamp': 0,
+      'content_type': 'AdditionMessage',
+      'content': {
+          'trip_id': {
+            'station_id': dep,
+            'service_num': 77777,
+            'schedule_time': t - 2 * 60,
+            'trip_type': 'Additional'
+          },
+          'events': [{
+            'base': {
+              'station_id': dep,
+              'service_num': 77777,
+              'line_id': '',
+              'type': 'DEP',
+              'schedule_time': t - 2 * 60
+            },
+            'category': 'TGV',
+            'track': '9'
+          }, {
+            'base': {
+              'station_id': arr,
+              'service_num': 77777,
+              'line_id': '',
+              'type': 'ARR',
+              'schedule_time': t + 20 * 60
+            },
+            'category': 'TGV',
+            'track': '9'
+          }]
+      }
+    }
+  }
+
+
+if __name__ == '__main__':
+  p = argparse.ArgumentParser(description='adds a single additional train', 
+                              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  p.add_argument('--url', '-u', nargs='?', default='http://localhost:8080', help='MOTIS url')
+  p.add_argument('--dep', '-d', nargs='?', default='8000105', help='dep station id')
+  p.add_argument('--arr', '-a', nargs='?', default='8000068', help='arr station id')
+
+  args = p.parse_args()
+
+  r = requests.post(args.url, json = make_query(args.dep, args.arr))
+  print(r.status_code)
+  print(r.text)

--- a/modules/rt/include/motis/rt/error.h
+++ b/modules/rt/include/motis/rt/error.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <system_error>
+#include <type_traits>
+
+namespace motis::rt {
+
+namespace error {
+enum error_code_t {
+  ok = 0,
+  sanity_check_failed = 1,
+};
+}  // namespace error
+
+class error_category_impl : public std::error_category {
+public:
+  const char* name() const noexcept override { return "motis::rt"; }
+
+  std::string message(int ev) const noexcept override {
+    switch (ev) {
+      case error::ok: return "rt: no error";
+      case error::sanity_check_failed: return "rt: sanity check failed";
+      default: return "rt: unkown error";
+    }
+  }
+};
+
+inline const std::error_category& error_category() {
+  static error_category_impl instance;
+  return instance;
+}
+
+namespace error {
+inline std::error_code make_error_code(error_code_t e) noexcept {
+  return std::error_code(static_cast<int>(e), error_category());
+}
+}  // namespace error
+
+}  // namespace motis::rt
+
+namespace std {
+template <>
+struct is_error_code_enum<motis::rt::error::error_code_t>
+    : public std::true_type {};
+
+}  // namespace std

--- a/modules/rt/include/motis/rt/rt_handler.h
+++ b/modules/rt/include/motis/rt/rt_handler.h
@@ -19,6 +19,8 @@ struct rt_handler {
                       bool validate_constant_graph);
 
   motis::module::msg_ptr update(motis::module::msg_ptr const&);
+  motis::module::msg_ptr single(motis::module::msg_ptr const&);
+  void update(schedule&, motis::ris::Message const*);
   motis::module::msg_ptr flush(motis::module::msg_ptr const&);
 
 private:

--- a/modules/rt/include/motis/rt/statistics.h
+++ b/modules/rt/include/motis/rt/statistics.h
@@ -160,8 +160,19 @@ struct statistics {
     }
   }
 
-  void resolve_events(std::vector<boost::optional<ev_key>> const&) {}
-  // void count_reroute(reroute_result const) {}
+  bool sanity_check_fails() const {
+    return (ev_invalid_time_ + ev_station_not_found_ + ev_trp_not_found_ +
+            additional_not_found_ + unresolved_events_ +
+            update_time_out_of_schedule_ + trip_station_not_found_ +
+            trip_time_not_found_ + trip_primary_not_found_ +
+            trip_primary_0_not_found_ + reroute_trip_not_found_ +
+            reroute_event_count_mismatch_ + reroute_station_mismatch_ +
+            reroute_event_order_mismatch_ +
+            reroute_rule_service_not_supported_ + additional_err_count_ +
+            additional_err_order_ + additional_err_station_ +
+            additional_err_time_ + additional_decreasing_ev_time_ +
+            additional_station_mismatch_ + canceled_trp_not_found_) != 0;
+  }
 
   unsigned delay_msgs_ = 0;
   unsigned cancel_msgs_ = 0;

--- a/modules/rt/src/rt.cc
+++ b/modules/rt/src/rt.cc
@@ -33,7 +33,10 @@ void rt::init(motis::module::registry& reg) {
       ctx::access_t::WRITE);
   reg.subscribe(
       "/ris/system_time_changed",
-      [&](motis::module::msg_ptr const& msg) { return handler_->flush(msg); },
+      [&](motis::module::msg_ptr const& msg) {
+        handler_->flush(msg);
+        return nullptr;
+      },
       ctx::access_t::WRITE);
   reg.register_op("/rt/dump", [&](motis::module::msg_ptr const& msg) {
     auto const m = motis_content(RtWriteGraphRequest, msg);

--- a/modules/rt/src/rt.cc
+++ b/modules/rt/src/rt.cc
@@ -27,6 +27,10 @@ void rt::init(motis::module::registry& reg) {
       "/ris/messages",
       [&](motis::module::msg_ptr const& msg) { return handler_->update(msg); },
       ctx::access_t::WRITE);
+  reg.register_op(
+      "/rt/single",
+      [&](motis::module::msg_ptr const& msg) { return handler_->single(msg); },
+      ctx::access_t::WRITE);
   reg.subscribe(
       "/ris/system_time_changed",
       [&](motis::module::msg_ptr const& msg) { return handler_->flush(msg); },

--- a/modules/rt/src/rt_handler.cc
+++ b/modules/rt/src/rt_handler.cc
@@ -101,10 +101,10 @@ msg_ptr rt_handler::single(msg_ptr const& msg) {
 }
 
 void rt_handler::update(schedule& s, motis::ris::Message const* m) {
-  stats_.count_message(nested->content_type());
-  auto c = nested->content();
+  stats_.count_message(m->content_type());
+  auto c = m->content();
   try {
-    switch (nested->content_type()) {
+    switch (m->content_type()) {
       case ris::MessageUnion_DelayMessage: {
         auto const msg = reinterpret_cast<ris::DelayMessage const*>(c);
         stats_.total_updates_ += msg->events()->size();
@@ -246,7 +246,7 @@ void rt_handler::update(schedule& s, motis::ris::Message const* m) {
             utl::to_vec(*msg->events(),
                         [](ris::Event const* ev) { return ev; }));
         if (trp == nullptr) {
-          continue;
+          return;
         }
         auto const events = utl::all(resolved)  //
                             | utl::remove_if([](auto&& k) { return !k; })  //

--- a/modules/rt/src/rt_handler.cc
+++ b/modules/rt/src/rt_handler.cc
@@ -12,6 +12,7 @@
 #include "motis/module/context/get_schedule.h"
 #include "motis/module/context/motis_publish.h"
 
+#include "motis/rt/error.h"
 #include "motis/rt/event_resolver.h"
 #include "motis/rt/reroute.h"
 #include "motis/rt/separate_trip.h"
@@ -88,7 +89,13 @@ msg_ptr rt_handler::update(msg_ptr const& msg) {
 
   auto& s = module::get_schedule();
   for (auto const& m : *motis_content(RISBatch, msg)->messages()) {
-    update(s, m->message_nested_root());
+    try {
+      update(s, m->message_nested_root());
+    } catch (std::exception const& e) {
+      printf("rt::on_message: UNEXPECTED ERROR: %s\n", e.what());
+    } catch (...) {
+      printf("rt::on_message: UNEXPECTED UNKNOWN ERROR\n");
+    }
   }
   return nullptr;
 }
@@ -96,177 +103,168 @@ msg_ptr rt_handler::update(msg_ptr const& msg) {
 msg_ptr rt_handler::single(msg_ptr const& msg) {
   using ris::Message;
   update(module::get_schedule(), motis_content(Message, msg));
-  flush(nullptr);
-  return nullptr;
+  return flush(nullptr);
 }
 
 void rt_handler::update(schedule& s, motis::ris::Message const* m) {
   stats_.count_message(m->content_type());
   auto c = m->content();
-  try {
-    switch (m->content_type()) {
-      case ris::MessageUnion_DelayMessage: {
-        auto const msg = reinterpret_cast<ris::DelayMessage const*>(c);
-        stats_.total_updates_ += msg->events()->size();
 
-        auto const reason = (msg->type() == ris::DelayType_Is)
-                                ? timestamp_reason::IS
-                                : timestamp_reason::FORECAST;
+  switch (m->content_type()) {
+    case ris::MessageUnion_DelayMessage: {
+      auto const msg = reinterpret_cast<ris::DelayMessage const*>(c);
+      stats_.total_updates_ += msg->events()->size();
 
-        auto const resolved = resolve_events(
-            stats_, s, msg->trip_id(),
-            utl::to_vec(*msg->events(), [](ris::UpdatedEvent const* ev) {
-              return ev->base();
-            }));
+      auto const reason = (msg->type() == ris::DelayType_Is)
+                              ? timestamp_reason::IS
+                              : timestamp_reason::FORECAST;
 
-        for (auto i = 0UL; i < resolved.size(); ++i) {
-          auto const& resolved_ev = resolved[i];
-          if (!resolved_ev) {
-            ++stats_.unresolved_events_;
-            continue;
-          }
+      auto const resolved = resolve_events(
+          stats_, s, msg->trip_id(),
+          utl::to_vec(*msg->events(),
+                      [](ris::UpdatedEvent const* ev) { return ev->base(); }));
 
-          auto const upd_time =
-              unix_to_motistime(s, msg->events()->Get(i)->updated_time());
-          if (upd_time == INVALID_TIME) {
-            ++stats_.update_time_out_of_schedule_;
-            continue;
-          }
-
-          propagator_.add_delay(*resolved_ev, reason, upd_time);
-          ++stats_.found_updates_;
+      for (auto i = 0UL; i < resolved.size(); ++i) {
+        auto const& resolved_ev = resolved[i];
+        if (!resolved_ev) {
+          ++stats_.unresolved_events_;
+          continue;
         }
 
-        break;
-      }
-
-      case ris::MessageUnion_AdditionMessage: {
-        auto result = additional_service_builder(s).build_additional_train(
-            reinterpret_cast<ris::AdditionMessage const*>(c));
-        stats_.count_additional(result);
-        break;
-      }
-
-      case ris::MessageUnion_CancelMessage: {
-        auto const msg = reinterpret_cast<ris::CancelMessage const*>(c);
-
-        propagate();
-
-        std::vector<ev_key> cancelled_evs;
-        auto const result =
-            reroute(stats_, s, cancelled_delays_, cancelled_evs, msg->trip_id(),
-                    utl::to_vec(*msg->events()), {});
-
-        if (result.first == reroute_result::OK) {
-          for (auto const& e : *result.second->edges_) {
-            propagator_.add_delay(ev_key{e, 0, event_type::DEP});
-            propagator_.add_delay(ev_key{e, 0, event_type::ARR});
-          }
-          for (auto const& e : cancelled_evs) {
-            propagator_.add_canceled(e);
-          }
+        auto const upd_time =
+            unix_to_motistime(s, msg->events()->Get(i)->updated_time());
+        if (upd_time == INVALID_TIME) {
+          ++stats_.update_time_out_of_schedule_;
+          continue;
         }
 
-        break;
+        propagator_.add_delay(*resolved_ev, reason, upd_time);
+        ++stats_.found_updates_;
       }
 
-      case ris::MessageUnion_RerouteMessage: {
-        auto const msg = reinterpret_cast<ris::RerouteMessage const*>(c);
-
-        propagate();
-
-        std::vector<ev_key> cancelled_evs;
-        auto const result =
-            reroute(stats_, s, cancelled_delays_, cancelled_evs, msg->trip_id(),
-                    utl::to_vec(*msg->cancelled_events()),
-                    utl::to_vec(*msg->new_events()));
-
-        stats_.count_reroute(result.first);
-
-        if (result.first == reroute_result::OK) {
-          for (auto const& e : *result.second->edges_) {
-            propagator_.add_delay(ev_key{e, 0, event_type::DEP});
-            propagator_.add_delay(ev_key{e, 0, event_type::ARR});
-          }
-          for (auto const& e : cancelled_evs) {
-            propagator_.add_canceled(e);
-          }
-        }
-
-        break;
-      }
-
-      case ris::MessageUnion_TrackMessage: {
-        auto const msg = reinterpret_cast<ris::TrackMessage const*>(c);
-
-        stats_.total_evs_ += msg->events()->size();
-
-        auto const resolved = resolve_events(
-            stats_, s, msg->trip_id(),
-            utl::to_vec(*msg->events(), [](ris::UpdatedTrack const* ev) {
-              return ev->base();
-            }));
-
-        for (auto i = 0UL; i < resolved.size(); ++i) {
-          auto const& k = resolved[i];
-          if (!k) {
-            continue;
-          }
-
-          if (auto const it = s.graph_to_track_index_.find(*k);
-              it == s.graph_to_track_index_.end()) {
-            s.graph_to_track_index_[*k] = k->ev_type_ == event_type::ARR
-                                              ? k->lcon()->full_con_->a_track_
-                                              : k->lcon()->full_con_->d_track_;
-          }
-
-          auto const ev = msg->events()->Get(i);
-
-          track_events_.emplace_back(track_info{
-              *k, ev->updated_track()->str(),
-              unix_to_motistime(sched_, ev->base()->schedule_time())});
-
-          auto fcon = *k->lcon()->full_con_;
-          (k->ev_type_ == event_type::ARR ? fcon.a_track_ : fcon.d_track_) =
-              get_track(s, ev->updated_track()->str());
-
-          const_cast<light_connection*>(k->lcon())->full_con_ =  // NOLINT
-              s.full_connections_
-                  .emplace_back(mcd::make_unique<connection>(fcon))
-                  .get();
-        }
-        break;
-      }
-
-      case ris::MessageUnion_FreeTextMessage: {
-        auto const msg = reinterpret_cast<ris::FreeTextMessage const*>(c);
-        stats_.total_evs_ += msg->events()->size();
-        auto const [trp, resolved] = resolve_events_and_trip(
-            stats_, s, msg->trip_id(),
-            utl::to_vec(*msg->events(),
-                        [](ris::Event const* ev) { return ev; }));
-        if (trp == nullptr) {
-          return;
-        }
-        auto const events = utl::all(resolved)  //
-                            | utl::remove_if([](auto&& k) { return !k; })  //
-                            | utl::transform([](auto&& k) { return *k; })  //
-                            | utl::vec();
-        auto const ft =
-            free_text{msg->free_text()->code(), msg->free_text()->text()->str(),
-                      msg->free_text()->type()->str()};
-        for (auto const& k : events) {
-          s.graph_to_free_texts_[k].emplace(ft);
-        }
-        free_text_events_.emplace_back(free_texts{trp, ft, events});
-        break;
-      }
-
-      default: break;
+      break;
     }
-  } catch (std::exception const& e) {
-    printf("rt::on_message: UNEXPECTED ERROR: %s\n", e.what());
-  } catch (...) {
+
+    case ris::MessageUnion_AdditionMessage: {
+      auto result = additional_service_builder(s).build_additional_train(
+          reinterpret_cast<ris::AdditionMessage const*>(c));
+      stats_.count_additional(result);
+      break;
+    }
+
+    case ris::MessageUnion_CancelMessage: {
+      auto const msg = reinterpret_cast<ris::CancelMessage const*>(c);
+
+      propagate();
+
+      std::vector<ev_key> cancelled_evs;
+      auto const result =
+          reroute(stats_, s, cancelled_delays_, cancelled_evs, msg->trip_id(),
+                  utl::to_vec(*msg->events()), {});
+
+      if (result.first == reroute_result::OK) {
+        for (auto const& e : *result.second->edges_) {
+          propagator_.add_delay(ev_key{e, 0, event_type::DEP});
+          propagator_.add_delay(ev_key{e, 0, event_type::ARR});
+        }
+        for (auto const& e : cancelled_evs) {
+          propagator_.add_canceled(e);
+        }
+      }
+
+      break;
+    }
+
+    case ris::MessageUnion_RerouteMessage: {
+      auto const msg = reinterpret_cast<ris::RerouteMessage const*>(c);
+
+      propagate();
+
+      std::vector<ev_key> cancelled_evs;
+      auto const result =
+          reroute(stats_, s, cancelled_delays_, cancelled_evs, msg->trip_id(),
+                  utl::to_vec(*msg->cancelled_events()),
+                  utl::to_vec(*msg->new_events()));
+
+      stats_.count_reroute(result.first);
+
+      if (result.first == reroute_result::OK) {
+        for (auto const& e : *result.second->edges_) {
+          propagator_.add_delay(ev_key{e, 0, event_type::DEP});
+          propagator_.add_delay(ev_key{e, 0, event_type::ARR});
+        }
+        for (auto const& e : cancelled_evs) {
+          propagator_.add_canceled(e);
+        }
+      }
+
+      break;
+    }
+
+    case ris::MessageUnion_TrackMessage: {
+      auto const msg = reinterpret_cast<ris::TrackMessage const*>(c);
+
+      stats_.total_evs_ += msg->events()->size();
+
+      auto const resolved = resolve_events(
+          stats_, s, msg->trip_id(),
+          utl::to_vec(*msg->events(),
+                      [](ris::UpdatedTrack const* ev) { return ev->base(); }));
+
+      for (auto i = 0UL; i < resolved.size(); ++i) {
+        auto const& k = resolved[i];
+        if (!k) {
+          continue;
+        }
+
+        if (auto const it = s.graph_to_track_index_.find(*k);
+            it == s.graph_to_track_index_.end()) {
+          s.graph_to_track_index_[*k] = k->ev_type_ == event_type::ARR
+                                            ? k->lcon()->full_con_->a_track_
+                                            : k->lcon()->full_con_->d_track_;
+        }
+
+        auto const ev = msg->events()->Get(i);
+
+        track_events_.emplace_back(
+            track_info{*k, ev->updated_track()->str(),
+                       unix_to_motistime(sched_, ev->base()->schedule_time())});
+
+        auto fcon = *k->lcon()->full_con_;
+        (k->ev_type_ == event_type::ARR ? fcon.a_track_ : fcon.d_track_) =
+            get_track(s, ev->updated_track()->str());
+
+        const_cast<light_connection*>(k->lcon())->full_con_ =  // NOLINT
+            s.full_connections_.emplace_back(mcd::make_unique<connection>(fcon))
+                .get();
+      }
+      break;
+    }
+
+    case ris::MessageUnion_FreeTextMessage: {
+      auto const msg = reinterpret_cast<ris::FreeTextMessage const*>(c);
+      stats_.total_evs_ += msg->events()->size();
+      auto const [trp, resolved] = resolve_events_and_trip(
+          stats_, s, msg->trip_id(),
+          utl::to_vec(*msg->events(), [](ris::Event const* ev) { return ev; }));
+      if (trp == nullptr) {
+        return;
+      }
+      auto const events = utl::all(resolved)  //
+                          | utl::remove_if([](auto&& k) { return !k; })  //
+                          | utl::transform([](auto&& k) { return *k; })  //
+                          | utl::vec();
+      auto const ft =
+          free_text{msg->free_text()->code(), msg->free_text()->text()->str(),
+                    msg->free_text()->type()->str()};
+      for (auto const& k : events) {
+        s.graph_to_free_texts_[k].emplace(ft);
+      }
+      free_text_events_.emplace_back(free_texts{trp, ft, events});
+      break;
+    }
+
+    default: break;
   }
 }
 
@@ -370,7 +368,11 @@ msg_ptr rt_handler::flush(msg_ptr const&) {
     validate_constant_graph(sched_);
   }
 
-  return nullptr;
+  if (stats_.sanity_check_fails()) {
+    return motis::module::make_error_msg(error::sanity_check_failed);
+  } else {
+    return nullptr;
+  }
 }
 
 }  // namespace motis::rt


### PR DESCRIPTION
Add /rt/single which accepts and applies a single RIS Message.

Use: Predictably modify the schedule and improve the ui-debugging experience.
- Messages are read directly (not in RISBatch / nested_flatbuffer) so you can actually use plain json.
- The add_train.py script conveniently adds an additional train between a chosen pair of stations.
