### PR TITLE
Add CMake target to build the Elm Web UI

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -47,6 +47,7 @@ jobs:
             os: macos-latest
             artifact: macos
             avx: On
+            webui: On
           - name: GCC 10 Release
             cxx: g++-10
             cc: gcc-10
@@ -54,6 +55,7 @@ jobs:
             os: ubuntu-20.04
             artifact: linux
             avx: On
+            webui: On
           - name: GCC 10 Release
             cxx: g++-10
             cc: gcc-10
@@ -61,12 +63,14 @@ jobs:
             os: ubuntu-20.04
             artifact: linux-noavx
             avx: Off
+            webui: On
           - name: GCC 10 Debug
             cxx: g++-10
             cc: gcc-10
             mode: Debug
             os: ubuntu-20.04
             avx: On
+            webui: Off
           - name: Clang 11 Release
             cxx: clang++-11
             cc: clang-11
@@ -75,6 +79,7 @@ jobs:
             ldflags: -lc++abi
             os: ubuntu-20.04
             avx: On
+            webui: Off
           - name: Clang Tidy
             cxx: clang++-11
             cc: clang-11
@@ -84,6 +89,7 @@ jobs:
             lint: true
             os: ubuntu-20.04
             avx: On
+            webui: Off
           - key: Clang 11 Sanitizer
             cxx: clang++-11
             cc: clang-11
@@ -93,6 +99,7 @@ jobs:
             ldflags: -lc++abi
             os: ubuntu-20.04
             avx: On
+            webui: Off
     env:
       DEBIAN_FRONTEND: noninteractive
       BUILDCACHE_COMPRESS: true
@@ -162,7 +169,8 @@ jobs:
             -DMOTIS_LINT=${{ matrix.config.lint }} \
             -DMOTIS_AVX=${{ matrix.config.avx }} \
             -DCTX_ASAN=${{ contains(matrix.config.cxxflags, '-fsanitize=address') }} \
-            -DCTX_VALGRIND=${{ matrix.config.cc == 'gcc-10' && matrix.config.mode == 'Debug' }}
+            -DCTX_VALGRIND=${{ matrix.config.cc == 'gcc-10' && matrix.config.mode == 'Debug' }} \
+            -DMOTIS_WITH_WEBUI=${{ matrix.config.webui }}
 
       - name: Build
         run: |
@@ -211,7 +219,7 @@ jobs:
         run: strip build/motis
 
       - name: Compile Web Interface
-        if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-10' || matrix.config.os == 'macos-latest')
+        if: matrix.config.webui == 'On'
         run: cmake --build build --target motis-web-ui
 
       - name: Create Distribution

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -45,7 +45,6 @@ jobs:
             mode: Release
             cxxflags: -stdlib=libc++
             os: macos-latest
-            elm: macos
             artifact: macos
             avx: On
           - name: GCC 10 Release
@@ -53,7 +52,6 @@ jobs:
             cc: gcc-10
             mode: Release
             os: ubuntu-20.04
-            elm: linux-64bit
             artifact: linux
             avx: On
           - name: GCC 10 Release
@@ -61,7 +59,6 @@ jobs:
             cc: gcc-10
             mode: Release
             os: ubuntu-20.04
-            elm: linux-64bit
             artifact: linux-noavx
             avx: Off
           - name: GCC 10 Debug
@@ -215,15 +212,7 @@ jobs:
 
       - name: Compile Web Interface
         if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-10' || matrix.config.os == 'macos-latest')
-        run: |
-          cd ./ui/web
-          mkdir elm
-          cd elm
-          curl -L -o elm-platform.tar.gz https://github.com/elm-lang/elm-platform/releases/download/0.18.0-exp/elm-platform-${{ matrix.config.elm }}.tar.gz
-          cmake -E tar xzf elm-platform.tar.gz
-          cd ..
-          ./elm/elm-make --yes src/Main.elm --output elm.js
-          rm -rf elm
+        run: cmake --build build --target motis-web-ui
 
       - name: Create Distribution
         if: matrix.config.mode == 'Release' && (matrix.config.cc == 'gcc-10' || matrix.config.os == 'macos-latest')

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -77,15 +77,7 @@ jobs:
       # ==== DISTRIBUTION ====
       - name: Compile Web Interface
         if: matrix.mode == 'Release'
-        run: |
-          cd .\ui\web
-          mkdir elm
-          cd elm
-          Invoke-WebRequest -Uri https://github.com/elm-lang/elm-platform/releases/download/0.18.0-exp/elm-platform-windows.tar.gz -OutFile elm-platform-windows.tar.gz
-          cmake -E tar xzf .\elm-platform-windows.tar.gz
-          cd ..
-          .\elm\elm-make.exe --yes .\src\Main.elm --output elm.js
-          Remove-Item -Recurse -Force .\elm
+        run: cmake --build build --target motis-web-ui
 
       - name: Move Profiles
         if: matrix.mode == 'Release'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode: [Debug, Release]
+        config:
+          - mode: Debug
+            webui: Off
+          - mode: Release
+            webui: On
 
     env:
       CXX: cl.exe
@@ -34,11 +38,11 @@ jobs:
         uses: actions/cache@v1.1.2
         with:
           path: ${{ github.workspace }}/.buildcache
-          key: buildcache-wnds-${{ matrix.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
+          key: buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
           restore-keys: |
-            buildcache-wnds-${{ matrix.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}
-            buildcache-wnds-${{ matrix.mode }}-${{ hashFiles('.pkg') }}-
-            buildcache-wnds-${{ matrix.mode }}-
+            buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}
+            buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-
+            buildcache-wnds-${{ matrix.config.mode }}-
 
       - name: Dependencies Cache
         uses: actions/cache@v1.1.2
@@ -53,7 +57,11 @@ jobs:
           $installPath = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationpath
           Import-Module $devShell
           Enter-VsDevShell -VsInstallPath $installPath -SkipAutomaticLocation -DevCmdArguments "-arch=amd64"
-          cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.mode }} -DMOTIS_DEBUG_SYMBOLS=OFF
+          cmake `
+            -GNinja -S . -B build `
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.mode }} `
+            -DMOTIS_DEBUG_SYMBOLS=OFF `
+            -DMOTIS_WITH_WEBUI=${{ matrix.config.webui }}
           .\build\buildcache\bin\buildcache.exe -z
           cmake --build build --target motis motis-test motis-itest motis-eval motis-intermodal-eval
           .\build\buildcache\bin\buildcache.exe -s
@@ -76,18 +84,18 @@ jobs:
 
       # ==== DISTRIBUTION ====
       - name: Compile Web Interface
-        if: matrix.mode == 'Release'
+        if: matrix.config.webui == 'On'
         run: cmake --build build --target motis-web-ui
 
       - name: Move Profiles
-        if: matrix.mode == 'Release'
+        if: matrix.config.mode == 'Release'
         run: |
           echo d | xcopy /s .\deps\osrm-backend\profiles .\osrm-profiles
           echo d | xcopy /s .\deps\ppr\profiles .\ppr-profiles
           echo d | xcopy /s .\deps\tiles\profile .\tiles-profiles
 
       - name: Create Distribution
-        if: matrix.mode == 'Release'
+        if: matrix.config.mode == 'Release'
         run: >
           7z a motis-windows.zip
           .\build\motis.exe
@@ -97,7 +105,7 @@ jobs:
           .\ui\web
 
       - name: Upload Distribution
-        if: matrix.mode == 'Release'
+        if: matrix.config.mode == 'Release'
         uses: actions/upload-artifact@v1
         with:
           name: motis-windows
@@ -105,7 +113,7 @@ jobs:
 
       # ==== RELEASE ====
       - name: Upload Release
-        if: github.event.action == 'published' && matrix.mode == 'Release'
+        if: github.event.action == 'published' && matrix.config.mode == 'Release'
         uses: actions/upload-release-asset@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,8 @@ endforeach(module)
 add_subdirectory(base/bootstrap EXCLUDE_FROM_ALL)
 add_subdirectory(base/launcher)
 
+add_subdirectory(ui/web)
+
 
 ################################
 # Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ endif()
 option(MOTIS_LINT "enable lint (clang-tidy) target" OFF)
 option(MOTIS_COV "enable coverage (coverage) target" OFF)
 
+option(MOTIS_WITH_WEBUI "enable motis-web-ui target" OFF)
+
 add_library(motis-generated INTERFACE)
 target_include_directories(motis-generated INTERFACE ${CMAKE_BINARY_DIR}/generated)
 
@@ -184,7 +186,9 @@ endforeach(module)
 add_subdirectory(base/bootstrap EXCLUDE_FROM_ALL)
 add_subdirectory(base/launcher)
 
-add_subdirectory(ui/web)
+if(MOTIS_WITH_WEBUI)
+  add_subdirectory(ui/web)
+endif()
 
 
 ################################

--- a/ui/web/CMakeLists.txt
+++ b/ui/web/CMakeLists.txt
@@ -1,0 +1,30 @@
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set(elm-platform "linux-64bit")
+  set(elm-make "${CMAKE_BINARY_DIR}/dl/elm-make")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL  "Windows")
+  set(elm-platform "windows")
+  set(elm-make "${CMAKE_BINARY_DIR}/dl/elm-make.exe")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  set(elm-platform "macos")
+  set(elm-make "${CMAKE_BINARY_DIR}/dl/elm-make")
+else()
+  message(WARNING "No Elm binary available for this platform.")
+endif()
+
+if (elm-platform)
+  if (NOT EXISTS ${elm-make})
+    set(elm-url "https://github.com/elm-lang/elm-platform/releases/download/0.18.0-exp/elm-platform-${elm-platform}.tar.gz")
+    message(STATUS "Downloading Elm from ${elm-url}")
+    file(DOWNLOAD "${elm-url}" "${CMAKE_BINARY_DIR}/dl/elm.tar.gz")
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/dl/elm.tar.gz"
+      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/dl"
+    )
+  endif()
+
+  add_custom_target(motis-web-ui
+    COMMAND "${elm-make}" --yes src/Main.elm --output elm.js
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    VERBATIM
+  )
+endif()


### PR DESCRIPTION
Download Elm binaries using CMake (instead of GitHub Actions) and add a new target `motis-web-ui` that builds the web ui using the downloaded Elm tools.