### PR TITLE
Mutable Forward Star Multimap + Graph Improvements

### DIFF
--- a/.pkg
+++ b/.pkg
@@ -77,7 +77,7 @@
 [utl]
   url=git@github.com:motis-project/utl.git
   branch=master
-  commit=af511584449a159dbeff133a96b8076f447fbdb6
+  commit=571abc1973838b36931c64b2c7d98cc47e34da34
 [guess]
   url=git@github.com:motis-project/guess.git
   branch=master

--- a/.pkg
+++ b/.pkg
@@ -5,7 +5,7 @@
 [cista]
   url=git@github.com:felixguendling/cista.git
   branch=master
-  commit=e69bd7d0d286d02448cfbb2ab094867735027258
+  commit=0ce645719d0212a3a8762f76b7470d5c96da8d19
 [conf]
   url=git@github.com:motis-project/conf.git
   branch=master
@@ -77,7 +77,7 @@
 [utl]
   url=git@github.com:motis-project/utl.git
   branch=master
-  commit=571abc1973838b36931c64b2c7d98cc47e34da34
+  commit=59d8e70d871c9d8db2c46e3f1aa1c29cb25a339a
 [guess]
   url=git@github.com:motis-project/guess.git
   branch=master

--- a/.pkg
+++ b/.pkg
@@ -5,7 +5,7 @@
 [cista]
   url=git@github.com:felixguendling/cista.git
   branch=master
-  commit=0ce645719d0212a3a8762f76b7470d5c96da8d19
+  commit=e69bd7d0d286d02448cfbb2ab094867735027258
 [conf]
   url=git@github.com:motis-project/conf.git
   branch=master

--- a/base/core/include/motis/core/common/dynamic_fws_multimap.h
+++ b/base/core/include/motis/core/common/dynamic_fws_multimap.h
@@ -79,7 +79,7 @@ struct dynamic_fws_multimap_base {
     friend const_iterator end(bucket const& b) { return b.end(); }
 
     T& operator[](size_type index) {
-      return mutable_mm().data_[get_index().begin_ + index];
+      return mutable_mm().data_[data_index(index)];
     }
 
     T const& operator[](size_type index) const {
@@ -97,10 +97,18 @@ struct dynamic_fws_multimap_base {
     T& front() { return (*this)[0]; }
     T const& front() const { return (*this)[0]; }
 
-    T& back() { return (*this)[size() - 1]; }
-    T const& back() const { return (*this)[size() - 1]; }
+    T& back() {
+      assert(!empty());
+      return (*this)[size() - 1];
+    }
+
+    T const& back() const {
+      assert(!empty());
+      return (*this)[size() - 1];
+    }
 
     size_type data_index(size_type index) const {
+      assert(index < get_index().size_);
       return get_index().begin_ + index;
     }
 
@@ -369,7 +377,10 @@ struct dynamic_fws_multimap_base {
     return {*this, index};
   }
 
-  const_bucket operator[](size_type index) const { return {*this, index}; }
+  const_bucket operator[](size_type index) const {
+    assert(index < index_.size());
+    return {*this, index};
+  }
 
   mutable_bucket at(size_type index) {
     if (index >= index_.size()) {
@@ -552,7 +563,8 @@ protected:
     return data_index;
   }
 
-  static size_type get_order(size_type const size) {
+  inline static size_type get_order(size_type const size) {
+    assert(size != 0);
 #ifdef MOTIS_AVX2
     if constexpr (sizeof(size_type) == 8) {
       return _tzcnt_u64(size);

--- a/base/core/include/motis/core/common/dynamic_fws_multimap.h
+++ b/base/core/include/motis/core/common/dynamic_fws_multimap.h
@@ -48,12 +48,12 @@ struct dynamic_fws_multimap_base {
 
     iterator end() {
       auto const& index = get_index();
-      return mutable_mm().data_.begin() + index.begin_ + index.size_;
+      return std::next(mutable_mm().data_.begin(), index.begin_ + index.size_);
     }
 
     const_iterator end() const {
       auto const& index = get_index();
-      return multimap_.data_.begin() + index.begin_ + index.size_;
+      return std::next(multimap_.data_.begin(), index.begin_ + index.size_);
     }
 
     const_iterator cbegin() const { return begin(); }
@@ -387,8 +387,12 @@ struct dynamic_fws_multimap_base {
 
   iterator begin() { return {*this, 0}; }
   const_iterator begin() const { return {*this, 0}; }
-  iterator end() { return iterator{*this, index_.size()}; }
-  const_iterator end() const { return const_iterator{*this, index_.size()}; }
+  iterator end() {
+    return iterator{*this, static_cast<size_type>(index_.size())};
+  }
+  const_iterator end() const {
+    return const_iterator{*this, static_cast<size_type>(index_.size())};
+  }
 
   friend iterator begin(dynamic_fws_multimap_base& m) { return m.begin(); }
   friend const_iterator begin(dynamic_fws_multimap_base const& m) {

--- a/base/core/include/motis/core/common/dynamic_fws_multimap.h
+++ b/base/core/include/motis/core/common/dynamic_fws_multimap.h
@@ -32,8 +32,8 @@ struct dynamic_fws_multimap_base {
     using const_iterator = typename mcd::vector<T>::const_iterator;
 
     template <bool IsConst = Const, typename = std::enable_if_t<IsConst>>
-    explicit bucket(bucket<false> const& b)
-        : multimap_{b.multimap_}, index_{b.index_} {}
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    bucket(bucket<false> const& b) : multimap_{b.multimap_}, index_{b.index_} {}
 
     size_type index() const { return index_; }
     size_type size() const { return get_index().size_; }
@@ -241,7 +241,8 @@ struct dynamic_fws_multimap_base {
     using reference = value_type;
 
     template <bool IsConst = Const, typename = std::enable_if_t<IsConst>>
-    explicit bucket_iterator(bucket_iterator<false> const& it)
+    // NOLINTNEXTLINE(google-explicit-constructor, hicpp-explicit-conversions)
+    bucket_iterator(bucket_iterator<false> const& it)
         : multimap_{it.multimap_}, index_{it.index_} {}
 
     value_type operator*() const { return multimap_.at(index_); }

--- a/base/core/include/motis/core/common/dynamic_fws_multimap.h
+++ b/base/core/include/motis/core/common/dynamic_fws_multimap.h
@@ -90,6 +90,14 @@ struct dynamic_fws_multimap_base {
       return get_index().begin_ + index;
     }
 
+    size_type bucket_index(const_iterator it) const {
+      if (it < begin() || it >= end()) {
+        throw std::out_of_range{
+            "dynamic_fws_multimap::bucket::bucket_index() out of range"};
+      }
+      return std::distance(begin(), it);
+    }
+
     template <bool IsConst = Const, typename = std::enable_if_t<!IsConst>>
     size_type push_back(entry_type const& val) {
       return mutable_mm().push_back_entry(index_, val);
@@ -257,9 +265,21 @@ struct dynamic_fws_multimap_base {
       return *this;
     }
 
+    bucket_iterator operator++(int) {
+      auto old = *this;
+      ++(*this);
+      return old;
+    }
+
     bucket_iterator& operator--() {
       ++index_;
       return *this;
+    }
+
+    bucket_iterator operator--(int) {
+      auto old = *this;
+      --(*this);
+      return old;
     }
 
     bucket_iterator operator+(difference_type n) const {
@@ -270,8 +290,9 @@ struct dynamic_fws_multimap_base {
       return {multimap_, index_ - n};
     }
 
-    int operator-(bucket_iterator const& rhs) const {
-      return index_ - rhs.index_;
+    difference_type operator-(bucket_iterator const& rhs) const {
+      return static_cast<difference_type>(index_) -
+             static_cast<difference_type>(rhs.index_);
     };
 
     value_type operator[](difference_type n) const {
@@ -298,11 +319,11 @@ struct dynamic_fws_multimap_base {
     }
 
     bool operator==(bucket_iterator const& rhs) const {
-      return &multimap_ == &rhs.multimap_ && index_ == rhs.index_;
+      return index_ == rhs.index_ && &multimap_ == &rhs.multimap_;
     }
 
     bool operator!=(bucket_iterator const& rhs) const {
-      return &multimap_ != &rhs.multimap_ || index_ != rhs.index_;
+      return index_ != rhs.index_ || &multimap_ != &rhs.multimap_;
     }
 
   protected:
@@ -359,11 +380,15 @@ struct dynamic_fws_multimap_base {
   iterator end() { return iterator{*this, index_.size()}; }
   const_iterator end() const { return const_iterator{*this, index_.size()}; }
 
-  friend iterator begin(dynamic_fws_multimap_base const& m) {
+  friend iterator begin(dynamic_fws_multimap_base& m) { return m.begin(); }
+  friend const_iterator begin(dynamic_fws_multimap_base const& m) {
     return m.begin();
   }
 
-  friend iterator end(dynamic_fws_multimap_base const& m) { return m.end(); }
+  friend iterator end(dynamic_fws_multimap_base& m) { return m.end(); }
+  friend const_iterator end(dynamic_fws_multimap_base const& m) {
+    return m.end();
+  }
 
   mcd::vector<T>& data() { return data_; }
 

--- a/base/core/include/motis/core/common/dynamic_fws_multimap.h
+++ b/base/core/include/motis/core/common/dynamic_fws_multimap.h
@@ -1,22 +1,35 @@
 #pragma once
 
-#include "motis/vector.h"
-
 #include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <algorithm>
+#include <array>
 #include <iterator>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <type_traits>
 
+#ifdef MOTIS_AVX2
+#include <immintrin.h>
+#endif
+
+#include "motis/vector.h"
+
+#include "cista/next_power_of_2.h"
+
+#include "utl/verify.h"
+
 namespace motis {
 
-template <typename Derived, typename T, typename SizeType = std::uint32_t>
+template <typename Derived, typename T, typename SizeType = std::uint32_t,
+          SizeType Log2MaxEntriesPerBucket = 20>
 struct dynamic_fws_multimap_base {
   using entry_type = T;
   using size_type = SizeType;
+  static SizeType const MAX_ENTRIES_PER_BUCKET =
+      static_cast<SizeType>(1ULL << Log2MaxEntriesPerBucket);
 
   struct index_type {
     size_type begin_{};
@@ -387,6 +400,12 @@ struct dynamic_fws_multimap_base {
   size_type element_count() const { return element_count_; }
   [[nodiscard]] bool empty() const { return index_size() == 0; }
 
+  size_type max_entries_per_bucket() const { return MAX_ENTRIES_PER_BUCKET; }
+
+  size_type max_entries_per_bucket_log2() const {
+    return Log2MaxEntriesPerBucket;
+  }
+
   iterator begin() { return {*this, 0}; }
   const_iterator begin() const { return {*this, 0}; }
   iterator end() {
@@ -427,32 +446,73 @@ protected:
   }
 
   void grow_bucket(size_type const map_index, index_type& idx) {
-    auto const new_capacity =
-        std::max(static_cast<size_type>(idx.capacity_ + 1),
-                 idx.capacity_ == 0 ? initial_capacity_
-                                    : idx.capacity_ * growth_factor_);
-    grow_bucket(map_index, idx, new_capacity);
+    grow_bucket(map_index, idx, idx.capacity_ + 1);
   }
 
   void grow_bucket(size_type const map_index, index_type& idx,
-                   size_type const new_capacity) {
-    if (idx.capacity_ == 0) {
-      // new bucket
-      idx.begin_ = data_.size();
-      data_.resize(data_.size() + new_capacity);
-      idx.capacity_ = new_capacity;
-    } else if (idx.begin_ + idx.capacity_ == data_.size()) {
-      // last bucket
-      auto const additional_capacity = new_capacity - idx.capacity_;
-      data_.resize(data_.size() + additional_capacity);
-      idx.capacity_ = new_capacity;
+                   size_type const requested_capacity) {
+    assert(requested_capacity > 0);
+    auto const new_capacity = cista::next_power_of_two(requested_capacity);
+    auto const new_order = get_order(new_capacity);
+
+    utl::verify(new_order <= Log2MaxEntriesPerBucket,
+                "dynamic_fws_multimap: too many entries in a bucket: {}",
+                new_capacity);
+
+    auto old_bucket = idx;
+
+    auto free_bucket = get_free_bucket(new_order);
+    if (free_bucket) {
+      // reuse free bucket
+      if (old_bucket.capacity_ != 0) {
+        move_entries(map_index, old_bucket.begin_, free_bucket->begin_,
+                     idx.size_);
+        release_bucket(old_bucket);
+      }
+      idx.begin_ = free_bucket->begin_;
+      idx.capacity_ = free_bucket->capacity_;
     } else {
-      // move to end of data vector
-      auto const new_begin = data_.size();
-      data_.resize(data_.size() + new_capacity);
-      move_entries(map_index, idx.begin_, new_begin, idx.size_);
-      idx.begin_ = new_begin;
-      idx.capacity_ = new_capacity;
+      if (idx.begin_ + idx.capacity_ == data_.size()) {
+        // last bucket -> resize
+        auto const additional_capacity = new_capacity - idx.capacity_;
+        data_.resize(data_.size() + additional_capacity);
+        idx.capacity_ = new_capacity;
+      } else {
+        // allocate new bucket at the end
+        auto const new_begin = data_.size();
+        data_.resize(data_.size() + new_capacity);
+        move_entries(map_index, idx.begin_, new_begin, idx.size_);
+        idx.begin_ = new_begin;
+        idx.capacity_ = new_capacity;
+        release_bucket(old_bucket);
+      }
+    }
+  }
+
+  std::optional<index_type> get_free_bucket(size_type const requested_order) {
+    assert(requested_order <= Log2MaxEntriesPerBucket);
+
+    auto const pop =
+        [](mcd::vector<index_type>& vec) -> std::optional<index_type> {
+      if (!vec.empty()) {
+        auto it = std::prev(vec.end());
+        auto const entry = *it;
+        vec.erase(it);
+        return entry;
+      } else {
+        return {};
+      }
+    };
+
+    return pop(free_buckets_[requested_order]);  // NOLINT
+  }
+
+  void release_bucket(index_type bucket) {
+    if (bucket.capacity_ != 0) {
+      auto const order = get_order(bucket.capacity_);
+      assert(order <= Log2MaxEntriesPerBucket);
+      bucket.size_ = 0;
+      free_buckets_[order].push_back(bucket);  // NOLINT
     }
   }
 
@@ -492,12 +552,30 @@ protected:
     return data_index;
   }
 
+  static size_type get_order(size_type const size) {
+#ifdef MOTIS_AVX2
+    if constexpr (sizeof(size_type) == 8) {
+      return _tzcnt_u64(size);
+    } else {
+      return _tzcnt_u32(static_cast<std::uint32_t>(size));
+    }
+#else
+    for (auto order = size_type{0}, value = size_type{1};
+         order <= Log2MaxEntriesPerBucket; ++order, value = value << 1) {
+      if (value == size) {
+        return order;
+      }
+    }
+    throw utl::fail("dynamic_fws_multimap::get_order: not found for {}", size);
+#endif
+  }
+
 public:
   mcd::vector<index_type> index_;
   mcd::vector<T> data_;
+  std::array<mcd::vector<index_type>, Log2MaxEntriesPerBucket + 1>
+      free_buckets_;
   size_type element_count_{};
-  size_type initial_capacity_{1};
-  size_type growth_factor_{2};
 };
 
 template <typename T, typename SizeType = std::uint32_t>

--- a/base/core/include/motis/core/common/fws_graph.h
+++ b/base/core/include/motis/core/common/fws_graph.h
@@ -173,14 +173,45 @@ struct fws_graph {
     size_type size() const { return edges_.bwd_[to_node_].size(); }
     [[nodiscard]] bool empty() const { return size() == 0; }
 
-    edge_type& operator[](size_type index) { return edges_[to_node_][index]; }
+    edge_type const& operator[](size_type index) const {
+      return edges_.data_[edges_.bwd_[to_node_][index]];
+    }
 
-    edge_type& at(size_type index) const { return edges_[to_node_].at(index); }
+    template <bool IsConst = Const, typename = std::enable_if_t<!IsConst>>
+    edge_type& operator[](size_type index) {
+      return mutable_edges().data_[edges_.bwd_[to_node_][index]];
+    }
+
+    edge_type const& at(size_type index) const {
+      return edges_.data_.at(edges_.bwd_[to_node_].at(index));
+    }
+
+    template <bool IsConst = Const, typename = std::enable_if_t<!IsConst>>
+    edge_type& at(size_type index) {
+      return mutable_edges().data_.at(edges_.bwd_[to_node_].at(index));
+    }
+
+    edge_type const& front() const { return (*this)[0]; }
+    edge_type& front() { return (*this)[0]; }
+
+    edge_type const& back() const {
+      assert(!empty());
+      return (*this)[size() - 1];
+    }
+
+    edge_type& back() {
+      assert(!empty());
+      return (*this)[size() - 1];
+    }
 
   protected:
     incoming_edge_bucket(edge_fws_multimap<edge_type> const& edges,
                          size_type to_node)
         : edges_{edges}, to_node_{to_node} {}
+
+    edge_fws_multimap<edge_type>& mutable_edges() {
+      return const_cast<edge_fws_multimap<edge_type>&>(edges_);  // NOLINT
+    }
 
     edge_fws_multimap<edge_type> const& edges_;
     size_type to_node_;

--- a/base/core/include/motis/core/common/fws_graph.h
+++ b/base/core/include/motis/core/common/fws_graph.h
@@ -37,13 +37,18 @@ struct fws_graph {
   // fwd: node_id -> outgoing edges
   // bwd: node_id -> trace (edge indices) -> incoming edges
 
+  template <bool Const>
   struct incoming_edge_bucket {
     friend fws_graph;
 
     using size_type = size_type;
     using value_type = edge_type;
 
-    template <bool Const>
+    template <bool IsConst = Const, typename = std::enable_if_t<IsConst>>
+    explicit incoming_edge_bucket(incoming_edge_bucket<false> const& b)
+        : edges_{b.edges_}, to_node_{b.to_node_} {}
+
+    template <bool ConstIt>
     struct edge_iterator {
       friend incoming_edge_bucket;
       using iterator_category = std::random_access_iterator_tag;
@@ -54,16 +59,16 @@ struct fws_graph {
       using const_reference = value_type const&;
 
       using bwd_bucket_t = typename edge_fws_multimap<
-          edge_type>::bwd_mm_t::template bucket<Const>;
+          edge_type>::bwd_mm_t::template bucket<ConstIt>;
       using bucket_iterator_t = typename bwd_bucket_t::const_iterator;
 
-      template <bool IsConst = Const, typename = std::enable_if_t<IsConst>>
+      template <bool IsConst = ConstIt, typename = std::enable_if_t<IsConst>>
       explicit edge_iterator(edge_iterator<false> const& it)
           : edges_{it.edges_}, bucket_it_{it.bucket_it_} {}
 
       const_reference operator*() const { return edges_.data_[*bucket_it_]; }
 
-      template <bool IsConst = Const, typename = std::enable_if_t<!IsConst>>
+      template <bool IsConst = ConstIt, typename = std::enable_if_t<!IsConst>>
       reference operator*() {
         return const_cast<edge_fws_multimap<edge_type>&>(edges_)  // NOLINT
             .data_[*bucket_it_];
@@ -71,7 +76,7 @@ struct fws_graph {
 
       const_reference operator->() const { return edges_.data_[*bucket_it_]; }
 
-      template <bool IsConst = Const, typename = std::enable_if_t<!IsConst>>
+      template <bool IsConst = ConstIt, typename = std::enable_if_t<!IsConst>>
       reference operator->() {
         return const_cast<edge_fws_multimap<edge_type>&>(edges_)  // NOLINT
             .data_[*bucket_it_];
@@ -154,27 +159,52 @@ struct fws_graph {
       return {edges_, edges_.bwd_[to_node_].cend()};
     }
 
-    friend iterator begin(incoming_edge_bucket const& b) { return b.begin(); }
-    friend iterator end(incoming_edge_bucket const& b) { return b.end(); }
+    const_iterator cbegin() const { return begin(); }
+    const_iterator cend() const { return end(); }
+
+    friend iterator begin(incoming_edge_bucket& b) { return b.begin(); }
+    friend const_iterator begin(incoming_edge_bucket const& b) {
+      return b.begin();
+    }
+
+    friend iterator end(incoming_edge_bucket& b) { return b.end(); }
+    friend const_iterator end(incoming_edge_bucket const& b) { return b.end(); }
 
     size_type size() const { return edges_.bwd_[to_node_].size(); }
-    bool empty() const { return size() == 0; }
+    [[nodiscard]] bool empty() const { return size() == 0; }
 
     edge_type& operator[](size_type index) { return edges_[to_node_][index]; }
 
     edge_type& at(size_type index) const { return edges_[to_node_].at(index); }
 
   protected:
-    incoming_edge_bucket(edge_fws_multimap<edge_type>& edges, size_type to_node)
+    incoming_edge_bucket(edge_fws_multimap<edge_type> const& edges,
+                         size_type to_node)
         : edges_{edges}, to_node_{to_node} {}
 
-    edge_fws_multimap<edge_type>& edges_;
+    edge_fws_multimap<edge_type> const& edges_;
     size_type to_node_;
   };
+
+  using mutable_outgoing_edge_bucket =
+      typename edge_fws_multimap<edge_type>::mutable_bucket;
+  using const_outgoing_edge_bucket =
+      typename edge_fws_multimap<edge_type>::const_bucket;
+
+  using mutable_incoming_edge_bucket = incoming_edge_bucket<false>;
+  using const_incoming_edge_bucket = incoming_edge_bucket<true>;
 
   edge_type& push_back_edge(edge_type const& e) {
     auto const data_index = edges_[e.from_].push_back(e);
     edges_.bwd_[e.to_].push_back(data_index);
+    return edges_.data_[data_index];
+  }
+
+  edge_type& push_back_edge(edge_type&& e) {
+    auto const from = e.from_;
+    auto const to = e.to_;
+    auto const data_index = edges_[from].emplace_back(std::move(e));
+    edges_.bwd_[to].push_back(data_index);
     return edges_.data_[data_index];
   }
 
@@ -187,37 +217,63 @@ struct fws_graph {
     return edges_.data_[data_index];
   }
 
+  template <typename... Args>
+  node_type& emplace_back_node(Args&&... args) {
+    auto& n = nodes_.emplace_back(std::forward<Args>(args)...);
+    init_node_edges(n);
+    return n;
+  }
+
+  node_type& push_back_node(node_type const& node) {
+    auto& n = nodes_.push_back(node);
+    init_node_edges(n);
+    return n;
+  }
+
   size_type node_index(node_type const* node) const {
     return std::distance(nodes_.begin(), node);
   }
 
-  typename edge_fws_multimap<edge_type>::mutable_bucket outgoing_edges(
-      size_type from_node) {
+  void init_node_edges(node_type const& node) {
+    auto const index = node_index(&node);
+    edges_[index];
+    edges_.bwd_[index];
+  }
+
+  mutable_outgoing_edge_bucket outgoing_edges(size_type from_node) {
     return edges_[from_node];
   }
 
-  typename edge_fws_multimap<edge_type>::const_bucket outgoing_edges(
-      size_type from_node) const {
+  const_outgoing_edge_bucket outgoing_edges(size_type from_node) const {
     return edges_[from_node];
   }
 
-  typename edge_fws_multimap<edge_type>::mutable_bucket outgoing_edges(
-      node_type const* from_node) {
+  mutable_outgoing_edge_bucket outgoing_edges(node_type const* from_node) {
     return outgoing_edge(node_index(from_node));
   }
 
-  typename edge_fws_multimap<edge_type>::const_bucket outgoing_edges(
-      node_type const* from_node) const {
+  const_outgoing_edge_bucket outgoing_edges(node_type const* from_node) const {
     return outgoing_edge(node_index(from_node));
   }
 
-  incoming_edge_bucket incoming_edges(size_type to_node) {
+  mutable_incoming_edge_bucket incoming_edges(size_type to_node) {
     return {edges_, to_node};
   }
 
-  incoming_edge_bucket incoming_edges(node_type const* to_node) {
+  const_incoming_edge_bucket incoming_edges(size_type to_node) const {
+    return {edges_, to_node};
+  }
+
+  mutable_incoming_edge_bucket incoming_edges(node_type const* to_node) {
     return incoming_edges(node_index(to_node));
   }
+
+  const_incoming_edge_bucket incoming_edges(node_type const* to_node) const {
+    return incoming_edges(node_index(to_node));
+  }
+
+  std::size_t node_count() const { return nodes_.size(); }
+  std::size_t edge_count() const { return edges_.element_count(); }
 
   mcd::vector<node_type> nodes_;
   edge_fws_multimap<edge_type> edges_;

--- a/base/core/include/motis/core/common/fws_graph.h
+++ b/base/core/include/motis/core/common/fws_graph.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <iterator>
+
 #include "motis/core/common/dynamic_fws_multimap.h"
 #include "motis/vector.h"
 
@@ -185,6 +187,10 @@ struct fws_graph {
     return edges_.data_[data_index];
   }
 
+  size_type node_index(node_type const* node) const {
+    return std::distance(nodes_.begin(), node);
+  }
+
   typename edge_fws_multimap<edge_type>::mutable_bucket outgoing_edges(
       size_type from_node) {
     return edges_[from_node];
@@ -195,8 +201,22 @@ struct fws_graph {
     return edges_[from_node];
   }
 
+  typename edge_fws_multimap<edge_type>::mutable_bucket outgoing_edges(
+      node_type const* from_node) {
+    return outgoing_edge(node_index(from_node));
+  }
+
+  typename edge_fws_multimap<edge_type>::const_bucket outgoing_edges(
+      node_type const* from_node) const {
+    return outgoing_edge(node_index(from_node));
+  }
+
   incoming_edge_bucket incoming_edges(size_type to_node) {
     return {edges_, to_node};
+  }
+
+  incoming_edge_bucket incoming_edges(node_type const* to_node) {
+    return incoming_edges(node_index(to_node));
   }
 
   mcd::vector<node_type> nodes_;

--- a/base/core/test/dynamic_fws_multimap_test.cc
+++ b/base/core/test/dynamic_fws_multimap_test.cc
@@ -1,44 +1,21 @@
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include <algorithm>
+#include "cista/reflection/comparable.h"
+
+#include "utl/erase.h"
+#include "utl/erase_if.h"
+
 #include <iostream>
-#include <iterator>
 
 #include "motis/core/common/dynamic_fws_multimap.h"
+
+using ::testing::ElementsAreArray;
+using ::testing::IsEmpty;
 
 namespace motis {
 
 namespace {
-
-template <typename T, bool ConstBucket>
-void check_result(
-    std::vector<T> const& ref,
-    typename dynamic_fws_multimap<T>::template bucket<ConstBucket> const&
-        result) {
-  if (ref.size() != result.size() && result.size() < 10) {
-    std::cout << "Invalid result:\n  Expected: ";
-    std::copy(begin(ref), end(ref), std::ostream_iterator<T>(std::cout, " "));
-    std::cout << "\n  Result:   ";
-    std::copy(begin(result), end(result),
-              std::ostream_iterator<T>(std::cout, " "));
-    std::cout << std::endl;
-  }
-  ASSERT_EQ(ref.size(), result.size());
-  for (auto i = 0UL; i < ref.size(); ++i) {
-    EXPECT_EQ(ref[i], result[i]);
-  }
-}
-
-template <typename T, typename SizeType>
-void print_multimap(dynamic_fws_multimap<T, SizeType>& mm) {
-  for (auto const& bucket : mm) {
-    std::cout << "key={" << bucket.index() << "} => [ ";
-    for (auto const& entry : bucket) {
-      std::cout << entry << " ";
-    }
-    std::cout << "]\n";
-  }
-}
 
 /*
 struct test_node {
@@ -48,6 +25,8 @@ struct test_node {
 */
 
 struct test_edge {
+  CISTA_COMPARABLE()
+
   std::uint32_t from_{};
   std::uint32_t to_{};
   std::uint32_t weight_{};
@@ -56,6 +35,27 @@ struct test_edge {
 inline std::ostream& operator<<(std::ostream& out, test_edge const& e) {
   return out << "{from=" << e.from_ << ", to=" << e.to_
              << ", weight=" << e.weight_ << "}";
+}
+
+inline dynamic_fws_multimap<int> build_test_map_1() {
+  dynamic_fws_multimap<int> mm;
+
+  mm[0].push_back(4);
+  mm[0].push_back(8);
+
+  mm[1].push_back(15);
+  mm[1].push_back(16);
+  mm[1].push_back(23);
+  mm[1].push_back(42);
+
+  mm[2].push_back(100);
+  mm[2].push_back(200);
+  mm[2].push_back(250);
+  mm[2].push_back(300);
+  mm[2].push_back(350);
+  mm[2].push_back(400);
+
+  return mm;
 }
 
 }  // namespace
@@ -69,50 +69,48 @@ TEST(fws_dynamic_multimap_test, int_1) {
   mm[0].push_back(42);
   ASSERT_EQ(1, mm.element_count());
   ASSERT_EQ(1, mm.index_size());
-  check_result<int>({42}, mm[0]);
-  ASSERT_EQ(1, mm[0].size());
+  EXPECT_THAT(mm[0], ElementsAreArray({42}));
+  EXPECT_EQ(1, mm[0].size());
 
   mm[1].push_back(4);
   ASSERT_EQ(2, mm.element_count());
   ASSERT_EQ(2, mm.index_size());
-  check_result<int>({42}, mm[0]);
-  ASSERT_EQ(1, mm[0].size());
-  check_result<int>({4}, mm[1]);
-  ASSERT_EQ(1, mm[1].size());
+  EXPECT_THAT(mm[0], ElementsAreArray({42}));
+  EXPECT_EQ(1, mm[0].size());
+  EXPECT_THAT(mm[1], ElementsAreArray({4}));
+  EXPECT_EQ(1, mm[1].size());
 
   mm[1].push_back(8);
   ASSERT_EQ(3, mm.element_count());
   ASSERT_EQ(2, mm.index_size());
-  check_result<int>({42}, mm[0]);
-  ASSERT_EQ(1, mm[0].size());
-  check_result<int>({4, 8}, mm[1]);
-  ASSERT_EQ(2, mm[1].size());
+  EXPECT_THAT(mm[0], ElementsAreArray({42}));
+  EXPECT_EQ(1, mm[0].size());
+  EXPECT_THAT(mm[1], ElementsAreArray({4, 8}));
+  EXPECT_EQ(2, mm[1].size());
 
   mm[1].emplace_back(15);
   ASSERT_EQ(4, mm.element_count());
   ASSERT_EQ(2, mm.index_size());
-  check_result<int>({42}, mm[0]);
-  ASSERT_EQ(1, mm[0].size());
-  check_result<int>({4, 8, 15}, mm[1]);
-  ASSERT_EQ(3, mm[1].size());
+  EXPECT_THAT(mm[0], ElementsAreArray({42}));
+  EXPECT_EQ(1, mm[0].size());
+  EXPECT_THAT(mm[1], ElementsAreArray({4, 8, 15}));
+  EXPECT_EQ(3, mm[1].size());
 
   mm[1].push_back(16);
   ASSERT_EQ(5, mm.element_count());
   ASSERT_EQ(2, mm.index_size());
-  check_result<int>({42}, mm[0]);
-  ASSERT_EQ(1, mm[0].size());
-  check_result<int>({4, 8, 15, 16}, mm[1]);
-  ASSERT_EQ(4, mm[1].size());
+  EXPECT_THAT(mm[0], ElementsAreArray({42}));
+  EXPECT_EQ(1, mm[0].size());
+  EXPECT_THAT(mm[1], ElementsAreArray({4, 8, 15, 16}));
+  EXPECT_EQ(4, mm[1].size());
 
   mm[0].push_back(23);
   ASSERT_EQ(6, mm.element_count());
   ASSERT_EQ(2, mm.index_size());
-  check_result<int>({42, 23}, mm[0]);
-  ASSERT_EQ(2, mm[0].size());
-  check_result<int>({4, 8, 15, 16}, mm[1]);
-  ASSERT_EQ(4, mm[1].size());
-
-  print_multimap(mm);
+  EXPECT_THAT(mm[0], ElementsAreArray({42, 23}));
+  EXPECT_EQ(2, mm[0].size());
+  EXPECT_THAT(mm[1], ElementsAreArray({4, 8, 15, 16}));
+  EXPECT_EQ(4, mm[1].size());
 }
 
 TEST(fws_dynamic_multimap_test, graph_1) {
@@ -124,7 +122,197 @@ TEST(fws_dynamic_multimap_test, graph_1) {
   mm[3].emplace_back(3U, 0U, 50U);
   mm[2].emplace_back(2U, 3U, 5U);
 
-  print_multimap(mm);
+  ASSERT_EQ(4, mm.index_size());
+  EXPECT_EQ(5, mm.element_count());
+
+  EXPECT_THAT(mm[0], ElementsAreArray({test_edge{0U, 1U, 10U}}));
+  EXPECT_THAT(mm[1], ElementsAreArray(
+                         {test_edge{1U, 2U, 20U}, test_edge{1U, 3U, 30U}}));
+  EXPECT_THAT(mm[2], ElementsAreArray({test_edge{2U, 3U, 5U}}));
+  EXPECT_THAT(mm[3], ElementsAreArray({test_edge{3U, 0U, 50U}}));
+}
+
+TEST(fws_dynamic_multimap_test, int_2) {
+  auto const mm = build_test_map_1();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(12, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+
+  EXPECT_THAT(mm.front(), ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm.back(), ElementsAreArray({100, 200, 250, 300, 350, 400}));
+  EXPECT_EQ(15, mm[1].front());
+  EXPECT_EQ(42, mm[1].back());
+}
+
+TEST(fws_dynamic_multimap_test, int_insert_1) {
+  auto mm = build_test_map_1();
+
+  mm[1].insert(std::next(mm[1].begin(), 2), 20);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(13, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 20, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+}
+
+TEST(fws_dynamic_multimap_test, int_erase_1) {
+  auto mm = build_test_map_1();
+
+  utl::erase(mm[1], 16);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(11, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+
+  utl::erase(mm[2], 100);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(10, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({200, 250, 300, 350, 400}));
+
+  utl::erase(mm[2], 400);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(9, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({200, 250, 300, 350}));
+
+  utl::erase(mm[2], 250);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(8, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({200, 300, 350}));
+
+  utl::erase(mm[1], 404);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(8, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({200, 300, 350}));
+}
+
+TEST(fws_dynamic_multimap_test, int_erase_2) {
+  auto mm = build_test_map_1();
+
+  utl::erase_if(mm[2], [](int e) { return e % 100 == 0; });
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(8, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({250, 350}));
+}
+
+TEST(fws_dynamic_multimap_test, int_resize_1) {
+  auto mm = build_test_map_1();
+
+  mm[0].resize(4);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(14, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8, 0, 0}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+
+  mm[1].resize(3);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(13, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8, 0, 0}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+
+  mm[1].resize(6, 123);
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(16, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8, 0, 0}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23, 123, 123, 123}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+}
+
+TEST(fws_dynamic_multimap_test, pop_back_1) {
+  auto mm = build_test_map_1();
+
+  mm[2].pop_back();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(11, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350}));
+
+  mm[1].pop_back();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(10, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350}));
+
+  mm[0].pop_back();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(9, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350}));
+
+  mm[0].pop_back();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(8, mm.element_count());
+  EXPECT_THAT(mm[0], IsEmpty());
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350}));
+}
+
+TEST(fws_dynamic_multimap_test, clear_1) {
+  auto mm = build_test_map_1();
+
+  mm[0].clear();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(10, mm.element_count());
+  EXPECT_THAT(mm[0], IsEmpty());
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23, 42}));
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+}
+
+TEST(fws_dynamic_multimap_test, clear_2) {
+  auto mm = build_test_map_1();
+
+  mm[1].clear();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(8, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], IsEmpty());
+  EXPECT_THAT(mm[2], ElementsAreArray({100, 200, 250, 300, 350, 400}));
+}
+
+TEST(fws_dynamic_multimap_test, clear_3) {
+  auto mm = build_test_map_1();
+
+  mm[2].clear();
+
+  ASSERT_EQ(3, mm.index_size());
+  EXPECT_EQ(6, mm.element_count());
+  EXPECT_THAT(mm[0], ElementsAreArray({4, 8}));
+  EXPECT_THAT(mm[1], ElementsAreArray({15, 16, 23, 42}));
+  EXPECT_THAT(mm[2], IsEmpty());
 }
 
 }  // namespace motis

--- a/base/core/test/fws_graph_test.cc
+++ b/base/core/test/fws_graph_test.cc
@@ -66,11 +66,29 @@ void check_graph(
     auto const bucket = g.outgoing_edges(from);
     EXPECT_EQ(edges.size(), bucket.size());
     EXPECT_THAT(bucket, ElementsAreArray(edges));
+    if (!edges.empty()) {
+      EXPECT_EQ(bucket.front(), edges.front());
+      EXPECT_EQ(bucket.back(), edges.back());
+    }
+    if (bucket.size() == edges.size()) {
+      for (auto i = 0; i < bucket.size(); ++i) {
+        EXPECT_EQ(bucket[i], edges[i]);
+      }
+    }
   }
   for (auto const& [to, edges] : check_bwd) {
     auto const bucket = g.incoming_edges(to);
     EXPECT_EQ(edges.size(), bucket.size());
     EXPECT_THAT(bucket, ElementsAreArray(edges));
+    if (!edges.empty()) {
+      EXPECT_EQ(bucket.front(), edges.front());
+      EXPECT_EQ(bucket.back(), edges.back());
+    }
+    if (bucket.size() == edges.size()) {
+      for (auto i = 0; i < bucket.size(); ++i) {
+        EXPECT_EQ(bucket[i], edges[i]);
+      }
+    }
   }
 }
 
@@ -120,6 +138,7 @@ TEST(fws_graph_test, t1) {
   check_graph(g, check_fwd, check_bwd);
 
   if (HasFailure()) {
+    std::cout << "\ngraph:\n\n";
     print_graph(g);
   }
 
@@ -130,6 +149,10 @@ TEST(fws_graph_test, t1) {
       EXPECT_EQ(ei, edges.bucket_index(&e));
     }
   }
+
+  EXPECT_EQ(g.incoming_edges(1).front().weight_, 3U);
+  g.incoming_edges(1).front().weight_ = 100U;
+  EXPECT_EQ(g.incoming_edges(1).front().weight_, 100U);
 }
 
 }  // namespace motis

--- a/base/core/test/fws_graph_test.cc
+++ b/base/core/test/fws_graph_test.cc
@@ -122,6 +122,14 @@ TEST(fws_graph_test, t1) {
   if (HasFailure()) {
     print_graph(g);
   }
+
+  for (auto const& [ni, n] : utl::enumerate(g.nodes_)) {
+    EXPECT_EQ(ni, g.node_index(&n));
+    auto const edges = g.outgoing_edges(ni);
+    for (auto const& [ei, e] : utl::enumerate(edges)) {
+      EXPECT_EQ(ei, edges.bucket_index(&e));
+    }
+  }
 }
 
 }  // namespace motis

--- a/base/core/test/fws_graph_test.cc
+++ b/base/core/test/fws_graph_test.cc
@@ -93,15 +93,15 @@ TEST(fws_graph_test, t1) {
   mcd::hash_map<std::uint32_t, mcd::vector<test_edge>> check_fwd;
   mcd::hash_map<std::uint32_t, mcd::vector<test_edge>> check_bwd;
 
-  g.nodes_.emplace_back(0U, 4U);
-  g.nodes_.emplace_back(1U, 8U);
-  g.nodes_.emplace_back(2U, 15U);
-  g.nodes_.emplace_back(3U, 16U);
-  g.nodes_.emplace_back(4U, 23U);
-  g.nodes_.emplace_back(5U, 42U);
-  g.nodes_.emplace_back(6U, 42U);
-  g.nodes_.emplace_back(7U, 42U);
-  g.nodes_.emplace_back(8U, 42U);
+  g.emplace_back_node(0U, 4U);
+  g.emplace_back_node(1U, 8U);
+  g.emplace_back_node(2U, 15U);
+  g.emplace_back_node(3U, 16U);
+  g.emplace_back_node(4U, 23U);
+  g.emplace_back_node(5U, 42U);
+  g.emplace_back_node(6U, 42U);
+  g.emplace_back_node(7U, 42U);
+  g.emplace_back_node(8U, 42U);
 
   add_edge(g, check_fwd, check_bwd, {0U, 2U, 5U});
   add_edge(g, check_fwd, check_bwd, {0U, 3U, 7U});


### PR DESCRIPTION
Improvements to `dynamic_fws_multimap`:

- Buckets are recycled (using free lists). Initial capacity and growth factor parameters removed, bucket capacity is now always 2^n.
- Various new methods (insert, erase, clear, front, back...)

Improvements to `fws_graph`:

- `emplace_back_node` + `push_back_node` (fix for nodes without outgoing or incoming edges)
- const iterator
