### PR TITLE
Fix GitHub CI: Use Environment Files

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -173,15 +173,15 @@ jobs:
 
       - name: Set BOOST_ROOT for GCC 9
         if: matrix.config.cxx == 'g++-9'
-        run: echo "::set-env name=BOOST_ROOT::$BOOST_ROOT_1_72_0"
+        run: echo "BOOST_ROOT=$BOOST_ROOT_1_72_0" >> $GITHUB_ENV
 
       - name: Set BOOST_ROOT
         if: contains(matrix.config.cxxflags, 'libc++') && !contains(matrix.config.cxxflags, '-fsanitize=address')
-        run: echo "::set-env name=BOOST_ROOT::`pwd`/boost_1_72_0"
+        run: echo "BOOST_ROOT=`pwd`/boost_1_72_0" >> $GITHUB_ENV
 
       - name: Set BOOST_ROOT asan
         if: contains(matrix.config.cxxflags, 'libc++') && contains(matrix.config.cxxflags, '-fsanitize=address')
-        run: echo "::set-env name=BOOST_ROOT::`pwd`/boost_1_72_0_asan"
+        run: echo "BOOST_ROOT=`pwd`/boost_1_72_0_asan" >> $GITHUB_ENV
 
       # ==== BUILD ====
       - name: CMake


### PR DESCRIPTION
See:

- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files