### PR TITLE
import: exit if not all imports are successful

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -160,7 +160,8 @@ jobs:
           ./build/motis --mode test \
             --import.paths base/loader/test_resources/hrd_schedules/single-ice \
             --dataset.begin 20151111 \
-            --dataset.write_serialized false
+            --dataset.write_serialized false \
+            --exclude_modules address osrm parking path ppr tiles
 
       - name: Run Tests
         run: ./build/motis-test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,14 +100,22 @@ jobs:
       - name: libc++ Boost Cache
         uses: actions/cache@v1
         id: libcxxboostcache
-        if: contains(matrix.config.cxxflags, 'libc++')
+        if: contains(matrix.config.cxxflags, 'libc++') && !contains(matrix.config.cxxflags, '-fsanitize=address')
         with:
           path: boost_1_72_0
           key: boost_1_72_0
 
+      - name: libc++ Boost asan Cache
+        uses: actions/cache@v1
+        id: libcxxboostasancache
+        if: contains(matrix.config.cxxflags, 'libc++') && contains(matrix.config.cxxflags, '-fsanitize=address')
+        with:
+          path: boost_1_72_0_asan
+          key: boost_1_72_0_asan
+
       # ==== BOOST FOR LIBCXX ====
       - name: Boost for libc++
-        if: contains(matrix.config.cxxflags, 'libc++') && steps.libcxxboostcache.outputs.cache-hit != 'true'
+        if: contains(matrix.config.cxxflags, 'libc++') && !contains(matrix.config.cxxflags, '-fsanitize=address') && steps.libcxxboostcache.outputs.cache-hit != 'true'
         run: |
           echo "using clang : 9 : /usr/bin/clang++-9 ;" > $HOME/user-config.jam
           wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
@@ -127,9 +135,35 @@ jobs:
             --with-serialization \
             -s NO_BZIP2=1
 
+      - name: Boost for libc++ asan
+        if: contains(matrix.config.cxxflags, 'libc++') && contains(matrix.config.cxxflags, '-fsanitize=address') && steps.libcxxboostasancache.outputs.cache-hit != 'true'
+        run: |
+          echo "using clang : 9 : /usr/bin/clang++-9 ;" > $HOME/user-config.jam
+          wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+          tar xf boost_1_72_0.tar.bz2
+          mv boost_1_72_0 boost_1_72_0_asan
+          cd boost_1_72_0_asan
+          ./bootstrap.sh
+          ./b2 -j6 \
+            link=static threading=multi variant=release \
+            toolset=clang-9 cxxflags="-fsanitize=address,undefined -fno-omit-frame-pointer -stdlib=libc++" \
+            --with-system \
+            --with-filesystem \
+            --with-iostreams \
+            --with-program_options \
+            --with-thread \
+            --with-date_time \
+            --with-regex \
+            --with-serialization \
+            -s NO_BZIP2=1
+
       - name: Set BOOST_ROOT
-        if: contains(matrix.config.cxxflags, 'libc++')
+        if: contains(matrix.config.cxxflags, 'libc++') && !contains(matrix.config.cxxflags, '-fsanitize=address')
         run: echo "::set-env name=BOOST_ROOT::`pwd`/boost_1_72_0"
+
+      - name: Set BOOST_ROOT asan
+        if: contains(matrix.config.cxxflags, 'libc++') && contains(matrix.config.cxxflags, '-fsanitize=address')
+        run: echo "::set-env name=BOOST_ROOT::`pwd`/boost_1_72_0_asan"
 
       # ==== BUILD ====
       - name: CMake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,6 +66,7 @@ jobs:
           --import.paths base/loader/test_resources/hrd_schedules/single-ice
           --dataset.begin 20151111
           --dataset.write_serialized false
+          --exclude_modules address osrm parking path ppr tiles
 
       - name: Run Tests
         run: .\build\motis-test.exe

--- a/base/bootstrap/include/motis/bootstrap/import_settings.h
+++ b/base/bootstrap/include/motis/bootstrap/import_settings.h
@@ -13,6 +13,8 @@ struct import_settings : conf::configuration {
         import_paths_{std::move(import_paths)} {
     param(import_paths_, "paths", "input paths to process");
     param(data_directory_, "data_dir", "directory for preprocessing output");
+    param(require_successful_, "require_successful",
+          "exit if import is not successful for all modules");
   }
 
   import_settings(import_settings const&) = delete;
@@ -23,6 +25,7 @@ struct import_settings : conf::configuration {
 
   std::vector<std::string> import_paths_;
   std::string data_directory_{"data"};
+  bool require_successful_{true};
 };
 
 }  // namespace motis::bootstrap

--- a/base/bootstrap/src/motis_instance.cc
+++ b/base/bootstrap/src/motis_instance.cc
@@ -129,6 +129,18 @@ void motis_instance::import(module_settings const& module_opt,
   registry_.reset();
 
   utl::verify(shared_data_.includes(SCHEDULE_DATA_KEY), "schedule not loaded");
+
+  if (import_opt.require_successful_) {
+    std::vector<std::string> unsuccessful_imports;
+    for (auto const& module : modules_) {
+      if (module_opt.is_module_active(module->module_name()) &&
+          !module->import_successful()) {
+        unsuccessful_imports.push_back(module->module_name());
+      }
+    }
+    utl::verify(unsuccessful_imports.empty(),
+                "some imports were not successful: {}", unsuccessful_imports);
+  }
 }
 
 void motis_instance::init_modules(module_settings const& module_opt,

--- a/base/launcher/src/main.cc
+++ b/base/launcher/src/main.cc
@@ -82,6 +82,10 @@ int main(int argc, char const** argv) {
     return 1;
   }
 
+  if (launcher_opt.mode_ == launcher_settings::motis_mode_t::TEST) {
+    import_opt.require_successful_ = false;
+  }
+
   try {
     instance.import(module_opt, dataset_opt, import_opt);
     instance.init_modules(module_opt, launcher_opt.num_threads_);

--- a/base/launcher/src/main.cc
+++ b/base/launcher/src/main.cc
@@ -82,10 +82,6 @@ int main(int argc, char const** argv) {
     return 1;
   }
 
-  if (launcher_opt.mode_ == launcher_settings::motis_mode_t::TEST) {
-    import_opt.require_successful_ = false;
-  }
-
   try {
     instance.import(module_opt, dataset_opt, import_opt);
     instance.init_modules(module_opt, launcher_opt.num_threads_);


### PR DESCRIPTION
By default, all imports should be successful.
The check can also be skipped with a comandline argument for development purposes.