### PR TITLE
RAPTOR Pretrip fix

### DIFF
--- a/modules/raptor/CMakeLists.txt
+++ b/modules/raptor/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(motis-raptor STATIC ${motis-raptor-files})
 target_include_directories(motis-raptor PUBLIC include)
 target_compile_features(motis-raptor PUBLIC cxx_std_17)
 target_link_libraries(motis-raptor
+        boost
         motis-routing
         motis-module
         motis-core


### PR DESCRIPTION
This fixes a bug where the departure events where not correctly calculated when meta start stations are enabled for a pretrip search.

Previously, if a station was reachable by foot from the source station it would result in departure event timestamps reduced by the footpath length for the source station, as we have to walk from the source station.
If the station is also denoted as a meta station then we do NOT want the departure event timestamps reduced by the footpath length, as it is possible to directly start at the meta station. 

This seems to be correct (tested for swiss gtfs), but still very slow while building the raptor timetable (~20s).