### PR TITLE
RSL: Add support for DailyTReK input files

### DIFF
--- a/modules/paxmon/include/motis/paxmon/loader/csv/csv_journeys.h
+++ b/modules/paxmon/include/motis/paxmon/loader/csv/csv_journeys.h
@@ -7,14 +7,13 @@
 #include "motis/core/journey/journey.h"
 
 #include "motis/paxmon/loader/loader_result.h"
+#include "motis/paxmon/settings/journey_input_settings.h"
 #include "motis/paxmon/universe.h"
 
 namespace motis::paxmon::loader::csv {
 
-loader_result load_journeys(schedule const& sched, universe& uv,
-                            std::string const& journey_file,
-                            std::string const& match_log_file,
-                            duration match_tolerance,
-                            std::string const& timezone_name);
+loader_result load_journeys(
+    schedule const& sched, universe& uv, std::string const& journey_file,
+    motis::paxmon::settings::journey_input_settings const& settings);
 
 }  // namespace motis::paxmon::loader::csv

--- a/modules/paxmon/include/motis/paxmon/loader/csv/csv_journeys.h
+++ b/modules/paxmon/include/motis/paxmon/loader/csv/csv_journeys.h
@@ -14,6 +14,7 @@ namespace motis::paxmon::loader::csv {
 loader_result load_journeys(schedule const& sched, universe& uv,
                             std::string const& journey_file,
                             std::string const& match_log_file,
-                            duration match_tolerance);
+                            duration match_tolerance,
+                            std::string const& timezone_name);
 
 }  // namespace motis::paxmon::loader::csv

--- a/modules/paxmon/include/motis/paxmon/loader/csv/motis_row.h
+++ b/modules/paxmon/include/motis/paxmon/loader/csv/motis_row.h
@@ -7,7 +7,7 @@
 
 namespace motis::paxmon::loader::csv {
 
-struct row {
+struct motis_row {
   utl::csv_col<std::uint64_t, UTL_NAME("id")> id_;
   utl::csv_col<std::uint64_t, UTL_NAME("secondary_id")> secondary_id_;
   utl::csv_col<std::uint16_t, UTL_NAME("leg_idx")> leg_idx_;

--- a/modules/paxmon/include/motis/paxmon/loader/csv/row.h
+++ b/modules/paxmon/include/motis/paxmon/loader/csv/row.h
@@ -8,8 +8,8 @@
 namespace motis::paxmon::loader::csv {
 
 struct row {
-  utl::csv_col<std::uint32_t, UTL_NAME("id")> id_;
-  utl::csv_col<std::uint32_t, UTL_NAME("secondary_id")> secondary_id_;
+  utl::csv_col<std::uint64_t, UTL_NAME("id")> id_;
+  utl::csv_col<std::uint64_t, UTL_NAME("secondary_id")> secondary_id_;
   utl::csv_col<std::uint16_t, UTL_NAME("leg_idx")> leg_idx_;
   utl::csv_col<utl::cstr, UTL_NAME("leg_type")> leg_type_;
   utl::csv_col<utl::cstr, UTL_NAME("from")> from_;

--- a/modules/paxmon/include/motis/paxmon/loader/csv/trek_row.h
+++ b/modules/paxmon/include/motis/paxmon/loader/csv/trek_row.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+#include "utl/parser/cstr.h"
+#include "utl/parser/csv_range.h"
+
+namespace motis::paxmon::loader::csv {
+
+struct trek_row {
+  utl::csv_col<std::uint64_t, UTL_NAME("Id")> id_;
+  utl::csv_col<std::uint16_t, UTL_NAME("AnzP")> passengers_;
+  utl::csv_col<std::uint16_t, UTL_NAME("AnzTeilwege")> leg_count_;
+  utl::csv_col<std::uint16_t, UTL_NAME("Position")> leg_idx_;
+  utl::csv_col<utl::cstr, UTL_NAME("Zuggattung")> category_;
+  utl::csv_col<std::uint32_t, UTL_NAME("ZugNr")> train_nr_;
+  utl::csv_col<utl::cstr, UTL_NAME("EinZeitpunkt")> enter_;
+  utl::csv_col<utl::cstr, UTL_NAME("EinHafasBhfNr")> from_;
+  utl::csv_col<utl::cstr, UTL_NAME("AusZeitpunkt")> exit_;
+  utl::csv_col<utl::cstr, UTL_NAME("AusHafasBhfNr")> to_;
+};
+
+}  // namespace motis::paxmon::loader::csv

--- a/modules/paxmon/include/motis/paxmon/passenger_group.h
+++ b/modules/paxmon/include/motis/paxmon/passenger_group.h
@@ -22,8 +22,8 @@ using passenger_group_index = std::uint64_t;
 struct data_source {
   CISTA_COMPARABLE()
 
-  std::uint32_t primary_ref_{};
-  std::uint32_t secondary_ref_{};
+  std::uint64_t primary_ref_{};
+  std::uint64_t secondary_ref_{};
 };
 
 enum class group_source_flags : std::uint8_t {

--- a/modules/paxmon/include/motis/paxmon/paxmon.h
+++ b/modules/paxmon/include/motis/paxmon/paxmon.h
@@ -12,6 +12,7 @@
 
 #include "motis/paxmon/loader/loader_result.h"
 #include "motis/paxmon/paxmon_data.h"
+#include "motis/paxmon/settings/journey_input_settings.h"
 #include "motis/paxmon/statistics.h"
 #include "motis/paxmon/stats_writer.h"
 #include "motis/paxmon/universe.h"
@@ -45,12 +46,11 @@ private:
   universe& primary_universe();
 
   std::vector<std::string> journey_files_;
+  settings::journey_input_settings journey_input_settings_{};
   std::vector<std::string> capacity_files_;
-  std::string journey_timezone_;
   std::string generated_capacity_file_;
   std::string stats_file_;
   std::string capacity_match_log_file_{};
-  std::string journey_match_log_file_{};
   std::string initial_over_capacity_report_file_{};
   std::string initial_broken_report_file_{};
   std::string initial_reroute_query_file_{};
@@ -58,7 +58,6 @@ private:
   conf::time start_time_{};
   conf::time end_time_{};
   int time_step_{60};
-  std::uint16_t match_tolerance_{0};
   bool reroute_unmatched_{false};
   int arrival_delay_threshold_{20};
   int preparation_time_{15};

--- a/modules/paxmon/include/motis/paxmon/paxmon.h
+++ b/modules/paxmon/include/motis/paxmon/paxmon.h
@@ -46,6 +46,7 @@ private:
 
   std::vector<std::string> journey_files_;
   std::vector<std::string> capacity_files_;
+  std::string journey_timezone_;
   std::string generated_capacity_file_;
   std::string stats_file_;
   std::string capacity_match_log_file_{};

--- a/modules/paxmon/include/motis/paxmon/settings/journey_input_settings.h
+++ b/modules/paxmon/include/motis/paxmon/settings/journey_input_settings.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace motis::paxmon::settings {
+
+struct journey_input_settings {
+  std::string journey_timezone_;
+  std::string journey_match_log_file_{};
+  std::uint16_t match_tolerance_{0};
+
+  bool split_groups_{false};
+  double split_groups_size_mean_{1.5};
+  double split_groups_size_stddev_{3.0};
+  unsigned split_groups_seed_{0};
+};
+
+}  // namespace motis::paxmon::settings

--- a/modules/paxmon/include/motis/paxmon/tools/groups/group_generator.h
+++ b/modules/paxmon/include/motis/paxmon/tools/groups/group_generator.h
@@ -8,8 +8,9 @@ namespace motis::paxmon::tools::groups {
 
 struct group_generator {
   group_generator(double group_size_mean, double group_size_stddev,
-                  double group_count_mean, double group_count_stddev)
-      : rng_{std::random_device{}()},
+                  double group_count_mean, double group_count_stddev,
+                  unsigned seed = std::random_device{}())
+      : rng_{seed},
         group_size_dist_{group_size_mean, group_size_stddev},
         group_count_dist_{group_count_mean, group_count_stddev} {}
 

--- a/modules/paxmon/src/loader/csv/csv_journeys.cc
+++ b/modules/paxmon/src/loader/csv/csv_journeys.cc
@@ -452,7 +452,8 @@ loader_result load_journeys(schedule const& sched, universe& uv,
                                    settings.split_groups_size_stddev_, 0, 0,
                                    settings.split_groups_seed_};
 
-  auto current_id = std::optional<std::pair<std::uint64_t, std::uint64_t>>{};
+  using id_t = std::pair<std::uint64_t, std::uint64_t>;
+  auto current_id = std::optional<id_t>{};
   auto current_input_legs = std::vector<input_journey_leg>{};
   std::uint16_t current_passengers = 0;
 
@@ -592,8 +593,7 @@ loader_result load_journeys(schedule const& sched, universe& uv,
     utl::line_range<utl::buf_reader>{file_content}  //
         | utl::csv<motis_row>()  //
         | utl::for_each([&](motis_row const& row) {
-            auto const id =
-                std::make_pair(row.id_.val(), row.secondary_id_.val());
+            auto const id = id_t{row.id_.val(), row.secondary_id_.val()};
             if (id != current_id) {
               finish_journey();
               current_id = id;
@@ -629,7 +629,7 @@ loader_result load_journeys(schedule const& sched, universe& uv,
     utl::line_range<utl::buf_reader>{file_content}  //
         | utl::csv<trek_row, ';'>()  //
         | utl::for_each([&](trek_row const& row) {
-            auto const base_id = std::make_pair(row.id_.val(), 0ULL);
+            auto const base_id = id_t{row.id_.val(), 0U};
             if (base_id != current_id) {
               finish_journey();
               current_id = base_id;

--- a/modules/paxmon/src/loader/csv/csv_journeys.cc
+++ b/modules/paxmon/src/loader/csv/csv_journeys.cc
@@ -348,7 +348,7 @@ loader_result load_journeys(schedule const& sched, universe& uv,
     match_log.open(match_log_file);
   }
 
-  auto current_id = std::optional<std::pair<std::uint32_t, std::uint32_t>>{};
+  auto current_id = std::optional<std::pair<std::uint64_t, std::uint64_t>>{};
   auto current_input_legs = std::vector<input_journey_leg>{};
   std::uint16_t current_passengers = 0;
 

--- a/modules/paxmon/src/loader/journeys/motis_journeys.cc
+++ b/modules/paxmon/src/loader/journeys/motis_journeys.cc
@@ -29,8 +29,8 @@ loader_result load_journeys(schedule const& sched, universe& uv,
                             std::string const& journey_file) {
   auto result = loader_result{};
 
-  auto add_journey = [&](journey const& j, std::uint32_t primary_ref = 0,
-                         std::uint32_t secondary_ref = 0) {
+  auto add_journey = [&](journey const& j, std::uint64_t primary_ref = 0,
+                         std::uint64_t secondary_ref = 0) {
     load_journey(sched, uv, j, data_source{primary_ref, secondary_ref}, 1);
     ++result.loaded_journeys_;
   };

--- a/modules/paxmon/src/paxmon.cc
+++ b/modules/paxmon/src/paxmon.cc
@@ -374,8 +374,9 @@ loader::loader_result paxmon::load_journeys(std::string const& file) {
     result = loader::journeys::load_journeys(sched, uv, file);
   } else if (journey_path.extension() == ".csv") {
     scoped_timer journey_timer{"load csv journeys"};
-    result = loader::csv::load_journeys(
-        sched, uv, file, journey_match_log_file_, match_tolerance_);
+    result =
+        loader::csv::load_journeys(sched, uv, file, journey_match_log_file_,
+                                   match_tolerance_, journey_timezone_);
   } else {
     LOG(logging::error) << "paxmon: unknown journey file type: " << file;
   }

--- a/modules/paxmon/src/paxmon.cc
+++ b/modules/paxmon/src/paxmon.cc
@@ -63,12 +63,27 @@ using namespace motis::rt;
 namespace motis::paxmon {
 
 paxmon::paxmon() : module("Passenger Monitoring", "paxmon"), data_{*this} {
+  param(journey_input_settings_.journey_timezone_, "journey_timezone",
+        "timezone for timestamps in daily trek input files (e.g. "
+        "Europe/Berlin), or empty for current system time zone");
+  param(journey_input_settings_.journey_match_log_file_, "journey_match_log",
+        "journey match log file");
+  param(journey_input_settings_.match_tolerance_, "match_tolerance",
+        "journey match time tolerance (minutes)");
+  param(journey_input_settings_.split_groups_, "split_groups",
+        "split groups from journey input files into smaller groups");
+  param(journey_input_settings_.split_groups_size_mean_, "split_groups_mean",
+        "mean size for split groups");
+  param(journey_input_settings_.split_groups_size_stddev_,
+        "split_groups_stddev", "standard deviation for split groups size");
+  param(journey_input_settings_.split_groups_seed_, "split_groups_seed",
+        "rng seed for splitting groups");
+
   param(generated_capacity_file_, "generated_capacity_file",
         "output for generated capacities");
   param(stats_file_, "stats", "statistics file");
   param(capacity_match_log_file_, "capacity_match_log",
         "capacity match log file");
-  param(journey_match_log_file_, "journey_match_log", "journey match log file");
   param(initial_over_capacity_report_file_, "over_capacity_report",
         "initial over capacity report file");
   param(initial_broken_report_file_, "broken_report",
@@ -81,8 +96,6 @@ paxmon::paxmon() : module("Passenger Monitoring", "paxmon"), data_{*this} {
   param(start_time_, "start_time", "evaluation start time");
   param(end_time_, "end_time", "evaluation end time");
   param(time_step_, "time_step", "evaluation time step (seconds)");
-  param(match_tolerance_, "match_tolerance",
-        "journey match time tolerance (minutes)");
   param(arrival_delay_threshold_, "arrival_delay_threshold",
         "threshold for arrival delay at the destination (minutes, -1 to "
         "disable)");
@@ -375,8 +388,7 @@ loader::loader_result paxmon::load_journeys(std::string const& file) {
   } else if (journey_path.extension() == ".csv") {
     scoped_timer journey_timer{"load csv journeys"};
     result =
-        loader::csv::load_journeys(sched, uv, file, journey_match_log_file_,
-                                   match_tolerance_, journey_timezone_);
+        loader::csv::load_journeys(sched, uv, file, journey_input_settings_);
   } else {
     LOG(logging::error) << "paxmon: unknown journey file type: " << file;
   }

--- a/modules/paxmon/src/tools/groups/groups.cc
+++ b/modules/paxmon/src/tools/groups/groups.cc
@@ -21,7 +21,7 @@
 #include "utl/pipes/for_each.h"
 
 #include "motis/paxmon/csv_writer.h"
-#include "motis/paxmon/loader/csv/row.h"
+#include "motis/paxmon/loader/csv/motis_row.h"
 
 #include "motis/paxmon/tools/groups/group_generator.h"
 
@@ -114,7 +114,7 @@ int gen_groups(int argc, char const** argv) {
   auto const file_content = utl::cstr{buf.data(), buf.size()};
 
   auto current_id = std::pair<std::uint64_t, std::uint64_t>{0, 0};
-  auto current_rows = std::vector<motis::paxmon::loader::csv::row>{};
+  auto current_rows = std::vector<motis::paxmon::loader::csv::motis_row>{};
 
   auto total_input_groups = 0ULL;
   auto total_input_pax = 0ULL;
@@ -185,9 +185,9 @@ int gen_groups(int argc, char const** argv) {
   };
 
   utl::line_range<utl::buf_reader>{file_content}  //
-      | utl::csv<loader::csv::row>()  //
+      | utl::csv<loader::csv::motis_row>()  //
       |
-      utl::for_each([&](loader::csv::row const& row) {
+      utl::for_each([&](loader::csv::motis_row const& row) {
         auto const id = std::make_pair(row.id_.val(), row.secondary_id_.val());
         if (id != current_id) {
           process_journey();

--- a/modules/paxmon/src/tools/groups/groups.cc
+++ b/modules/paxmon/src/tools/groups/groups.cc
@@ -113,7 +113,7 @@ int gen_groups(int argc, char const** argv) {
   auto buf = utl::file(opt.in_path_.data(), "r").content();
   auto const file_content = utl::cstr{buf.data(), buf.size()};
 
-  auto current_id = std::pair<std::uint32_t, std::uint32_t>{0, 0};
+  auto current_id = std::pair<std::uint64_t, std::uint64_t>{0, 0};
   auto current_rows = std::vector<motis::paxmon::loader::csv::row>{};
 
   auto total_input_groups = 0ULL;

--- a/protocol/paxmon/PaxMonGroup.fbs
+++ b/protocol/paxmon/PaxMonGroup.fbs
@@ -3,8 +3,8 @@ include "paxmon/PaxMonCompactJourney.fbs";
 namespace motis.paxmon;
 
 table PaxMonDataSource {
-  primary_ref: uint;
-  secondary_ref: uint;
+  primary_ref: ulong;
+  secondary_ref: ulong;
 }
 
 table PaxMonGroup {


### PR DESCRIPTION
- Add support for DailyTReK input files (.csv)
- Add support for splitting groups read from csv input files (`paxmon.split_groups*` options)
- Passenger group primary and secondary IDs are now uint64

Example config:

```ini
[import]
paths=journeys:/path/to/DailyTReK.csv

[paxmon]
journey_timezone=Europe/Berlin
split_groups=1
#split_groups_mean=1.5
#split_groups_stddev=3
#split_groups_seed=0
```