### PR TITLE
Better utl progress tracker

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -100,14 +100,22 @@ jobs:
       - name: libc++ Boost Cache
         uses: actions/cache@v1
         id: libcxxboostcache
-        if: contains(matrix.config.cxxflags, 'libc++')
+        if: contains(matrix.config.cxxflags, 'libc++') && !contains(matrix.config.cxxflags, '-fsanitize=address')
         with:
           path: boost_1_72_0
           key: boost_1_72_0
 
+      - name: libc++ Boost asan Cache
+        uses: actions/cache@v1
+        id: libcxxboostasancache
+        if: contains(matrix.config.cxxflags, 'libc++') && contains(matrix.config.cxxflags, '-fsanitize=address')
+        with:
+          path: boost_1_72_0_asan
+          key: boost_1_72_0_asan
+
       # ==== BOOST FOR LIBCXX ====
       - name: Boost for libc++
-        if: contains(matrix.config.cxxflags, 'libc++') && steps.libcxxboostcache.outputs.cache-hit != 'true'
+        if: contains(matrix.config.cxxflags, 'libc++') && !contains(matrix.config.cxxflags, '-fsanitize=address') && steps.libcxxboostcache.outputs.cache-hit != 'true'
         run: |
           echo "using clang : 9 : /usr/bin/clang++-9 ;" > $HOME/user-config.jam
           wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
@@ -127,9 +135,35 @@ jobs:
             --with-serialization \
             -s NO_BZIP2=1
 
+      - name: Boost for libc++ asan
+        if: contains(matrix.config.cxxflags, 'libc++') && contains(matrix.config.cxxflags, '-fsanitize=address') && steps.libcxxboostasancache.outputs.cache-hit != 'true'
+        run: |
+          echo "using clang : 9 : /usr/bin/clang++-9 ;" > $HOME/user-config.jam
+          wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2
+          tar xf boost_1_72_0.tar.bz2
+          mv boost_1_72_0 boost_1_72_0_asan
+          cd boost_1_72_0_asan
+          ./bootstrap.sh
+          ./b2 -j6 \
+            link=static threading=multi variant=release \
+            toolset=clang-9 cxxflags="-fsanitize=address,undefined -fno-omit-frame-pointer -stdlib=libc++" \
+            --with-system \
+            --with-filesystem \
+            --with-iostreams \
+            --with-program_options \
+            --with-thread \
+            --with-date_time \
+            --with-regex \
+            --with-serialization \
+            -s NO_BZIP2=1
+
       - name: Set BOOST_ROOT
-        if: contains(matrix.config.cxxflags, 'libc++')
+        if: contains(matrix.config.cxxflags, 'libc++') && !contains(matrix.config.cxxflags, '-fsanitize=address')
         run: echo "::set-env name=BOOST_ROOT::`pwd`/boost_1_72_0"
+
+      - name: Set BOOST_ROOT asan
+        if: contains(matrix.config.cxxflags, 'libc++') && contains(matrix.config.cxxflags, '-fsanitize=address')
+        run: echo "::set-env name=BOOST_ROOT::`pwd`/boost_1_72_0_asan"
 
       # ==== BUILD ====
       - name: CMake
@@ -160,7 +194,8 @@ jobs:
           ./build/motis --mode test \
             --import.paths base/loader/test_resources/hrd_schedules/single-ice \
             --dataset.begin 20151111 \
-            --dataset.write_serialized false
+            --dataset.write_serialized false \
+            --exclude_modules address osrm parking path ppr tiles
 
       - name: Run Tests
         run: ./build/motis-test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,6 +66,7 @@ jobs:
           --import.paths base/loader/test_resources/hrd_schedules/single-ice
           --dataset.begin 20151111
           --dataset.write_serialized false
+          --exclude_modules address osrm parking path ppr tiles
 
       - name: Run Tests
         run: .\build\motis-test.exe

--- a/.pkg
+++ b/.pkg
@@ -1,7 +1,7 @@
 [address-typeahead]
   url=git@github.com:motis-project/address-typeahead.git
   branch=master
-  commit=108d77c0f0bf5c30bfde892f24f05550e5b3e2dc
+  commit=bd1d937cc9c8a0efec6ad93a91b5c9e1c776291b
 [cista]
   url=git@github.com:felixguendling/cista.git
   branch=master
@@ -49,7 +49,7 @@
 [osrm-backend]
   url=git@github.com:motis-project/osrm-backend.git
   branch=motis
-  commit=a03c1568503fb12830ca8f34c2a357739635d75a
+  commit=cbdca34884edec6ead24e61808e1f7d815ab8267
 [ppr]
   url=git@github.com:motis-project/ppr.git
   branch=master
@@ -73,8 +73,8 @@
 [tiles]
   url=git@github.com:motis-project/tiles.git
   branch=pristine
-  commit=13f8393163014b9a8145f762df1bfbaa93f7dc69
+  commit=1d4bdd271a369d77c5903ea9be6fc143b688c896
 [utl]
   url=git@github.com:motis-project/utl.git
   branch=master
-  commit=8ccc9be49342148ae2f1a54d8433492210001f22
+  commit=57b8d92388c1576623f8c1ef7b713e8efd41f30e

--- a/.pkg
+++ b/.pkg
@@ -1,7 +1,7 @@
 [address-typeahead]
   url=git@github.com:motis-project/address-typeahead.git
   branch=master
-  commit=bd1d937cc9c8a0efec6ad93a91b5c9e1c776291b
+  commit=f047113b0197d413663d78b0c40129d467d628a0
 [cista]
   url=git@github.com:felixguendling/cista.git
   branch=master
@@ -49,7 +49,7 @@
 [osrm-backend]
   url=git@github.com:motis-project/osrm-backend.git
   branch=motis
-  commit=cbdca34884edec6ead24e61808e1f7d815ab8267
+  commit=2a68bf1242aab63ad6dc96b5c15eb064ac8e55a9
 [ppr]
   url=git@github.com:motis-project/ppr.git
   branch=master

--- a/.pkg
+++ b/.pkg
@@ -73,8 +73,8 @@
 [tiles]
   url=git@github.com:motis-project/tiles.git
   branch=pristine
-  commit=1d4bdd271a369d77c5903ea9be6fc143b688c896
+  commit=7d0118b9dbbcc65f5c8a8a6694d43f0d5190e842
 [utl]
   url=git@github.com:motis-project/utl.git
   branch=master
-  commit=57b8d92388c1576623f8c1ef7b713e8efd41f30e
+  commit=55c1f939c12aa3f9b0279761766a6bf980be6e01

--- a/base/bootstrap/include/motis/bootstrap/import_settings.h
+++ b/base/bootstrap/include/motis/bootstrap/import_settings.h
@@ -13,6 +13,8 @@ struct import_settings : conf::configuration {
         import_paths_{std::move(import_paths)} {
     param(import_paths_, "paths", "input paths to process");
     param(data_directory_, "data_dir", "directory for preprocessing output");
+    param(require_successful_, "require_successful",
+          "exit if import is not successful for all modules");
   }
 
   import_settings(import_settings const&) = delete;
@@ -23,6 +25,7 @@ struct import_settings : conf::configuration {
 
   std::vector<std::string> import_paths_;
   std::string data_directory_{"data"};
+  bool require_successful_{true};
 };
 
 }  // namespace motis::bootstrap

--- a/base/bootstrap/src/motis_instance.cc
+++ b/base/bootstrap/src/motis_instance.cc
@@ -67,11 +67,7 @@ void motis_instance::import(module_settings const& module_opt,
                             loader::loader_options const& dataset_opt,
                             import_settings const& import_opt,
                             bool const silent) {
-  auto& progress = utl::get_global_progress_trackers();
-  auto const reset_silent = utl::make_raii(
-      progress.silent_,
-      [&](auto const old_silent) { progress.silent_ = old_silent; });
-  progress.silent_ = silent;
+  auto bars = utl::global_progress_bars{silent};
 
   registry_.subscribe("/import", import_osm);
   registry_.subscribe("/import", import_dem);

--- a/base/bootstrap/src/motis_instance.cc
+++ b/base/bootstrap/src/motis_instance.cc
@@ -6,6 +6,7 @@
 
 #include "boost/filesystem.hpp"
 
+#include "utl/pipes.h"
 #include "utl/progress_tracker.h"
 #include "utl/raii.h"
 #include "utl/verify.h"
@@ -129,6 +130,19 @@ void motis_instance::import(module_settings const& module_opt,
   registry_.reset();
 
   utl::verify(shared_data_.includes(SCHEDULE_DATA_KEY), "schedule not loaded");
+
+  if (import_opt.require_successful_) {
+    auto const unsuccessful_imports =
+        utl::all(modules_)  //
+        | utl::remove_if([&](auto&& m) {
+            return !module_opt.is_module_active(m->module_name()) ||
+                   m->import_successful();
+          })  //
+        | utl::transform([&](auto&& m) { return m->module_name(); })  //
+        | utl::vec();
+    utl::verify(unsuccessful_imports.empty(),
+                "some imports were not successful: {}", unsuccessful_imports);
+  }
 }
 
 void motis_instance::init_modules(module_settings const& module_opt,

--- a/base/loader/src/graph_builder.cc
+++ b/base/loader/src/graph_builder.cc
@@ -274,8 +274,8 @@ void graph_builder::add_services(Vector<Offset<Service>> const* services) {
                      return lhs->route() < rhs->route();
                    });
 
-  auto& progress_tracker = utl::get_active_progress_tracker();
-  progress_tracker.status("Build Services")
+  auto progress_tracker = utl::get_active_progress_tracker();
+  progress_tracker->status("Build Services")
       .out_bounds(progress_offset_, 90)
       .in_high(sorted.size());
 
@@ -295,7 +295,7 @@ void graph_builder::add_services(Vector<Offset<Service>> const* services) {
     }
 
     route_services.clear();
-    progress_tracker.update(std::distance(begin(sorted), it));
+    progress_tracker->update(std::distance(begin(sorted), it));
   }
 }
 
@@ -853,9 +853,9 @@ schedule_ptr build_graph(Schedule const* serialized, loader_options const& opt,
     sched->name_ = serialized->name()->str();
   }
 
-  auto& progress_tracker = utl::get_active_progress_tracker();
+  auto progress_tracker = utl::get_active_progress_tracker();
 
-  progress_tracker.status("Build Graph").out_bounds(progress_offset, 90);
+  progress_tracker->status("Build Graph").out_bounds(progress_offset, 90);
   graph_builder builder(*sched, serialized->interval(), opt, progress_offset);
   builder.add_stations(serialized->stations());
   if (serialized->meta_stations() != nullptr) {
@@ -865,7 +865,7 @@ schedule_ptr build_graph(Schedule const* serialized, loader_options const& opt,
   builder.add_services(serialized->services());
   if (opt.apply_rules_) {
     scoped_timer timer("rule services");
-    progress_tracker.status("Rule Services").out_bounds(90, 92);
+    progress_tracker->status("Rule Services").out_bounds(90, 92);
     build_rule_routes(builder, serialized->rule_services());
   }
 
@@ -873,17 +873,17 @@ schedule_ptr build_graph(Schedule const* serialized, loader_options const& opt,
     sched->expanded_trips_.finish_map();
   }
 
-  progress_tracker.status("Footpaths").out_bounds(92, 93);
+  progress_tracker->status("Footpaths").out_bounds(92, 93);
   builder.add_footpaths(serialized->footpaths());
 
-  progress_tracker.status("Connect Reverse").out_bounds(93, 94);
+  progress_tracker->status("Connect Reverse").out_bounds(93, 94);
   builder.connect_reverse();
 
-  progress_tracker.status("Sort Trips").out_bounds(94, 95);
+  progress_tracker->status("Sort Trips").out_bounds(94, 95);
   builder.sort_trips();
 
   if (opt.expand_footpaths_) {
-    progress_tracker.status("Expand Footpaths").out_bounds(95, 96);
+    progress_tracker->status("Expand Footpaths").out_bounds(95, 96);
     calc_footpaths(*sched);
   }
 
@@ -891,19 +891,19 @@ schedule_ptr build_graph(Schedule const* serialized, loader_options const& opt,
   sched->route_count_ = builder.next_route_index_;
   sched->node_count_ = builder.next_node_id_;
 
-  progress_tracker.status("Lower Bounds").out_bounds(96, 100).in_high(4);
+  progress_tracker->status("Lower Bounds").out_bounds(96, 100).in_high(4);
   sched->transfers_lower_bounds_fwd_ = build_interchange_graph(
       sched->station_nodes_, sched->route_count_, search_dir::FWD);
-  progress_tracker.increment();
+  progress_tracker->increment();
   sched->transfers_lower_bounds_bwd_ = build_interchange_graph(
       sched->station_nodes_, sched->route_count_, search_dir::BWD);
-  progress_tracker.increment();
+  progress_tracker->increment();
   sched->travel_time_lower_bounds_fwd_ =
       build_station_graph(sched->station_nodes_, search_dir::FWD);
-  progress_tracker.increment();
+  progress_tracker->increment();
   sched->travel_time_lower_bounds_bwd_ =
       build_station_graph(sched->station_nodes_, search_dir::BWD);
-  progress_tracker.increment();
+  progress_tracker->increment();
 
   sched->waiting_time_rules_ = load_waiting_time_rules(
       opt.wzr_classes_path_, opt.wzr_matrix_path_, sched->categories_);

--- a/base/loader/src/gtfs/calendar_date.cc
+++ b/base/loader/src/gtfs/calendar_date.cc
@@ -33,12 +33,12 @@ std::map<std::string, std::vector<calendar_date>> read_calendar_date(
   motis::logging::scoped_timer timer{"calendar dates"};
   std::map<std::string, std::vector<calendar_date>> services;
   auto const entries = read<gtfs_calendar_date>(f.content(), calendar_columns);
-  auto& progress_tracker = utl::get_active_progress_tracker();
-  progress_tracker.status("Parse Calendar Dates")
+  auto progress_tracker = utl::get_active_progress_tracker();
+  progress_tracker->status("Parse Calendar Dates")
       .out_bounds(0.F, 5.F)
       .in_high(entries.size());
   for (auto const& d : entries) {
-    progress_tracker.increment();
+    progress_tracker->increment();
     services[get<service_id>(d).to_str()].push_back(read_date(d));
   }
   return services;

--- a/base/loader/src/gtfs/gtfs_parser.cc
+++ b/base/loader/src/gtfs/gtfs_parser.cc
@@ -266,8 +266,8 @@ void gtfs_parser::parse(fs::path const& root, FlatBufferBuilder& fbb) {
   };
 
   motis::logging::scoped_timer export_timer{"export"};
-  auto& progress_tracker = utl::get_active_progress_tracker();
-  progress_tracker.status("Export schedule.raw")
+  auto progress_tracker = utl::get_active_progress_tracker();
+  progress_tracker->status("Export schedule.raw")
       .out_bounds(40.F, 80.F)
       .in_high(trips.size());
   auto const interval =
@@ -333,7 +333,7 @@ void gtfs_parser::parse(fs::path const& root, FlatBufferBuilder& fbb) {
   auto output_services =
       utl::all(trips)  //
       | utl::remove_if([&](auto const& entry) {
-          progress_tracker.increment();
+          progress_tracker->increment();
           auto const stop_count = entry.second->stops().size();
           if (stop_count < 2) {
             LOG(warn) << "invalid trip " << entry.first << ": "

--- a/base/loader/src/gtfs/stop_time.cc
+++ b/base/loader/src/gtfs/stop_time.cc
@@ -59,12 +59,12 @@ void read_stop_times(loaded_file const& file, trip_map& trips,
 
   auto const entries = read<gtfs_stop_time>(file.content(), stop_time_columns);
 
-  auto& progress_tracker = utl::get_active_progress_tracker();
-  progress_tracker.status("Parse Stop Times")
+  auto progress_tracker = utl::get_active_progress_tracker();
+  progress_tracker->status("Parse Stop Times")
       .out_bounds(20.F, 40.F)
       .in_high(entries.size());
   for (auto const& [i, s] : utl::enumerate(entries)) {
-    progress_tracker.update(i);
+    progress_tracker->update(i);
     trip* t = nullptr;
     auto t_id = get<trip_id>(s).to_str();
     if (last_trip != nullptr && t_id == last_trip_id) {

--- a/base/loader/src/gtfs/trip.cc
+++ b/base/loader/src/gtfs/trip.cc
@@ -133,11 +133,11 @@ std::pair<trip_map, block_map> read_trips(loaded_file file,
   auto& [trips, blocks] = ret;
   auto const entries = read<gtfs_trip>(file.content(), columns);
 
-  auto& progress_tracker = utl::get_active_progress_tracker();
-  progress_tracker.status("Trips").out_bounds(5.F, 20.F).in_high(
+  auto progress_tracker = utl::get_active_progress_tracker();
+  progress_tracker->status("Trips").out_bounds(5.F, 20.F).in_high(
       entries.size());
   for (auto const& [i, t] : utl::enumerate(entries)) {
-    progress_tracker.update(i);
+    progress_tracker->update(i);
     auto const blk =
         get<block_id>(t).trim().empty()
             ? nullptr

--- a/base/loader/src/hrd/hrd_parser.cc
+++ b/base/loader/src/hrd/hrd_parser.cc
@@ -154,14 +154,14 @@ void parse_and_build_services(
   auto const total_bytes =
       collect_files(hrd_root / c.fplan_, c.fplan_file_extension_, files);
 
-  auto& progress_tracker = utl::get_active_progress_tracker();
-  progress_tracker.status("Parse HRD Services")
+  auto progress_tracker = utl::get_active_progress_tracker();
+  progress_tracker->status("Parse HRD Services")
       .out_bounds(0.F, 80.F)
       .in_high(total_bytes);
 
   auto total_consumed = size_t{0ULL};
   auto const progress_update = [&](std::size_t const file_consumed) {
-    progress_tracker.update(total_consumed + file_consumed);
+    progress_tracker->update(total_consumed + file_consumed);
   };
 
   for (auto const& [i, file] : utl::enumerate(files)) {
@@ -268,7 +268,7 @@ void hrd_parser::parse(fs::path const& hrd_root, FlatBufferBuilder& fbb,
       c);
 
   // compute and build rule services
-  utl::get_active_progress_tracker().status("Generate Rule Services");
+  utl::get_active_progress_tracker()->status("Generate Rule Services");
   rsb.resolve_rule_services();
   rsb.create_rule_services(
       [&](hrd_service const& s, bool is_rule_service, FlatBufferBuilder& fbb) {

--- a/base/loader/src/loader.cc
+++ b/base/loader/src/loader.cc
@@ -54,6 +54,9 @@ schedule_ptr load_schedule(loader_options const& opt,
     return read_graph(serialized_file_path, schedule_buf, opt.read_graph_mmap_);
   }
 
+  // ensure there is an active progress tracker (e.g. for test cases)
+  utl::get_active_progress_tracker_or_activate("schedule");
+
   if (fs::is_regular_file(binary_schedule_file)) {
     auto buf = file(binary_schedule_file.string().c_str(), "r").content();
     auto sched = build_graph(GetSchedule(buf.buf_), opt);

--- a/base/loader/src/loader.cc
+++ b/base/loader/src/loader.cc
@@ -67,7 +67,7 @@ schedule_ptr load_schedule(loader_options const& opt,
         FlatBufferBuilder builder;
         parser->parse(opt.dataset_, builder);
         if (opt.write_serialized_) {
-          utl::get_active_progress_tracker().status("Write Schedule File");
+          utl::get_active_progress_tracker()->status("Write Schedule File");
           utl::file(binary_schedule_file.string().c_str(), "w+")
               .write(builder.GetBufferPointer(), builder.GetSize());
         }

--- a/base/module/include/motis/module/event_collector.h
+++ b/base/module/include/motis/module/event_collector.h
@@ -49,7 +49,7 @@ private:
   std::set<std::string> waiting_for_;
   std::set<dependency_matcher> matchers_;
   bool executed_{false};
-  utl::progress_tracker& progress_tracker_;
+  utl::progress_tracker_ptr progress_tracker_;
 };
 
 }  // namespace motis::module

--- a/modules/parking/src/parking.cc
+++ b/modules/parking/src/parking.cc
@@ -409,8 +409,8 @@ void parking::import(registry& reg) {
 
           std::vector<motis::parking::parking_lot> parking_data;
 
-          auto& progress_tracker = utl::get_active_progress_tracker();
-          progress_tracker.status("Extract Parkings");
+          auto progress_tracker = utl::get_active_progress_tracker();
+          progress_tracker->status("Extract Parkings");
 
           utl::verify(extract_parkings(osm_ev->path()->str(), parking_file(),
                                        parking_data),
@@ -419,7 +419,7 @@ void parking::import(registry& reg) {
           auto park = parkings{std::move(parking_data)};
           auto st = stations{get_schedule()};
 
-          progress_tracker.status("Compute Foot Edges");
+          progress_tracker->status("Compute Foot Edges");
           compute_foot_edges(st, park, footedges_db_file(),
                              ppr_ev->graph_path()->str(), edge_rtree_max_size_,
                              area_rtree_max_size_, lock_rtrees_, ppr_profiles,

--- a/modules/parking/src/prepare/foot_edges.cc
+++ b/modules/parking/src/prepare/foot_edges.cc
@@ -132,11 +132,11 @@ void compute_foot_edges(
   std::clog << "Precomputing foot edges for " << max << " parkings..."
             << std::endl;
 
-  auto& progress_tracker = utl::get_active_progress_tracker();
-  progress_tracker.reset_bounds().in_high(max);
+  auto progress_tracker = utl::get_active_progress_tracker();
+  progress_tracker->reset_bounds().in_high(max);
   for (auto const& [i, p] : utl::enumerate(park.parkings_)) {
     pool.post([&, i = i, &p = p] {
-      progress_tracker.increment();
+      progress_tracker->increment();
       compute_edges(db, rg, st, ppr_profiles, p, stations_per_parking, i);
     });
   }

--- a/modules/path/src/prepare/resolve/resolve_sequences.cc
+++ b/modules/path/src/prepare/resolve/resolve_sequences.cc
@@ -53,7 +53,7 @@ struct plan_executor {
     ml::scoped_timer t{"resolve_sequences"};
     start_ = sc::steady_clock::now();
 
-    progress_tracker_.status("Resolve Sequences")
+    progress_tracker_->status("Resolve Sequences")
         .reset_bounds()
         .in_high(pp_.part_task_queue_.size());
 
@@ -263,7 +263,7 @@ struct plan_executor {
         std::count_if(begin(result_caches_), end(result_caches_),
                       [](auto const& r) { return r != nullptr; });
 
-    progress_tracker_.update(curr_part_task);
+    progress_tracker_->update(curr_part_task);
 
     std::clog << "resolve_sequences [" << microsecond_fmt{t_curr} << " | est. "
               << microsecond_fmt{t_est} << "] ("  //
@@ -305,7 +305,7 @@ struct plan_executor {
 
   sc::time_point<sc::steady_clock> start_;
   execution_stats stats_;
-  utl::progress_tracker& progress_tracker_;
+  utl::progress_tracker_ptr progress_tracker_;
 };
 
 std::vector<resolved_station_seq> resolve_sequences(

--- a/modules/path/test/database_query_test.cc
+++ b/modules/path/test/database_query_test.cc
@@ -40,13 +40,11 @@ struct path_database_query_test : public ::testing::Test {
         boost::filesystem::unique_path("pathdb_test_%%%%-%%%%-%%%%-%%%%")
             .string();
 
-    utl::get_global_progress_trackers().silent_ = true;
     utl::activate_progress_tracker("query_test");
   }
 
   void TearDown() override {
     utl::get_global_progress_trackers().clear();
-    utl::get_global_progress_trackers().silent_ = false;
 
     boost::filesystem::remove(db_fname_ + ".mdb");
     boost::filesystem::remove(db_fname_ + ".mdb-lock");

--- a/modules/ppr/src/ppr.cc
+++ b/modules/ppr/src/ppr.cc
@@ -294,7 +294,7 @@ void ppr::import(registry& reg) {
           dem_hash = dem->hash();
         }
 
-        auto& progress_tracker = utl::get_active_progress_tracker();
+        auto progress_tracker = utl::get_active_progress_tracker();
 
         auto const state =
             import_state{data_path(osm_path), osm->hash(), osm->size(),
@@ -318,12 +318,12 @@ void ppr::import(registry& reg) {
             std::clog << "Step " << (log.current_step() + 1) << "/"
                       << log.step_count() << ": " << step.name() << ": Starting"
                       << std::endl;
-            progress_tracker.status(step.name());
+            progress_tracker->status(step.name());
           };
 
           log.step_progress_ = [&progress_tracker](pp::logging const& log,
                                                    pp::step_info const&) {
-            progress_tracker.update(
+            progress_tracker->update(
                 static_cast<int>(log.total_progress() * 100));
           };
 
@@ -341,7 +341,7 @@ void ppr::import(registry& reg) {
         }
         import_successful_ = true;
 
-        progress_tracker.update(100);
+        progress_tracker->update(100);
         auto graph_hash = cista::hash_t{};
         auto graph_size = std::size_t{};
         {

--- a/modules/tiles/src/tiles.cc
+++ b/modules/tiles/src/tiles.cc
@@ -106,11 +106,11 @@ void tiles::import(mm::registry& reg) {
             coastline_hash, coastline_size};
         if (mm::read_ini<import_state>(dir / "import.ini") != state) {
           fs::create_directories(dir);
-          auto& progress_tracker = utl::get_active_progress_tracker();
+          auto progress_tracker = utl::get_active_progress_tracker();
 
           auto const db_fname = dir / "tiles.mdb";
 
-          progress_tracker.status("Clear Database");
+          progress_tracker->status("Clear Database");
           ::tiles::clear_database(path);
           ::tiles::clear_pack_file(path.c_str());
 
@@ -124,19 +124,19 @@ void tiles::import(mm::registry& reg) {
                 pack_handle};
 
             if (use_coastline_) {
-              progress_tracker.status("Load Coastlines").out_bounds(0, 20);
+              progress_tracker->status("Load Coastlines").out_bounds(0, 20);
               ::tiles::load_coastlines(db_handle, inserter, coastline_path);
             }
 
-            progress_tracker.status("Load Features").out_bounds(20, 70);
+            progress_tracker->status("Load Features").out_bounds(20, 70);
             ::tiles::load_osm(db_handle, inserter, osm_path,
                               profile_path.string(), dir.generic_string());
           }
 
-          progress_tracker.status("Pack Features").out_bounds(70, 90);
+          progress_tracker->status("Pack Features").out_bounds(70, 90);
           ::tiles::pack_features(db_handle, pack_handle);
 
-          progress_tracker.status("Prepare Tiles").out_bounds(90, 100);
+          progress_tracker->status("Prepare Tiles").out_bounds(90, 100);
           ::tiles::prepare_tiles(db_handle, pack_handle, 10);
         }
 

--- a/modules/tripbased/src/preprocessing.cc
+++ b/modules/tripbased/src/preprocessing.cc
@@ -105,7 +105,7 @@ struct preprocessing {
     std::vector<std::vector<std::pair<line_id, stop_idx_t>>> lines_at_stop;
     lines_at_stop.resize(stop_count);
 
-    progress_tracker_.status("Init: Routes");
+    progress_tracker_->status("Init: Routes");
     for (auto route_idx = 0UL; route_idx < line_count; ++route_idx) {
       auto const& route_trips = sched_.expanded_trips_[route_idx];
       utl::verify(!route_trips.empty(), "empty route");
@@ -173,7 +173,7 @@ struct preprocessing {
       }
     }
 
-    progress_tracker_.status("Init: Lines at Stop");
+    progress_tracker_->status("Init: Lines at Stop");
     for (auto const& lines : lines_at_stop) {
       for (auto const& [line, stop_idx] : lines) {
         utl::verify(stop_idx < data_.line_stop_count_[line],
@@ -183,7 +183,7 @@ struct preprocessing {
       data_.lines_at_stop_.finish_key();
     }
 
-    progress_tracker_.status("Init: Station Nodes");
+    progress_tracker_->status("Init: Station Nodes");
     for (auto const& st : sched_.station_nodes_) {
       for (auto const& fp : sched_.stations_[st->id_]->outgoing_footpaths_) {
         data_.footpaths_.emplace_back(fp);
@@ -256,7 +256,7 @@ struct preprocessing {
   }
 
   void precompute_transfers() {
-    progress_tracker_.status("Transfers: FWD").out_bounds(0.F, 50.F);
+    progress_tracker_->status("Transfers: FWD").out_bounds(0.F, 50.F);
 
     scoped_timer timer{"trip-based preprocessing: precompute transfers"};
     auto const prev_locale =
@@ -294,7 +294,7 @@ struct preprocessing {
   }
 
   void precompute_reverse_transfers() {
-    progress_tracker_.status("Transfers: BWD").out_bounds(50.F, 100.F);
+    progress_tracker_->status("Transfers: BWD").out_bounds(50.F, 100.F);
 
     scoped_timer timer{
         "trip-based preprocessing: precompute reverse transfers"};
@@ -604,7 +604,7 @@ private:
       auto const percentage =
           static_cast<int>(std::round(100.0 * static_cast<double>(trip + 1) /
                                       static_cast<double>(data_.trip_count_)));
-      progress_tracker_.update(percentage);
+      progress_tracker_->update(percentage);
       LOG(info) << percentage << "% - " << (trip + 1) << "/"
                 << data_.trip_count_ << " trips... " << transfer_count
                 << " transfers, " << (uturns_ + no_improvements_)
@@ -711,7 +711,7 @@ private:
 
   schedule const& sched_;
   tb_data& data_;
-  utl::progress_tracker& progress_tracker_;
+  utl::progress_tracker_ptr progress_tracker_;
   std::atomic<uint64_t> uturns_{0};
   std::atomic<uint64_t> no_improvements_{0};
   std::mutex transfers_mutex_;

--- a/modules/tripbased/src/tripbased.cc
+++ b/modules/tripbased/src/tripbased.cc
@@ -678,10 +678,6 @@ void tripbased::init(motis::module::registry& reg) {
       impl_ = std::make_unique<impl>(
           load_data(get_sched(), filename.generic_string()));
     } else {
-      auto& p = utl::get_global_progress_trackers();
-      auto const reset_silent =
-          utl::make_raii(p.silent_, [&](auto const s) { p.silent_ = s; });
-      p.silent_ = true;
       impl_ = std::make_unique<impl>(build_data(get_sched()));
     }
 


### PR DESCRIPTION
* global_progress_tracker defaults to silent, utl::global_progress_bars{} conveniently unsilences it
* switch to std::shared_ptr reduce opportunities for dangling references after .clear()
* fixes