### PR TITLE
database_query_test: disable optimizations for msvc

### DIFF
--- a/modules/path/test/database_query_test.cc
+++ b/modules/path/test/database_query_test.cc
@@ -18,6 +18,10 @@
 #include "motis/path/prepare/db_builder.h"
 #include "geo/polyline_format.h"
 
+#ifdef _MSC_VER
+#pragma optimize("", off)
+#endif
+
 namespace m = motis;
 namespace mp = m::path;
 namespace mm = m::module;


### PR DESCRIPTION
Workaround for failed tests when using Visual Studio 2022