### PR TITLE
Add dataset.cache_graph option

### DIFF
--- a/base/bootstrap/include/motis/bootstrap/dataset_settings.h
+++ b/base/bootstrap/include/motis/bootstrap/dataset_settings.h
@@ -25,6 +25,7 @@ struct dataset_settings : public conf::configuration,
     param(write_graph_, "write_graph", "Write bianry schedule graph");
     param(read_graph_, "read_graph", "Read binary schedule graph");
     param(read_graph_mmap_, "read_graph_mmap", "Read using memory mapped file");
+    param(cache_graph_, "cache_graph", "Cache binary schedule graph");
     param(apply_rules_, "apply_rules",
           "Apply special rules (through-services, merge-split-services)");
     param(adjust_footpaths_, "adjust_footpaths",

--- a/base/bootstrap/src/import_schedule.cc
+++ b/base/bootstrap/src/import_schedule.cc
@@ -47,7 +47,7 @@ void register_import_schedule(motis_instance& instance,
                     "import_schedule: dataset_opt.dataset_.empty()");
 
         cista::memory_holder memory;
-        auto sched = loader::load_schedule(dataset_opt_cpy, memory);
+        auto sched = loader::load_schedule(dataset_opt_cpy, memory, data_dir);
         instance.shared_data_.emplace_data(
             SCHEDULE_DATA_KEY,
             schedule_data{std::move(memory), std::move(sched)});

--- a/base/loader/include/motis/loader/loader.h
+++ b/base/loader/include/motis/loader/loader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "cista/memory_holder.h"
 
 #include "motis/core/schedule/schedule.h"
@@ -12,7 +14,8 @@ namespace motis::loader {
 std::vector<std::unique_ptr<format_parser>> parsers();
 
 schedule_ptr load_schedule(loader_options const&,
-                           cista::memory_holder& schedule_buf);
+                           cista::memory_holder& schedule_buf,
+                           std::string const& data_dir);
 
 schedule_ptr load_schedule(loader_options const&);
 

--- a/base/loader/include/motis/loader/loader_options.h
+++ b/base/loader/include/motis/loader/loader_options.h
@@ -11,7 +11,7 @@ namespace motis::loader {
 
 struct loader_options {
   std::pair<std::time_t, std::time_t> interval() const;
-  std::string graph_path() const;
+  std::string graph_path(std::string const& data_dir) const;
 
   std::vector<std::string> dataset_{"rohdaten"};
   std::string schedule_begin_{"TODAY"};
@@ -20,6 +20,7 @@ struct loader_options {
   bool write_graph_{false};
   bool read_graph_{false};
   bool read_graph_mmap_{false};
+  bool cache_graph_{false};
   bool apply_rules_{true};
   bool adjust_footpaths_{false};
   bool expand_trips_{true};

--- a/base/loader/src/loader_options.cc
+++ b/base/loader/src/loader_options.cc
@@ -3,8 +3,11 @@
 #include <sstream>
 
 #include "boost/date_time/local_time/local_time.hpp"
+#include "boost/filesystem.hpp"
 
 #include "motis/core/common/date_time_util.h"
+
+namespace fs = boost::filesystem;
 
 namespace motis::loader {
 
@@ -25,14 +28,14 @@ std::pair<std::time_t, std::time_t> loader_options::interval() const {
   return interval;
 }
 
-std::string loader_options::graph_path() const {
+std::string loader_options::graph_path(std::string const& data_dir) const {
   if (graph_path_ == "default") {
     auto const [from, to] = interval();
     std::stringstream ss;
     ss << "graph_" << from << "-" << to << "af" << adjust_footpaths_ << "ar"
        << apply_rules_ << "et" << expand_trips_ << "ef" << expand_footpaths_
        << "ptd" << planned_transfer_delta_ << ".raw";
-    return ss.str();
+    return (fs::path{data_dir} / "schedule" / ss.str()).generic_string();
   } else {
     return graph_path_;
   }


### PR DESCRIPTION
Add a new `dataset.cache_graph` (bool) option, which is easier to use than the existing `dataset.read_graph` and `dataset.write_graph` options.

If `dataset.cache_graph` is enabled, an existing binary graph file is read if possible. If it doesn't exist or deserialization fails (e.g. because of an incompatible version), the schedule is loaded regularly and a new binary graph file is created, which will then automatically be used on subsequent runs.

Binary graph files are also moved into the data directory (in a `schedule` subdirectory).

The behavior of the existing `dataset.read_graph` and `dataset.write_graph` options remains unchanged (except for the path change).