### PR TITLE
json output: include all fields (even those with default values)

### DIFF
--- a/.pkg
+++ b/.pkg
@@ -21,7 +21,7 @@
 [flatbuffers]
   url=git@github.com:motis-project/flatbuffers.git
   branch=motis
-  commit=67c40dd37ab31c895ddd4bda8331ad56c777a9a7
+  commit=b0966f5f4c14ffc7ffb3badb90d7fdee4b86836a
 [fmt]
   url=git@github.com:motis-project/fmt.git
   branch=master

--- a/base/module/src/message.cc
+++ b/base/module/src/message.cc
@@ -21,6 +21,7 @@ std::unique_ptr<Parser> init_parser(bool compact = false) {
   auto parser = std::make_unique<Parser>();
   parser->opts.strict_json = true;
   parser->opts.skip_unexpected_fields_in_json = true;
+  parser->opts.output_default_scalars_in_json = true;
   if (compact) {
     parser->opts.indent_step = -1;
   }


### PR DESCRIPTION
After this change, messages in JSON format will always include all fields, even those that have default values.

Example message schema:

```flatbuffers
enum TestEnum : ubyte {
  Foo, Bar, Baz
}

table TestResponse {
  non_def_bool: bool;
  non_def_enum: TestEnum;

  def_int_0: int;
  def_ulong_0: ulong;
  def_double_0: double;
  def_int_10: int = 10;
  def_ulong_10: ulong = 10;
  def_double_pi: double = 3.1415;
  def_bool_false: bool;
  def_bool_true: bool = true;
  def_enum_none: TestEnum;
  def_enum_first: TestEnum = Foo;
  def_enum_second: TestEnum = Bar;
}
```

JSON output of a message where all `def_*` fields are set to their default values:

Before:

```json
{
  "destination": {
    "target": ""
  },
  "content_type": "TestResponse",
  "content": {
    "non_def_bool": true,
    "non_def_enum": "Baz"
  },
  "id": 1
}
```

After:

```json
{
  "destination": {
    "type": "Module",
    "target": ""
  },
  "content_type": "TestResponse",
  "content": {
    "non_def_bool": true,
    "non_def_enum": "Baz",
    "def_int_0": 0,
    "def_ulong_0": 0,
    "def_double_0": 0.0,
    "def_int_10": 10,
    "def_ulong_10": 10,
    "def_double_pi": 3.1415,
    "def_bool_false": false,
    "def_bool_true": true,
    "def_enum_none": "Foo",
    "def_enum_first": "Foo",
    "def_enum_second": "Bar"
  },
  "id": 1
}
```

FlatBuffers changes: https://github.com/motis-project/flatbuffers/pull/1
