### PR TITLE
buildcache: upgrade to version 0.27.6

### DIFF
--- a/cmake/buildcache.cmake
+++ b/cmake/buildcache.cmake
@@ -23,7 +23,7 @@ else()
       message(FATAL "Error: NO_BUILDCACHE was not set but buildcache was not in path and system OS detection failed")
     endif()
 
-    set(buildcache-url "https://github.com/mbitsnbites/buildcache/releases/download/v0.27.1/${buildcache-archive}")
+    set(buildcache-url "https://github.com/mbitsnbites/buildcache/releases/download/v0.27.6/${buildcache-archive}")
     message(STATUS "Downloading buildcache binary from ${buildcache-url}")
     file(DOWNLOAD "${buildcache-url}" ${CMAKE_CURRENT_BINARY_DIR}/${buildcache-archive})
     execute_process(


### PR DESCRIPTION
Changes since v0.27.1.:

- Bugfix: For some versions of QNX qcc the qcc/q++ wrapper would fail in the preprocessor step due to BuildCache passing an unrecognized -H flag (thus no builds would ever be cached).
- Bugfix: Better handling of empty HTTP content responses.
- Add support for Redis AUTH.
- Add support for cc/c++ commands when they are copies of clang or gcc (fixes support on macOS when CC/CXX are undefined).
- **Improve direct mode hash calculation (fixes direct mode under Visual Studio).**
- **Speed up direct mode for MSVC.**
- Reduce memory footprint during housekeeping.
- Better handling of remote cache errors.
- Fix compilation errors on Ubuntu 18.04 (GCC 7.5).
- Delete stale lock files during housekeeping.
- Run at most one housekeeping process at once.