### PR TITLE
tripbased: move preprocessing to import step

### DIFF
--- a/modules/tripbased/include/motis/tripbased/preprocessing.h
+++ b/modules/tripbased/include/motis/tripbased/preprocessing.h
@@ -8,7 +8,10 @@ namespace motis::tripbased {
 
 std::unique_ptr<tb_data> build_data(schedule const& sched);
 
-std::unique_ptr<tb_data> load_or_build_data(schedule const& sched,
-                                            std::string const& filename);
+std::unique_ptr<tb_data> load_data(schedule const& sched,
+                                   std::string const& filename);
+
+void update_data_file(schedule const& sched, std::string const& filename,
+                      bool force_update);
 
 }  // namespace motis::tripbased

--- a/modules/tripbased/include/motis/tripbased/serialization.h
+++ b/modules/tripbased/include/motis/tripbased/serialization.h
@@ -59,7 +59,10 @@ struct header {
 
 void write_data(tb_data const& data, std::string const& filename,
                 schedule const& sched);
-bool read_data(tb_data& data, std::string const& filename,
-               schedule const& sched);
+
+bool data_okay_for_schedule(std::string const& filename, schedule const& sched);
+
+std::unique_ptr<tb_data> read_data(std::string const& filename,
+                                   schedule const& sched);
 
 }  // namespace motis::tripbased::serialization

--- a/modules/tripbased/include/motis/tripbased/tripbased.h
+++ b/modules/tripbased/include/motis/tripbased/tripbased.h
@@ -17,12 +17,17 @@ struct tripbased : public motis::module::module {
   tripbased(tripbased&&) = delete;
   tripbased& operator=(tripbased&&) = delete;
 
+  void import(motis::module::registry&) override;
   void init(motis::module::registry&) override;
+
+  bool import_successful() const override;
 
   tb_data const* get_data() const;
 
 private:
-  std::string data_file_{"trip_based.bin"};
+  bool use_data_file_{true};
+
+  bool import_successful_{false};
 
   struct impl;
   std::unique_ptr<impl> impl_;


### PR DESCRIPTION
Let's minimize the spammy output at startup and move the tripbased preprocessing to the import step