### PR TITLE
Flag for GTFS & GTFS-RT: Shorten Stop IDs

### DIFF
--- a/base/bootstrap/include/motis/bootstrap/dataset_settings.h
+++ b/base/bootstrap/include/motis/bootstrap/dataset_settings.h
@@ -38,6 +38,8 @@ struct dataset_settings : public conf::configuration,
     param(wzr_matrix_path_, "wzr_classes_path",
           "waiting time rules class mapping");
     param(wzr_classes_path_, "wzr_matrix_path", "waiting time matrix");
+    param(gtfs_shorten_stop_ids_, "gtfs_shorten_stop_ids",
+          "unify stops by removing everything after the first \":\"");
   }
 };
 

--- a/base/core/include/motis/core/schedule/schedule.h
+++ b/base/core/include/motis/core/schedule/schedule.h
@@ -80,6 +80,8 @@ struct schedule {
   mcd::hash_map<ev_key, mcd::vector<ev_key>> trains_wait_for_;
 
   fws_multimap<ptr<trip>> expanded_trips_;
+
+  mcd::hash_map<mcd::string, mcd::string> parser_options_;
 };
 
 using schedule_ptr = mcd::unique_ptr<schedule>;

--- a/base/loader/include/motis/loader/gtfs/common.h
+++ b/base/loader/include/motis/loader/gtfs/common.h
@@ -2,12 +2,8 @@
 
 #include <string>
 
-namespace motis {
-namespace loader {
-namespace gtfs {
+namespace motis::loader::gtfs {
 
-std::string parse_stop_id(std::string const&);
+std::string parse_stop_id(bool shorten_stop_ids, std::string const&);
 
-}  // end namespace gtfs
-}  // end namespace loader
-}  // end namespace motis
+}  // namespace motis::loader::gtfs

--- a/base/loader/include/motis/loader/gtfs/gtfs_parser.h
+++ b/base/loader/include/motis/loader/gtfs/gtfs_parser.h
@@ -6,7 +6,7 @@ struct gtfs_parser : public format_parser {
   bool applicable(boost::filesystem::path const&) override;
   std::vector<std::string> missing_files(
       boost::filesystem::path const&) const override;
-  void parse(boost::filesystem::path const& root,
+  void parse(loader_options const&, boost::filesystem::path const& root,
              flatbuffers64::FlatBufferBuilder&) override;
 };
 

--- a/base/loader/include/motis/loader/gtfs/stop.h
+++ b/base/loader/include/motis/loader/gtfs/stop.h
@@ -27,6 +27,6 @@ struct stop {
 
 using stop_map = std::map<std::string, std::unique_ptr<stop>>;
 
-stop_map read_stops(loaded_file);
+stop_map read_stops(loaded_file, bool shorten_stop_ids);
 
 }  // namespace motis::loader::gtfs

--- a/base/loader/include/motis/loader/gtfs/stop_time.h
+++ b/base/loader/include/motis/loader/gtfs/stop_time.h
@@ -8,6 +8,7 @@
 
 namespace motis::loader::gtfs {
 
-void read_stop_times(loaded_file const&, trip_map&, stop_map const&);
+void read_stop_times(loaded_file const&, trip_map&, stop_map const&,
+                     bool shorten_stop_ids);
 
 }  // namespace motis::loader::gtfs

--- a/base/loader/include/motis/loader/gtfs/transfers.h
+++ b/base/loader/include/motis/loader/gtfs/transfers.h
@@ -27,6 +27,7 @@ struct transfer {
 };
 
 using stop_pair = std::pair<stop const*, stop const*>;
-std::map<stop_pair, transfer> read_transfers(loaded_file, stop_map const&);
+std::map<stop_pair, transfer> read_transfers(loaded_file, stop_map const&,
+                                             bool shorten_stop_ids);
 
 }  // namespace motis::loader::gtfs

--- a/base/loader/include/motis/loader/hrd/hrd_parser.h
+++ b/base/loader/include/motis/loader/hrd/hrd_parser.h
@@ -15,7 +15,7 @@ struct hrd_parser : public format_parser {
   static std::vector<std::string> missing_files(
       boost::filesystem::path const& hrd_root, config const& c);
 
-  void parse(boost::filesystem::path const& hrd_root,
+  void parse(loader_options const&, boost::filesystem::path const& hrd_root,
              flatbuffers64::FlatBufferBuilder&) override;
   static void parse(boost::filesystem::path const& hrd_root,
                     flatbuffers64::FlatBufferBuilder&, config const& c);

--- a/base/loader/include/motis/loader/loader_options.h
+++ b/base/loader/include/motis/loader/loader_options.h
@@ -27,6 +27,7 @@ struct loader_options {
   std::string graph_path_{"default"};
   std::string wzr_classes_path_{""};
   std::string wzr_matrix_path_{""};
+  bool gtfs_shorten_stop_ids_{false};
 };
 
 }  // namespace motis::loader

--- a/base/loader/include/motis/loader/parser.h
+++ b/base/loader/include/motis/loader/parser.h
@@ -7,6 +7,8 @@
 
 #include "flatbuffers/flatbuffers.h"
 
+#include "motis/loader/loader_options.h"
+
 namespace flatbuffers64 {
 class FlatBufferBuilder;  // NOLINT(readability-identifier-naming)
 }  // namespace flatbuffers64
@@ -26,7 +28,7 @@ struct format_parser {
   virtual bool applicable(boost::filesystem::path const&) = 0;
   virtual std::vector<std::string> missing_files(
       boost::filesystem::path const&) const = 0;
-  virtual void parse(boost::filesystem::path const&,
+  virtual void parse(loader_options const&, boost::filesystem::path const&,
                      flatbuffers64::FlatBufferBuilder&) = 0;
 };
 

--- a/base/loader/schedule-format/ParserOption.fbs
+++ b/base/loader/schedule-format/ParserOption.fbs
@@ -1,0 +1,6 @@
+namespace motis.loader;
+
+table ParserOption {
+  key: string;
+  value: string;
+}

--- a/base/loader/schedule-format/Schedule.fbs
+++ b/base/loader/schedule-format/Schedule.fbs
@@ -7,6 +7,7 @@ include "Interval.fbs";
 include "Footpath.fbs";
 include "RuleService.fbs";
 include "MetaStation.fbs";
+include "ParserOption.fbs";
 
 namespace motis.loader;
 
@@ -20,6 +21,7 @@ table Schedule {
   meta_stations: [MetaStation];
   name: string;
   hash: ulong;
+  parser_options: [ParserOption];
 }
 
 root_type Schedule;

--- a/base/loader/src/graph_builder.cc
+++ b/base/loader/src/graph_builder.cc
@@ -880,6 +880,12 @@ schedule_ptr build_graph(Schedule const* serialized, loader_options const& opt,
     calc_footpaths(*sched);
   }
 
+  if (serialized->parser_options() != nullptr) {
+    for (auto const& opt : *serialized->parser_options()) {
+      sched->parser_options_[opt->key()->str()] = opt->value()->str();
+    }
+  }
+
   sched->hash_ = serialized->hash();
   sched->route_count_ = builder.next_route_index_;
   sched->node_count_ = builder.next_node_id_;

--- a/base/loader/src/gtfs/common.cc
+++ b/base/loader/src/gtfs/common.cc
@@ -2,6 +2,15 @@
 
 namespace motis::loader::gtfs {
 
-std::string parse_stop_id(std::string const& stop_id) { return stop_id; }
+std::string parse_stop_id(bool const shorten_stop_ids,
+                          std::string const& stop_id) {
+  if (shorten_stop_ids) {
+    auto colon_idx = stop_id.find_first_of(':');
+    return colon_idx != std::string::npos ? stop_id.substr(0, colon_idx)
+                                          : stop_id;
+  } else {
+    return stop_id;
+  }
+}
 
 }  // namespace motis::loader::gtfs

--- a/base/loader/src/gtfs/gtfs_parser.cc
+++ b/base/loader/src/gtfs/gtfs_parser.cc
@@ -312,7 +312,9 @@ void gtfs_parser::parse(fs::path const& root, FlatBufferBuilder& fbb) {
       fbb.CreateVector(footpaths),
       fbb.CreateVector(std::vector<Offset<RuleService>>()),
       fbb.CreateVector(meta_stations), fbb.CreateString(dataset_name),
-      hash(root)));
+      hash(root),
+      fbb.CreateVector(CreateParserOption(
+          fbb, fbb.CreateString("shorten_stop_id"), fbb.CreateString("1")))));
 }
 
 }  // namespace motis::loader::gtfs

--- a/base/loader/src/gtfs/stop.cc
+++ b/base/loader/src/gtfs/stop.cc
@@ -23,14 +23,14 @@ using gtfs_stop = std::tuple<cstr, cstr, cstr, float, float>;
 static const column_mapping<gtfs_stop> columns = {
     {"stop_id", "stop_name", "stop_timezone", "stop_lat", "stop_lon"}};
 
-stop_map read_stops(loaded_file file) {
+stop_map read_stops(loaded_file file, bool const shorten_stop_ids) {
   motis::logging::scoped_timer timer{"read stops"};
 
   stop_map stops;
   mcd::hash_map<std::string, std::vector<stop*>> equal_names;
   for (auto const& s : read<gtfs_stop>(file.content(), columns)) {
     // load the swiss dataset without track information
-    auto id = parse_stop_id(get<stop_id>(s).to_str());
+    auto id = parse_stop_id(shorten_stop_ids, get<stop_id>(s).to_str());
     if (auto const it = stops.find(id); it == end(stops)) {
       auto const new_stop =
           stops

--- a/base/loader/src/gtfs/stop_time.cc
+++ b/base/loader/src/gtfs/stop_time.cc
@@ -52,7 +52,7 @@ int hhmm_to_min(cstr s) {
 }
 
 void read_stop_times(loaded_file const& file, trip_map& trips,
-                     stop_map const& stops) {
+                     stop_map const& stops, bool const shorten_stop_ids) {
   motis::logging::scoped_timer timer{"read stop times"};
   std::string last_trip_id;
   trip* last_trip = nullptr;
@@ -73,8 +73,8 @@ void read_stop_times(loaded_file const& file, trip_map& trips,
 
     t->stop_times_.emplace(
         get<stop_sequence>(s),  // index
-        stops.at(parse_stop_id(get<stop_id>(s).to_str()))
-            .get(),  // constructor arguments
+        stops.at(parse_stop_id(shorten_stop_ids, get<stop_id>(s).to_str()))
+            .get(),
         get<stop_headsign>(s).to_str(),  //
         hhmm_to_min(get<arrival_time>(s)), get<drop_off_type>(s) == 0,
         hhmm_to_min(get<departure_time>(s)), get<pickup_type>(s) == 0);

--- a/base/loader/src/hrd/hrd_parser.cc
+++ b/base/loader/src/hrd/hrd_parser.cc
@@ -196,7 +196,8 @@ void delete_f_equivalences(
   }
 }
 
-void hrd_parser::parse(fs::path const& hrd_root, FlatBufferBuilder& fbb) {
+void hrd_parser::parse(loader_options const&, fs::path const& hrd_root,
+                       FlatBufferBuilder& fbb) {
   for (auto const& c : configs) {
     if (applicable(hrd_root, c)) {
       return parse(hrd_root, fbb, c);

--- a/base/loader/src/loader.cc
+++ b/base/loader/src/loader.cc
@@ -1,19 +1,12 @@
 #include "motis/loader/loader.h"
 
-#include <fstream>
-#include <istream>
 #include <memory>
 #include <ostream>
 #include <vector>
 
-#include "cista/serialization.h"
-#include "cista/targets/file.h"
-
 #include "boost/filesystem.hpp"
 
 #include "flatbuffers/flatbuffers.h"
-
-#include "cista/mmap.h"
 
 #include "utl/parser/file.h"
 #include "utl/verify.h"
@@ -64,7 +57,7 @@ schedule_ptr load_schedule(loader_options const& opt,
     for (auto const& parser : parsers()) {
       if (parser->applicable(opt.dataset_)) {
         FlatBufferBuilder builder;
-        parser->parse(opt.dataset_, builder);
+        parser->parse(opt, opt.dataset_, builder);
         if (opt.write_serialized_) {
           utl::file(binary_schedule_file.string().c_str(), "w+")
               .write(builder.GetBufferPointer(), builder.GetSize());

--- a/base/loader/test/gtfs/stop_test.cc
+++ b/base/loader/test/gtfs/stop_test.cc
@@ -11,7 +11,8 @@ using namespace motis::loader;
 using namespace motis::loader::gtfs;
 
 TEST(loader_gtfs_stop, read_stations_example_data) {
-  auto stops = read_stops(loaded_file{SCHEDULES / "example" / STOPS_FILE});
+  auto stops =
+      read_stops(loaded_file{SCHEDULES / "example" / STOPS_FILE}, false);
 
   EXPECT_EQ(8, stops.size());
 
@@ -35,7 +36,8 @@ TEST(loader_gtfs_stop, read_stations_example_data) {
 }
 
 TEST(loader_gtfs_stop, read_stations_berlin_data) {
-  auto stops = read_stops(loaded_file{SCHEDULES / "berlin" / STOPS_FILE});
+  auto stops =
+      read_stops(loaded_file{SCHEDULES / "berlin" / STOPS_FILE}, false);
 
   EXPECT_EQ(3, stops.size());
 

--- a/base/loader/test/gtfs/stop_time_test.cc
+++ b/base/loader/test/gtfs/stop_time_test.cc
@@ -21,9 +21,10 @@ TEST(loader_gtfs_route, read_stop_times_example_data) {
   auto services = traffic_days(calendar, dates);
   auto trips = read_trips(loaded_file{SCHEDULES / "example" / TRIPS_FILE},
                           routes, services);
-  auto stops = read_stops(loaded_file{SCHEDULES / "example" / STOPS_FILE});
+  auto stops =
+      read_stops(loaded_file{SCHEDULES / "example" / STOPS_FILE}, false);
   read_stop_times(loaded_file{SCHEDULES / "example" / STOP_TIMES_FILE}, trips,
-                  stops);
+                  stops, false);
 
   auto awe1_it = trips.find("AWE1");
   ASSERT_NE(end(trips), awe1_it);

--- a/base/loader/test/gtfs/transfers_test.cc
+++ b/base/loader/test/gtfs/transfers_test.cc
@@ -16,9 +16,10 @@ stop_pair t(stop_map const& stops, std::string const& s1,
 }
 
 TEST(loader_gtfs_transfer, read_transfers_example_data) {
-  auto stops = read_stops(loaded_file{SCHEDULES / "example" / STOPS_FILE});
+  auto stops =
+      read_stops(loaded_file{SCHEDULES / "example" / STOPS_FILE}, false);
   auto transfers = read_transfers(
-      loaded_file{SCHEDULES / "example" / TRANSFERS_FILE}, stops);
+      loaded_file{SCHEDULES / "example" / TRANSFERS_FILE}, stops, false);
 
   EXPECT_EQ(2, transfers.size());
 

--- a/base/loader/test/hrd/fbs_schedules_test.cc
+++ b/base/loader/test/hrd/fbs_schedules_test.cc
@@ -22,7 +22,7 @@ TEST(loader_hrd_fbs_services, repeated_service) {
 
   ASSERT_TRUE(p.applicable(hrd_root));
 
-  p.parse(hrd_root, b);
+  p.parse(loader_options{}, hrd_root, b);
   auto schedule = GetSchedule(b.GetBufferPointer());
 
   ASSERT_EQ(3, schedule->services()->size());
@@ -75,7 +75,7 @@ TEST(loader_hrd_fbs_services, multiple_services) {
 
   ASSERT_TRUE(p.applicable(hrd_root));
 
-  p.parse(hrd_root, b);
+  p.parse(loader_options{}, hrd_root, b);
 }
 
 TEST(loader_hrd_fbs_services, multiple_files) {
@@ -85,7 +85,7 @@ TEST(loader_hrd_fbs_services, multiple_files) {
 
   ASSERT_TRUE(p.applicable(hrd_root));
 
-  p.parse(hrd_root, b);
+  p.parse(loader_options{}, hrd_root, b);
 }
 
 TEST(loader_hrd_fbs_services, directions_and_providers) {
@@ -95,7 +95,7 @@ TEST(loader_hrd_fbs_services, directions_and_providers) {
 
   ASSERT_TRUE(p.applicable(hrd_root));
 
-  p.parse(hrd_root, b);
+  p.parse(loader_options{}, hrd_root, b);
   auto schedule = GetSchedule(b.GetBufferPointer());
 
   ASSERT_EQ(7, schedule->services()->size());

--- a/base/loader/test/hrd/rule_standalone_test.cc
+++ b/base/loader/test/hrd/rule_standalone_test.cc
@@ -33,7 +33,7 @@ TEST(loader_hrd_fbs_services, rule_standalone) {
 
   ASSERT_TRUE(p.applicable(hrd_root));
 
-  p.parse(hrd_root, b);
+  p.parse(loader_options{}, hrd_root, b);
   auto schedule = GetSchedule(b.GetBufferPointer());
 
   ASSERT_EQ(1U, schedule->rule_services()->size());

--- a/modules/ris/include/motis/ris/gtfs-rt/parse_stop.h
+++ b/modules/ris/include/motis/ris/gtfs-rt/parse_stop.h
@@ -31,7 +31,7 @@ struct stop_context {
 
 int get_stop_edge_idx(int, event_type);
 
-std::string parse_stop_id(std::string const&);
+std::string parse_stop_id(schedule const&, std::string const&);
 
 }  // namespace ris::gtfsrt
 }  // namespace motis

--- a/modules/ris/src/gtfs-rt/parse_stop.cc
+++ b/modules/ris/src/gtfs-rt/parse_stop.cc
@@ -14,11 +14,7 @@ int get_stop_edge_idx(const int stop_idx, const event_type type) {
   return type == event_type::DEP ? stop_idx : stop_idx - 1;
 }
 
-std::string parse_stop_id(std::string const& stop_id) {
-  auto colon_idx = stop_id.find_first_of(':');
-  return colon_idx != std::string::npos ? stop_id.substr(0, colon_idx)
-                                        : stop_id;
-}
+std::string parse_stop_id(std::string const& stop_id) { return stop_id; }
 
 int get_future_stop_idx(trip const& trip, schedule& sched,
                         const int last_stop_idx, std::string const& stop_id) {

--- a/modules/ris/src/gtfs-rt/parse_trip_update.cc
+++ b/modules/ris/src/gtfs-rt/parse_trip_update.cc
@@ -112,7 +112,7 @@ void collect_events(trip_update_context& update_ctx,
 }
 
 void collect_additional_events(
-    trip_update_context& update_ctx,
+    schedule const& sched, trip_update_context& update_ctx,
     std::unique_ptr<knowledge_context> const& knowledge) {
   // additional trip updates always contain all stops
   auto trip_update = update_ctx.trip_update_;
@@ -122,7 +122,7 @@ void collect_additional_events(
   auto stop_count = 0;
 
   for (auto const& stu : trip_update.stop_time_update()) {
-    auto stop_id = parse_stop_id(stu.stop_id());
+    auto stop_id = parse_stop_id(sched, stu.stop_id());
 
     if (known_skips != nullptr) {
       update_ctx.is_stop_skip_new_.resize(stop_count + 1);
@@ -428,7 +428,7 @@ void handle_trip_update(
 
   if (update_ctx.is_new_addition_ ||
       (update_ctx.is_addition_ && !update_ctx.is_addition_skip_allowed_)) {
-    collect_additional_events(update_ctx, knowledge);
+    collect_additional_events(sched, update_ctx, knowledge);
   } else if (update_ctx.is_canceled_) {
     collect_canceled_events(update_ctx, knowledge);
   } else {

--- a/test/include/motis/test/schedule/gtfs_minimal_swiss.h
+++ b/test/include/motis/test/schedule/gtfs_minimal_swiss.h
@@ -13,7 +13,8 @@ static loader::loader_options dataset_opt{
     .dataset_ = "test/schedule/gtfs_minimal_swiss",
     .schedule_begin_ = "20190625",
     .num_days_ = 6,
-    .apply_rules_ = false};
+    .apply_rules_ = false,
+    .gtfs_shorten_stop_ids_ = true};
 
 }  // namespace test::schedule::gtfs_minimal_swiss
 }  // namespace motis


### PR DESCRIPTION
In order to match the EVA-numbers from the SBB HRD dataset, only the GTFS trip id's fist part (until the first ":") can be used. Thus, the stops in the SBB GTFS dataset are joined together: all tracks of one stop are one station.

This behaviour is now optional since the DELFI dataset has another logic to use the ":" separator. Here, many stops in Germany start with "de:".