### PR TITLE
motis-print-journey: Read from stdin if possible

### DIFF
--- a/modules/routing/eval/include/motis/eval/is_terminal.h
+++ b/modules/routing/eval/include/motis/eval/is_terminal.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdio>
+
+#ifdef _MSC_VER
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace motis::eval {
+
+inline bool is_terminal(std::FILE* f) {
+#ifdef _MSC_VER
+  return _isatty(_fileno(f)) != 0;
+#else
+  return isatty(fileno(f)) != 0;
+#endif
+}
+
+}  // namespace motis::eval

--- a/modules/routing/eval/src/print.cc
+++ b/modules/routing/eval/src/print.cc
@@ -15,10 +15,12 @@
 #include "motis/core/journey/message_to_journeys.h"
 #include "motis/core/journey/print_journey.h"
 #include "motis/module/message.h"
+#include "motis/eval/is_terminal.h"
 
 using namespace motis;
 using namespace motis::module;
 using namespace motis::routing;
+using namespace motis::eval;
 using namespace flatbuffers;
 
 namespace fs = boost::filesystem;
@@ -48,6 +50,10 @@ int main(int argc, char** argv) {
       po::command_line_parser(argc, argv).options(desc).positional(pod).run(),
       vm);
   po::notify(vm);
+
+  if (!help && files.empty() && !is_terminal(stdin)) {
+    files.emplace_back("-");
+  }
 
   if (help || files.empty()) {
     std::cout << desc << std::endl;


### PR DESCRIPTION
If no input files are specified, motis-print-journey now reads input from stdin (without having to specify "-" as an input file) if input is piped into stdin.