### PR TITLE
Fix elm build

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -45,6 +45,7 @@ jobs:
             mode: Release
             cxxflags: -stdlib=libc++
             os: macos-latest
+            elm: macos
             artifact: macos
             avx: On
           - name: GCC 10 Release
@@ -52,6 +53,7 @@ jobs:
             cc: gcc-10
             mode: Release
             os: ubuntu-20.04
+            elm: linux-64bit
             artifact: linux
             avx: On
           - name: GCC 10 Release
@@ -59,6 +61,7 @@ jobs:
             cc: gcc-10
             mode: Release
             os: ubuntu-20.04
+            elm: linux-64bit
             artifact: linux-noavx
             avx: Off
           - name: GCC 10 Debug
@@ -214,9 +217,10 @@ jobs:
         if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-10' || matrix.config.os == 'macos-latest')
         run: |
           cd ./ui/web
-          npm install
-          ./node_modules/elm/binwrappers/elm-make --yes src/Main.elm --output elm.js
-          rm -rf node_modules
+          mkdir elm
+          curl -sL https://github.com/elm-lang/elm-platform/releases/download/0.18.0-exp/elm-platform-${{ matrix.config.elm }}.tar.gz | tar xz -C elm
+          ./elm/elm-make --yes src/Main.elm --output elm.js
+          rm -rf elm
 
       - name: Create Distribution
         if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-10' || matrix.config.os == 'macos-latest')

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,8 +84,13 @@ jobs:
         if: matrix.mode == 'Release'
         run: |
           cd .\ui\web
-          .\node_modules\elm\Elm-Platform\0.18.0\.cabal-sandbox\bin\elm-make.exe --yes .\src\Main.elm --output elm.js
-          Remove-Item -Recurse -Force .\node_modules
+          mkdir elm
+          cd elm
+          Invoke-WebRequest -Uri https://github.com/elm-lang/elm-platform/releases/download/0.18.0-exp/elm-platform-windows.tar.gz -OutFile elm-platform-windows.tar.gz
+          cmake -E tar xzf .\elm-platform-windows.tar.gz
+          cd ..
+          .\elm\elm-make.exe --yes .\src\Main.elm --output elm.js
+          Remove-Item -Recurse -Force .\elm
 
       - name: Move Profiles
         if: matrix.mode == 'Release'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,11 +75,6 @@ jobs:
         run: .\build\motis-itest.exe
 
       # ==== DISTRIBUTION ====
-      - uses: bahmutov/npm-install@v1
-        if: matrix.mode == 'Release'
-        with:
-          working-directory: ui/web
-
       - name: Compile Web Interface
         if: matrix.mode == 'Release'
         run: |

--- a/ui/web/README.md
+++ b/ui/web/README.md
@@ -1,6 +1,6 @@
 # Install Elm 0.18
 
-    npm install -g elm@0.18.0
+https://github.com/elm-lang/elm-platform/releases
 
 # Build
 


### PR DESCRIPTION
The elm npm package (version 0.18) can no longer be downloaded, switch to [GitHub Releases](https://github.com/elm-lang/elm-platform/releases).