### PR TITLE
Add Trip Lookup in RI Basis Format

### DIFF
--- a/modules/lookup/include/motis/lookup/lookup.h
+++ b/modules/lookup/include/motis/lookup/lookup.h
@@ -31,6 +31,8 @@ private:
   motis::module::msg_ptr lookup_meta_stations(motis::module::msg_ptr const&);
   motis::module::msg_ptr lookup_schedule_info();
 
+  motis::module::msg_ptr lookup_ribasis(motis::module::msg_ptr const&);
+
   std::unique_ptr<geo::point_rtree> station_geo_index_;
 };
 

--- a/modules/lookup/include/motis/lookup/lookup_ribasis.h
+++ b/modules/lookup/include/motis/lookup/lookup_ribasis.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <vector>
+
+#include "motis/core/schedule/schedule.h"
+#include "motis/protocol/Message_generated.h"
+
+namespace motis::lookup {
+
+flatbuffers::Offset<LookupRiBasisResponse> lookup_ribasis(
+    flatbuffers::FlatBufferBuilder&, schedule const&,
+    LookupRiBasisRequest const*);
+
+}  // namespace motis::lookup

--- a/modules/lookup/src/lookup.cc
+++ b/modules/lookup/src/lookup.cc
@@ -8,6 +8,7 @@
 #include "motis/lookup/lookup_geo_station.h"
 #include "motis/lookup/lookup_id_train.h"
 #include "motis/lookup/lookup_meta_station.h"
+#include "motis/lookup/lookup_ribasis.h"
 #include "motis/lookup/lookup_station_events.h"
 
 using namespace flatbuffers;
@@ -41,6 +42,8 @@ void lookup::init(registry& r) {
                 [&](msg_ptr const& m) { return lookup_meta_station(m); });
   r.register_op("/lookup/meta_station_batch",
                 [&](msg_ptr const& m) { return lookup_meta_stations(m); });
+  r.register_op("/lookup/ribasis",
+                [&](msg_ptr const& m) { return lookup_ribasis(m); }, {});
 }
 
 msg_ptr lookup::lookup_station_id(msg_ptr const& msg) const {
@@ -147,6 +150,20 @@ msg_ptr lookup::lookup_schedule_info() {
                                        external_schedule_begin(sched),
                                        external_schedule_end(sched))
           .Union());
+  return make_msg(b);
+}
+
+msg_ptr lookup::lookup_ribasis(msg_ptr const& msg) {
+  auto req = motis_content(LookupRiBasisRequest, msg);
+  auto const schedule_res_id =
+      req->schedule() == 0U ? to_res_id(global_res_id::SCHEDULE)
+                            : static_cast<ctx::res_id_t>(req->schedule());
+  auto res_lock = lock_resources({{schedule_res_id, ctx::access_t::READ}});
+  auto const& sched = *res_lock.get<schedule_data>(schedule_res_id).schedule_;
+
+  message_creator b;
+  auto rbf = motis::lookup::lookup_ribasis(b, sched, req);
+  b.create_and_finish(MsgContent_LookupRiBasisResponse, rbf.Union());
   return make_msg(b);
 }
 

--- a/modules/lookup/src/lookup_ribasis.cc
+++ b/modules/lookup/src/lookup_ribasis.cc
@@ -1,0 +1,427 @@
+#include "motis/lookup/lookup_ribasis.h"
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "boost/uuid/uuid.hpp"
+#include "boost/uuid/uuid_generators.hpp"
+#include "boost/uuid/uuid_io.hpp"
+
+#include "date/date.h"
+
+#include "utl/get_or_create.h"
+#include "utl/to_set.h"
+#include "utl/to_vec.h"
+#include "utl/verify.h"
+
+#include "motis/hash_map.h"
+#include "motis/hash_set.h"
+#include "motis/pair.h"
+#include "motis/string.h"
+
+#include "motis/core/access/bfs.h"
+#include "motis/core/access/realtime_access.h"
+#include "motis/core/access/service_access.h"
+#include "motis/core/access/time_access.h"
+#include "motis/core/access/trip_access.h"
+#include "motis/core/access/trip_iterator.h"
+#include "motis/core/conv/trip_conv.h"
+
+using namespace flatbuffers;
+using namespace motis::ribasis;
+namespace uu = boost::uuids;
+
+namespace motis::lookup {
+
+/* Current limitations:
+ * - All UUIDs are randomly generated for every request and can
+ *   only be used to parse the message (i.e. they are not stable and not stored)
+ * - All lines with the same name have the same UUID
+ * - All tracks with the same name (even at different stations) have the same
+ *   UUID
+ * - kategorie is always set to VORSCHAU
+ * - fahrttyp is always set to PLANFAHRT
+ * - zusatzhalt and bedarfshalt are always set to false
+ * - RiBasisFahrtZuordnungstyp is always set to DURCHBINDUNG
+ */
+
+namespace {
+
+constexpr auto const FULL_TIME_FORMAT = "%FT%T%Ez";
+constexpr auto const DATE_FORMAT = "%F";
+
+struct rib_ctx {
+  rib_ctx(FlatBufferBuilder& fbb, schedule const& sched)
+      : fbb_{fbb}, sched_{sched}, empty_string_{fbb.CreateString("")} {}
+
+  Offset<String> timestamp(time const mt,
+                           char const* format = FULL_TIME_FORMAT) {
+    return fbb_.CreateString(date::format(
+        format, std::chrono::system_clock::time_point{
+                    std::chrono::seconds{motis_to_unixtime(sched_, mt)}}));
+  }
+
+  Offset<RiBasisHaltestelle> station(uint32_t const station_idx) {
+    return utl::get_or_create(stations_, station_idx, [&]() {
+      auto const& st = sched_.stations_.at(station_idx);
+      auto const rl100 = st->external_ids_.empty()
+                             ? empty_string_
+                             : fbb_.CreateString(st->external_ids_.front());
+      return CreateRiBasisHaltestelle(
+          fbb_,
+          rand_uuid(),  // haltestelleid
+          fbb_.CreateString(st->name_),  // bezeichnung
+          fbb_.CreateString(st->eva_nr_),  // evanummer
+          rl100  // rl100
+      );
+    });
+  }
+
+  Offset<String> provider_id(provider const* p) {
+    return utl::get_or_create(provider_ids_, p, [&]() {
+      auto const id = rand_uuid();
+      providers_.emplace_back(CreateRiBasisVerwaltung(
+          fbb_, id,  // verwaltungid
+          CreateRiBasisBetreiber(
+              fbb_,
+              p != nullptr ? fbb_.CreateString(p->full_name_)
+                           : empty_string_,  // name
+              p != nullptr ? fbb_.CreateString(p->short_name_)
+                           : empty_string_  // code
+              )));
+      return id;
+    });
+  }
+
+  Offset<String> category_id(uint32_t const family) {
+    return utl::get_or_create(category_ids_, family, [&]() {
+      auto const& cat = sched_.categories_.at(family);
+      auto const id = rand_uuid();
+      auto const name = fbb_.CreateString(cat->name_);
+      categories_.emplace_back(CreateRiBasisGattung(fbb_,
+                                                    id,  // gattungid
+                                                    name,  // name
+                                                    name  // code
+                                                    ));
+      return id;
+    });
+  }
+
+  Offset<String> line_id(mcd::string const& line_identifier) {
+    return utl::get_or_create(line_ids_, line_identifier, [&]() {
+      auto const id = rand_uuid();
+      lines_.emplace_back(CreateRiBasisLinie(
+          fbb_,
+          id,  // linieid
+          fbb_.CreateString(line_identifier)  // name
+          ));
+      return id;
+    });
+  }
+
+  Offset<RiBasisOrt> track(uint16_t const track_idx) {
+    return utl::get_or_create(tracks_, track_idx, [&]() {
+      auto const id = track_idx == 0 ? empty_string_ : rand_uuid();
+      return CreateRiBasisOrt(
+          fbb_,
+          id,  // ortid
+          fbb_.CreateString(sched_.tracks_.at(track_idx)),  // bezeichnung
+          ribasis::RiBasisOrtTyp_GLEIS  // orttyp
+      );
+    });
+  }
+
+  Offset<String> trip_id(trip const* trp) {
+    return utl::get_or_create(trip_ids_, trp, [&]() { return rand_uuid(); });
+  }
+
+  Offset<String> event_key(trip const* trp, ev_key const ev) {
+    return utl::get_or_create(event_keys_, mcd::pair{trp, ev},
+                              [&]() { return rand_uuid(); });
+  }
+
+  Offset<String> rand_uuid() {
+    return fbb_.CreateString(uu::to_string(uuid_gen_()));
+  }
+
+  FlatBufferBuilder& fbb_;
+  schedule const& sched_;
+  uu::random_generator uuid_gen_;
+
+  Offset<String> empty_string_;
+
+  mcd::hash_map<uint32_t /* station index */, Offset<RiBasisHaltestelle>>
+      stations_;
+  mcd::hash_map<trip const*, Offset<String>> trip_ids_;
+  mcd::hash_map<mcd::pair<trip const*, ev_key>, Offset<String>> event_keys_;
+  mcd::hash_map<uint16_t /* track index */, Offset<RiBasisOrt>> tracks_;
+
+  mcd::hash_map<provider const*, Offset<String>> provider_ids_;
+  std::vector<Offset<RiBasisVerwaltung>> providers_;
+
+  mcd::hash_map<uint32_t /* family */, Offset<String>> category_ids_;
+  std::vector<Offset<RiBasisGattung>> categories_;
+
+  mcd::hash_map<mcd::string, Offset<String>> line_ids_;
+  std::vector<Offset<RiBasisLinie>> lines_;
+};
+
+Offset<RiBasisFahrtRelation> trip_relation(rib_ctx& rc, trip const* trp) {
+  // motis trip ids don't have provider + category information, so we
+  // need to look it up for the first trip section (not ideal since this
+  // may have changed...)
+  auto const sections = motis::access::sections{trp};
+  utl::verify(begin(sections) != end(sections),
+              "lookup_ribasis_trip: trip has no sections");
+  auto const first_section = *begin(sections);
+  auto const& provider = first_section.lcon().full_con_->con_info_->provider_;
+  return CreateRiBasisFahrtRelation(
+      rc.fbb_,
+      rc.fbb_.CreateSharedString(std::to_string(
+          trp->id_.primary_.get_train_nr())),  // startfahrtnummer
+      rc.timestamp(trp->id_.primary_.get_time()),  // startzeit
+      provider != nullptr ? rc.fbb_.CreateString(provider->short_name_)
+                          : rc.empty_string_,  // startverwaltung
+      rc.fbb_.CreateString(
+          rc.sched_.categories_
+              .at(first_section.lcon().full_con_->con_info_->family_)
+              ->name_),  // startgattung
+      rc.fbb_.CreateString(trp->id_.secondary_.line_id_),  // startlinie
+      rc.station(trp->id_.primary_.get_station_id()),  // starthaltestelle
+      rc.timestamp(trp->id_.secondary_.target_time_),  // zielzeit
+      rc.station(trp->id_.secondary_.target_station_id_)  // zielhaltestelle
+  );
+}
+
+RiBasisZeitstatus convert_reason(timestamp_reason const tr) {
+  switch (tr) {
+    case timestamp_reason::SCHEDULE: return ribasis::RiBasisZeitstatus_FAHRPLAN;
+    case timestamp_reason::FORECAST: return ribasis::RiBasisZeitstatus_PROGNOSE;
+    case timestamp_reason::IS: return ribasis::RiBasisZeitstatus_MELDUNG;
+    case timestamp_reason::PROPAGATION:
+      return ribasis::RiBasisZeitstatus_PROGNOSE;
+    case timestamp_reason::REPAIR: return ribasis::RiBasisZeitstatus_PROGNOSE;
+    default: throw utl::fail("unsupported timestamp_reason");
+  }
+}
+
+std::vector<trip const*> get_merged_trips(
+    rib_ctx& rc, trip const* trp, motis::access::trip_section const& sec) {
+  std::vector<trip const*> merged;
+  for (auto const& mt : *rc.sched_.merged_trips_.at(sec.lcon().trips_)) {
+    if (mt != trp) {
+      merged.emplace_back(mt);
+    }
+  }
+  return merged;
+}
+
+Offset<RiBasisAbfahrt> departure(rib_ctx& rc, trip const* trp,
+                                 motis::access::trip_section const& sec) {
+  auto const di = get_delay_info(rc.sched_, sec.ev_key_from());
+  return CreateRiBasisAbfahrt(
+      rc.fbb_, rc.event_key(trp, sec.ev_key_from()),  // abfahrtid
+      rc.station(sec.from_station_id()),  // haltestelle
+      sec.from_node()->is_in_allowed(),  // fahrgastwechsel
+      rc.timestamp(di.get_schedule_time()),  // planabfahrtzeit
+      rc.timestamp(sec.lcon().d_time_),  // abfahrtzeit
+      convert_reason(di.get_reason()),  // abfahrtzeitstatus
+      rc.track(
+          get_schedule_track(rc.sched_, sec.ev_key_from())),  // planabfahrtort
+      rc.track(sec.lcon().full_con_->d_track_),  // abfahrtort
+      false,  // zusatzhalt
+      false,  // bedarfshalt
+      rc.fbb_.CreateVector(
+          std::vector<
+              Offset<RiBasisAbfahrtZuordnung>>{})  // allAbfahrtzuordnung
+  );
+}
+
+Offset<RiBasisAnkunft> arrival(rib_ctx& rc, trip const* trp,
+                               motis::access::trip_section const& sec) {
+  auto const di = get_delay_info(rc.sched_, sec.ev_key_to());
+  return CreateRiBasisAnkunft(
+      rc.fbb_, rc.event_key(trp, sec.ev_key_to()),  // ankunftid
+      rc.station(sec.to_station_id()),  // haltestelle
+      sec.to_node()->is_out_allowed(),  // fahrgastwechsel
+      rc.timestamp(di.get_schedule_time()),  // planankunftzeit
+      rc.timestamp(sec.lcon().a_time_),  // ankunftzeit
+      convert_reason(di.get_reason()),  // ankunftzeitstatus
+      rc.track(
+          get_schedule_track(rc.sched_, sec.ev_key_to())),  // planankunftort,
+      rc.track(sec.lcon().full_con_->a_track_),  // ankunftort
+      false,  // zusatzhalt
+      false,  // bedarfshalt
+      rc.fbb_.CreateVector(
+          std::vector<
+              Offset<RiBasisAnkunftZuordnung>>{})  // allAnkunftzuordnung
+  );
+}
+
+Offset<Vector<Offset<RiBasisFahrtAbschnitt>>> trip_sections(rib_ctx& rc,
+                                                            trip const* trp) {
+  auto const secs = utl::to_vec(
+      motis::access::sections{trp},
+      [&](motis::access::trip_section const& sec) {
+        auto const& lc = sec.lcon();
+        auto const& ci = lc.full_con_->con_info_;
+        return CreateRiBasisFahrtAbschnitt(
+            rc.fbb_,
+            rc.fbb_.CreateSharedString(std::to_string(output_train_nr(
+                ci->train_nr_, ci->original_train_nr_))),  // fahrtnummer
+            rc.fbb_.CreateSharedString(
+                get_service_name(rc.sched_, ci)),  // fahrtbezeichnung
+            rc.empty_string_,  // fahrtname,
+            rc.provider_id(ci->provider_),  // verwaltungid
+            rc.category_id(ci->family_),  // gattungid
+            rc.line_id(ci->line_identifier_),  // lineid
+            departure(rc, trp, sec),  // abfahrt
+            arrival(rc, trp, sec),  // ankunft
+            rc.fbb_.CreateVector(  // allVereinigtmit
+                utl::to_vec(get_merged_trips(rc, trp, sec),
+                            [&](trip const* merged_trp) {
+                              return CreateRiBasisFormation(
+                                  rc.fbb_,
+                                  rc.trip_id(merged_trp),  // fahrtid
+                                  rc.event_key(merged_trp,
+                                               sec.ev_key_from()),  // abfahrtid
+                                  rc.event_key(merged_trp,
+                                               sec.ev_key_to()));  // ankunftid
+                            })));
+      });
+  return rc.fbb_.CreateVector(secs);
+}
+
+Offset<RiBasisTrip> rib_trip(rib_ctx& rc, trip const* trp,
+                             std::vector<edge const*> const& through_edges) {
+  auto const start_day =
+      rc.timestamp(trp->id_.primary_.get_time(), DATE_FORMAT);
+  auto const now = std::chrono::system_clock::now();
+
+  std::vector<Offset<RiBasisZubringerFahrtZuordnung>> through_in;
+  std::vector<Offset<RiBasisAbbringerFahrtZuordnung>> through_out;
+  auto const route_nodes = utl::to_set(
+      access::stops{trp}, [](auto const& ts) { return ts.get_route_node(); });
+  auto const lcon_idx = trp->lcon_idx_;
+  for (auto const te : through_edges) {
+    if (route_nodes.find(te->from_) != end(route_nodes)) {
+      for (auto const& oe : te->to_->edges_) {
+        if (oe.type() != edge::ROUTE_EDGE) {
+          continue;
+        }
+        for (auto const& tt : *rc.sched_.merged_trips_.at(
+                 oe.m_.route_edge_.conns_.at(lcon_idx).trips_)) {
+          through_out.emplace_back(CreateRiBasisAbbringerFahrtZuordnung(
+              rc.fbb_,
+              rc.trip_id(tt),  // fahrtid
+              rc.event_key(
+                  tt, ev_key{&oe, lcon_idx, event_type::DEP}),  // abfahrtid
+              ribasis::RiBasisFahrtZuordnungstyp_DURCHBINDUNG));  // typ
+        }
+      }
+    }
+    if (route_nodes.find(te->to_) != end(route_nodes)) {
+      for (auto const& ie : te->from_->incoming_edges_) {
+        if (ie->type() != edge::ROUTE_EDGE) {
+          continue;
+        }
+        for (auto const& tt : *rc.sched_.merged_trips_.at(
+                 ie->m_.route_edge_.conns_.at(lcon_idx).trips_)) {
+          through_in.emplace_back(CreateRiBasisZubringerFahrtZuordnung(
+              rc.fbb_,
+              rc.trip_id(tt),  // fahrtid
+              rc.event_key(tt, ev_key{cista::ptr_cast(ie), lcon_idx,
+                                      event_type::ARR}),  // ankunftid
+              ribasis::RiBasisFahrtZuordnungstyp_DURCHBINDUNG));  // typ
+        }
+      }
+    }
+  }
+
+  return CreateRiBasisTrip(
+      rc.fbb_, to_fbs(rc.sched_, rc.fbb_, trp),
+      CreateRiBasisFahrt(
+          rc.fbb_,
+          CreateRiBasisMeta(
+              rc.fbb_,
+              rc.rand_uuid(),  // id
+              rc.empty_string_,  // owner
+              rc.fbb_.CreateString("RIPL"),  // format
+              rc.fbb_.CreateString("v3"),  // version
+              rc.fbb_.CreateVector(
+                  std::vector<Offset<String>>{}),  // correlation
+              rc.fbb_.CreateString(  // created
+                  date::format(FULL_TIME_FORMAT, now)),
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                  now.time_since_epoch())
+                  .count()  // sequence
+              ),
+          CreateRiBasisFahrtData(
+              rc.fbb_,
+              ribasis::RiBasisFahrtKategorie_VORSCHAU,  // kategorie
+              start_day,  // planstarttag
+              rc.trip_id(trp),  // fahrtid
+              trip_relation(rc, trp),
+              start_day,  // verkehrstag
+              ribasis::RiBasisFahrtTyp_PLANFAHRT,  // fahrttyp
+              rc.fbb_.CreateVector(rc.providers_),  // allVerwaltung
+              rc.fbb_.CreateVector(rc.categories_),  // allGattung
+              rc.fbb_.CreateVector(rc.lines_),  // allLinie
+              trip_sections(rc, trp),  // allFahrtabschnitt
+              rc.fbb_.CreateVector(through_in),  // allZubringerfahrtzuordnung
+              rc.fbb_.CreateVector(  // allAbbringerfahrtzuordnung
+                  through_out))));
+}
+
+std::pair<mcd::hash_set<trip const*>, std::vector<edge const*>>
+trips_and_through_edges_in_route(schedule const& sched,
+                                 trip const* requested_trip) {
+  mcd::hash_set<trip const*> trips;
+  std::vector<edge const*> through_edges;
+  if (requested_trip->edges_->empty()) {
+    return {trips, through_edges};
+  }
+
+  auto const first_dep = ev_key{requested_trip->edges_->front().get_edge(),
+                                requested_trip->lcon_idx_, event_type::DEP};
+  auto const lcon_idx = requested_trip->lcon_idx_;
+
+  for (auto const& re : route_bfs(first_dep, bfs_direction::BOTH, true)) {
+    auto const* e = re.get_edge();
+    if (e->type() == edge::ROUTE_EDGE) {
+      auto const& lcon = e->m_.route_edge_.conns_.at(lcon_idx);
+      for (auto const& trp : *sched.merged_trips_.at(lcon.trips_)) {
+        trips.insert(trp);
+      }
+    } else if (e->type() == edge::THROUGH_EDGE) {
+      through_edges.emplace_back(e);
+    }
+  }
+  return {trips, through_edges};
+}
+
+}  // namespace
+
+Offset<LookupRiBasisResponse> lookup_ribasis(FlatBufferBuilder& fbb,
+                                             schedule const& sched,
+                                             LookupRiBasisRequest const* req) {
+  auto const t = req->trip_id();
+  auto requested_trp = get_trip(sched, t->station_id()->str(), t->train_nr(),
+                                t->time(), t->target_station_id()->str(),
+                                t->target_time(), t->line_id()->str());
+
+  auto rc = rib_ctx{fbb, sched};
+  auto const trips_and_through_edges =
+      trips_and_through_edges_in_route(sched, requested_trp);
+  auto const& trips = trips_and_through_edges.first;
+  auto const& through_edges = trips_and_through_edges.second;
+
+  return CreateLookupRiBasisResponse(
+      fbb, fbb.CreateVector(utl::to_vec(trips, [&](trip const* trp) {
+        return rib_trip(rc, trp, through_edges);
+      })));
+}
+
+}  // namespace motis::lookup

--- a/protocol/Message.fbs
+++ b/protocol/Message.fbs
@@ -21,6 +21,8 @@ include "lookup/LookupIdTrainRequest.fbs";
 include "lookup/LookupIdTrainResponse.fbs";
 include "lookup/LookupMetaStationRequest.fbs";
 include "lookup/LookupMetaStationResponse.fbs";
+include "lookup/LookupRiBasisRequest.fbs";
+include "lookup/LookupRiBasisResponse.fbs";
 include "lookup/LookupScheduleInfoResponse.fbs";
 include "lookup/LookupStationEventsRequest.fbs";
 include "lookup/LookupStationEventsResponse.fbs";
@@ -272,7 +274,9 @@ union MsgContent {
   motis.paxmon.PaxMonStatusRequest                                        = 123,
   motis.ris.RISApplyRequest                                               = 124,
   motis.ris.RISSystemTimeChanged                                          = 125,
-  motis.rt.RtGraphUpdated                                                 = 126
+  motis.rt.RtGraphUpdated                                                 = 126,
+  motis.lookup.LookupRiBasisRequest                                       = 127,
+  motis.lookup.LookupRiBasisResponse                                      = 128
 }
 
 // Destination Examples:

--- a/protocol/lookup/LookupRiBasisRequest.fbs
+++ b/protocol/lookup/LookupRiBasisRequest.fbs
@@ -1,0 +1,8 @@
+include "base/TripId.fbs";
+
+namespace motis.lookup;
+
+table LookupRiBasisRequest {
+  trip_id: TripId;
+  schedule: ulong; // schedule id (0 = default)
+}

--- a/protocol/lookup/LookupRiBasisResponse.fbs
+++ b/protocol/lookup/LookupRiBasisResponse.fbs
@@ -1,0 +1,13 @@
+include "base/TripId.fbs";
+include "ribasis/RiBasisFahrt.fbs";
+
+namespace motis.lookup;
+
+table RiBasisTrip {
+  trip_id: TripId;
+  fahrt: motis.ribasis.RiBasisFahrt;
+}
+
+table LookupRiBasisResponse {
+  trips: [RiBasisTrip];
+}

--- a/protocol/ribasis/RiBasisFahrt.fbs
+++ b/protocol/ribasis/RiBasisFahrt.fbs
@@ -1,0 +1,176 @@
+namespace motis.ribasis;
+
+table RiBasisMeta {
+  id: string; // uuid
+  owner: string;
+  format: string;
+  version: string;
+  correlation: [string];
+  created: string; // timestamp
+  sequence: long;
+}
+
+enum RiBasisFahrtKategorie : byte { SOLL, IST, VORSCHAU }
+
+enum RiBasisFahrtTyp : byte {
+  PLANFAHRT,
+  ERSATZFAHRT,
+  ENTLASTUNGSFAHRT,
+  SONDERFAHRT
+}
+
+table RiBasisHaltestelle {
+  haltestelleid: string; // uuid
+  bezeichnung: string;
+  evanummer: string;
+  rl100: string;
+}
+
+table RiBasisBetreiber {
+  name: string;
+  code: string;
+}
+
+table RiBasisVerwaltung {
+  verwaltungid: string;
+  betreiber: RiBasisBetreiber;
+}
+
+table RiBasisGattung {
+  gattungid: string;
+  name: string;
+  code: string;
+}
+
+table RiBasisLinie {
+  linieid: string;
+  name: string;
+}
+
+table RiBasisFahrtRelation {
+  startfahrtnummer: string;
+  startzeit: string; // timestamp
+  startverwaltung: string;
+  startgattung: string;
+  startlinie: string;
+  starthaltestelle: RiBasisHaltestelle;
+  zielzeit: string; // timestamp
+  zielhaltestelle: RiBasisHaltestelle;
+}
+
+enum RiBasisZeitstatus : byte {
+  FAHRPLAN,
+  MELDUNG,
+  AUTOMAT,
+  PROGNOSE,
+  UNBEKANNT
+}
+
+enum RiBasisOrtTyp : byte { STEIG, GLEIS }
+
+table RiBasisOrt {
+  ortid: string; // uuid | empty
+  bezeichnung: string;
+  orttyp: RiBasisOrtTyp;
+}
+
+enum RiBasisHaltzuordnungstyp : byte {
+  IST_ERSATZ_FUER,
+  WIRD_ERSETZT_DURCH,
+  IST_ENTLASTUNG_FUER,
+  WIRD_ENTLASTET_DURCH,
+  GLEISAENDERUNG_VON,
+  GLEISAENDERUNG_NACH
+}
+
+table RiBasisAbfahrtZuordnung {
+  fahrtid: string; // uuid
+  abfahrtid: string; // uuid
+  typ: RiBasisHaltzuordnungstyp;
+}
+
+table RiBasisAbfahrt {
+  abfahrtid: string; // uuid
+  haltestelle: RiBasisHaltestelle;
+  fahrgastwechsel: bool;
+  planabfahrtzeit: string; // timestamp
+  abfahrtzeit: string; // timestamp
+  abfahrtzeitstatus: RiBasisZeitstatus;
+  planabfahrtort: RiBasisOrt;
+  abfahrtort: RiBasisOrt;
+  zusatzhalt: bool;
+  bedarfshalt: bool;
+  allAbfahrtzuordnung: [RiBasisAbfahrtZuordnung];
+}
+
+table RiBasisAnkunftZuordnung {
+  fahrtid: string; // uuid
+  ankunftid: string; // uuid
+  typ: RiBasisHaltzuordnungstyp;
+}
+
+table RiBasisAnkunft {
+  ankunftid: string; // uuid
+  haltestelle: RiBasisHaltestelle;
+  fahrgastwechsel: bool;
+  planankunftzeit: string; // timestamp
+  ankunftzeit: string; // timestamp
+  ankunftzeitstatus: RiBasisZeitstatus;
+  planankunftort: RiBasisOrt;
+  ankunftort: RiBasisOrt;
+  zusatzhalt: bool;
+  bedarfshalt: bool;
+  allAnkunftzuordnung: [RiBasisAnkunftZuordnung];
+}
+
+table RiBasisFormation {
+  fahrtid: string; // uuid
+  abfahrtid: string; // uuid
+  ankunftid: string; // uuid
+}
+
+table RiBasisFahrtAbschnitt {
+  fahrtnummer: string;
+  fahrtbezeichnung: string;
+  fahrtname: string;
+  verwaltungid: string;
+  gattungid: string; // uuid
+  linieid: string; // uuid
+  abfahrt: RiBasisAbfahrt;
+  ankunft: RiBasisAnkunft;
+  allVereinigtmit: [RiBasisFormation];
+}
+
+enum RiBasisFahrtZuordnungstyp : byte { DURCHBINDUNG, WENDE }
+
+table RiBasisZubringerFahrtZuordnung {
+  fahrtid: string; // uuid
+  ankunftid: string; // uuid
+  typ: RiBasisFahrtZuordnungstyp;
+}
+
+table RiBasisAbbringerFahrtZuordnung {
+  fahrtid: string; // uuid
+  abfahrtid: string; // uuid
+  typ: RiBasisFahrtZuordnungstyp;
+}
+
+table RiBasisFahrtData {
+  kategorie: RiBasisFahrtKategorie;
+  planstarttag: string; // YYYY-MM-DD
+  fahrtid: string; // uuid
+  fahrtrelation: RiBasisFahrtRelation;
+  verkehrstag: string; // YYYY-MM-DD
+  fahrttyp: RiBasisFahrtTyp;
+  allVerwaltung: [RiBasisVerwaltung];
+  allGattung: [RiBasisGattung];
+  allLinie: [RiBasisLinie];
+  allFahrtabschnitt: [RiBasisFahrtAbschnitt];
+  allZubringerfahrtzuordnung: [RiBasisZubringerFahrtZuordnung];
+  allAbbringerfahrtzuordnung: [RiBasisAbbringerFahrtZuordnung];
+}
+
+table RiBasisFahrt {
+  meta: RiBasisMeta;
+  data: RiBasisFahrtData;
+}

--- a/ui/rsl/protocol.config.json
+++ b/ui/rsl/protocol.config.json
@@ -9,7 +9,8 @@
     "motis.paxforecast.*",
     "motis.routing.*",
     "motis.guesser.*",
-    "motis.lookup.*"
+    "motis.lookup.*",
+    "motis.ribasis.*"
   ],
   "header": "// generated file - do not modify - run update-protocol to update"
 }

--- a/ui/rsl/src/api/lookup.ts
+++ b/ui/rsl/src/api/lookup.ts
@@ -1,4 +1,8 @@
-import { LookupScheduleInfoResponse } from "./protocol/motis/lookup";
+import {
+  LookupRiBasisRequest,
+  LookupRiBasisResponse,
+  LookupScheduleInfoResponse,
+} from "./protocol/motis/lookup";
 import { sendRequest } from "./request";
 import { verifyContentType } from "./protocol/checks";
 import { useQuery, UseQueryResult } from "react-query";
@@ -13,7 +17,29 @@ export function useLookupScheduleInfoQuery(): UseQueryResult<LookupScheduleInfoR
   return useQuery(queryKeys.scheduleInfo(), sendLookupScheduleInfoRequest);
 }
 
+export async function sendLookupRiBasisRequest(
+  content: LookupRiBasisRequest
+): Promise<LookupRiBasisResponse> {
+  const msg = await sendRequest(
+    "/lookup/ribasis",
+    "LookupRiBasisRequest",
+    content
+  );
+  verifyContentType(msg, "LookupRiBasisResponse");
+  return msg.content as LookupRiBasisResponse;
+}
+
+export function useLookupRiBasisQuery(
+  content: LookupRiBasisRequest
+): UseQueryResult<LookupRiBasisResponse> {
+  return useQuery(queryKeys.riBasis(content), () =>
+    sendLookupRiBasisRequest(content)
+  );
+}
+
 export const queryKeys = {
   all: ["lookup"] as const,
   scheduleInfo: () => [...queryKeys.all, "schedule_info"] as const,
+  riBasis: (req: LookupRiBasisRequest) =>
+    [...queryKeys.all, "ribasis", req] as const,
 };

--- a/ui/rsl/src/api/protocol/motis.ts
+++ b/ui/rsl/src/api/protocol/motis.ts
@@ -16,6 +16,8 @@ import {
   LookupBatchMetaStationResponse,
   LookupIdTrainRequest,
   LookupIdTrainResponse,
+  LookupRiBasisRequest,
+  LookupRiBasisResponse,
 } from "./motis/lookup";
 import { RISForwardTimeRequest } from "./motis/ris";
 import { RoutingRequest, RoutingResponse } from "./motis/routing";
@@ -355,7 +357,9 @@ export type MsgContent =
   | PaxMonUniverseDestroyed
   | PaxMonGetInterchangesRequest
   | PaxMonGetInterchangesResponse
-  | PaxMonStatusRequest;
+  | PaxMonStatusRequest
+  | LookupRiBasisRequest
+  | LookupRiBasisResponse;
 
 export type MsgContentType =
   | "MotisNoMessage"
@@ -412,7 +416,9 @@ export type MsgContentType =
   | "PaxMonUniverseDestroyed"
   | "PaxMonGetInterchangesRequest"
   | "PaxMonGetInterchangesResponse"
-  | "PaxMonStatusRequest";
+  | "PaxMonStatusRequest"
+  | "LookupRiBasisRequest"
+  | "LookupRiBasisResponse";
 
 // Message.fbs
 export type DestinationType = "Module" | "Topic";

--- a/ui/rsl/src/api/protocol/motis/lookup.ts
+++ b/ui/rsl/src/api/protocol/motis/lookup.ts
@@ -8,6 +8,7 @@ import {
   Interval,
   EventType,
 } from "../motis";
+import { RiBasisFahrt } from "./ribasis";
 
 // lookup/LookupGeoStationIdRequest.fbs
 export interface LookupGeoStationIdRequest {
@@ -66,6 +67,23 @@ export interface LookupMetaStationResponse {
 // lookup/LookupMetaStationResponse.fbs
 export interface LookupBatchMetaStationResponse {
   responses: LookupMetaStationResponse[];
+}
+
+// lookup/LookupRiBasisRequest.fbs
+export interface LookupRiBasisRequest {
+  trip_id: TripId;
+  schedule: number;
+}
+
+// lookup/LookupRiBasisResponse.fbs
+export interface RiBasisTrip {
+  trip_id: TripId;
+  fahrt: RiBasisFahrt;
+}
+
+// lookup/LookupRiBasisResponse.fbs
+export interface LookupRiBasisResponse {
+  trips: RiBasisTrip[];
 }
 
 // lookup/LookupScheduleInfoResponse.fbs

--- a/ui/rsl/src/api/protocol/motis/ribasis.ts
+++ b/ui/rsl/src/api/protocol/motis/ribasis.ts
@@ -1,0 +1,197 @@
+// generated file - do not modify - run update-protocol to update
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisMeta {
+  id: string;
+  owner: string;
+  format: string;
+  version: string;
+  correlation: string[];
+  created: string;
+  sequence: number;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export type RiBasisFahrtKategorie = "SOLL" | "IST" | "VORSCHAU";
+
+// ribasis/RiBasisFahrt.fbs
+export type RiBasisFahrtTyp =
+  | "PLANFAHRT"
+  | "ERSATZFAHRT"
+  | "ENTLASTUNGSFAHRT"
+  | "SONDERFAHRT";
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisHaltestelle {
+  haltestelleid: string;
+  bezeichnung: string;
+  evanummer: string;
+  rl100: string;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisBetreiber {
+  name: string;
+  code: string;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisVerwaltung {
+  verwaltungid: string;
+  betreiber: RiBasisBetreiber;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisGattung {
+  gattungid: string;
+  name: string;
+  code: string;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisLinie {
+  linieid: string;
+  name: string;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisFahrtRelation {
+  startfahrtnummer: string;
+  startzeit: string;
+  startverwaltung: string;
+  startgattung: string;
+  startlinie: string;
+  starthaltestelle: RiBasisHaltestelle;
+  zielzeit: string;
+  zielhaltestelle: RiBasisHaltestelle;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export type RiBasisZeitstatus =
+  | "FAHRPLAN"
+  | "MELDUNG"
+  | "AUTOMAT"
+  | "PROGNOSE"
+  | "UNBEKANNT";
+
+// ribasis/RiBasisFahrt.fbs
+export type RiBasisOrtTyp = "STEIG" | "GLEIS";
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisOrt {
+  ortid: string;
+  bezeichnung: string;
+  orttyp: RiBasisOrtTyp;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export type RiBasisHaltzuordnungstyp =
+  | "IST_ERSATZ_FUER"
+  | "WIRD_ERSETZT_DURCH"
+  | "IST_ENTLASTUNG_FUER"
+  | "WIRD_ENTLASTET_DURCH"
+  | "GLEISAENDERUNG_VON"
+  | "GLEISAENDERUNG_NACH";
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisAbfahrtZuordnung {
+  fahrtid: string;
+  abfahrtid: string;
+  typ: RiBasisHaltzuordnungstyp;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisAbfahrt {
+  abfahrtid: string;
+  haltestelle: RiBasisHaltestelle;
+  fahrgastwechsel: boolean;
+  planabfahrtzeit: string;
+  abfahrtzeit: string;
+  abfahrtzeitstatus: RiBasisZeitstatus;
+  planabfahrtort: RiBasisOrt;
+  abfahrtort: RiBasisOrt;
+  zusatzhalt: boolean;
+  bedarfshalt: boolean;
+  allAbfahrtzuordnung: RiBasisAbfahrtZuordnung[];
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisAnkunftZuordnung {
+  fahrtid: string;
+  ankunftid: string;
+  typ: RiBasisHaltzuordnungstyp;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisAnkunft {
+  ankunftid: string;
+  haltestelle: RiBasisHaltestelle;
+  fahrgastwechsel: boolean;
+  planankunftzeit: string;
+  ankunftzeit: string;
+  ankunftzeitstatus: RiBasisZeitstatus;
+  planankunftort: RiBasisOrt;
+  ankunftort: RiBasisOrt;
+  zusatzhalt: boolean;
+  bedarfshalt: boolean;
+  allAnkunftzuordnung: RiBasisAnkunftZuordnung[];
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisFormation {
+  fahrtid: string;
+  abfahrtid: string;
+  ankunftid: string;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisFahrtAbschnitt {
+  fahrtnummer: string;
+  fahrtbezeichnung: string;
+  fahrtname: string;
+  verwaltungid: string;
+  gattungid: string;
+  linieid: string;
+  abfahrt: RiBasisAbfahrt;
+  ankunft: RiBasisAnkunft;
+  allVereinigtmit: RiBasisFormation[];
+}
+
+// ribasis/RiBasisFahrt.fbs
+export type RiBasisFahrtZuordnungstyp = "DURCHBINDUNG" | "WENDE";
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisZubringerFahrtZuordnung {
+  fahrtid: string;
+  ankunftid: string;
+  typ: RiBasisFahrtZuordnungstyp;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisAbbringerFahrtZuordnung {
+  fahrtid: string;
+  abfahrtid: string;
+  typ: RiBasisFahrtZuordnungstyp;
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisFahrtData {
+  kategorie: RiBasisFahrtKategorie;
+  planstarttag: string;
+  fahrtid: string;
+  fahrtrelation: RiBasisFahrtRelation;
+  verkehrstag: string;
+  fahrttyp: RiBasisFahrtTyp;
+  allVerwaltung: RiBasisVerwaltung[];
+  allGattung: RiBasisGattung[];
+  allLinie: RiBasisLinie[];
+  allFahrtabschnitt: RiBasisFahrtAbschnitt[];
+  allZubringerfahrtzuordnung: RiBasisZubringerFahrtZuordnung[];
+  allAbbringerfahrtzuordnung: RiBasisAbbringerFahrtZuordnung[];
+}
+
+// ribasis/RiBasisFahrt.fbs
+export interface RiBasisFahrt {
+  meta: RiBasisMeta;
+  data: RiBasisFahrtData;
+}


### PR DESCRIPTION
Adds a new operation `/lookup/ribasis` that returns a trip (and all connected rule services) in RI Basis format.

Limitations:

- All UUIDs are randomly generated for every request and can only be used to parse the message (i.e. they are not stable and not stored)
- All lines with the same name have the same UUID
- All tracks with the same name (even at different stations) have the same UUID
- `kategorie` is always set to `VORSCHAU`
- `fahrttyp` is always set to `PLANFAHRT`
- `zusatzhalt` and `bedarfshalt` are always set to false
- `RiBasisFahrtZuordnungstyp` is always set to `DURCHBINDUNG`
- `fahrtrelation.startverwaltung` and `fahrtrelation.startgattung` are set to the **current** values of the **current** first trip section, because MOTIS trip ids don't store provider and category information
