### PR TITLE
CI: Always save buildcache + deps cache (even if build fails)

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -86,6 +86,7 @@ jobs:
       # ==== RESTORE CACHE ====
       - name: Restore buildcache Cache
         uses: actions/cache/restore@v3
+        id: restore-buildcache
         with:
           path: ${{ github.workspace }}/.buildcache
           key: buildcache-${{ matrix.config.cache }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
@@ -96,6 +97,7 @@ jobs:
 
       - name: Restore Dependencies Cache
         uses: actions/cache/restore@v3
+        id: restore-deps-cache
         with:
           path: ${{ github.workspace }}/deps
           key: deps-${{ hashFiles('.pkg') }}
@@ -191,14 +193,14 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: ${{ github.workspace }}/.buildcache
-          key: buildcache-${{ matrix.config.cache }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
+          key: ${{ steps.restore-buildcache.outputs.cache-primary-key }}
 
       - name: Save Dependencies Cache
         if: always()
         uses: actions/cache/save@v3
         with:
           path: ${{ github.workspace }}/deps
-          key: deps-${{ hashFiles('.pkg') }}
+          key: ${{ steps.restore-deps-cache.outputs.cache-primary-key }}
 
   linux:
     runs-on: [ self-hosted, linux, x64, '${{ matrix.config.preset }}' ]

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -83,9 +83,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: seanmiddleditch/gha-setup-ninja@master
 
-      # ==== CACHE ====
-      - name: buildcache Cache
-        uses: actions/cache@v3
+      # ==== RESTORE CACHE ====
+      - name: Restore buildcache Cache
+        uses: actions/cache/restore@v3
         with:
           path: ${{ github.workspace }}/.buildcache
           key: buildcache-${{ matrix.config.cache }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
@@ -94,8 +94,8 @@ jobs:
             buildcache-${{ matrix.config.cache }}-${{ hashFiles('.pkg') }}-
             buildcache-${{ matrix.config.cache }}-
 
-      - name: Dependencies Cache
-        uses: actions/cache@v3
+      - name: Restore Dependencies Cache
+        uses: actions/cache/restore@v3
         with:
           path: ${{ github.workspace }}/deps
           key: deps-${{ hashFiles('.pkg') }}
@@ -184,6 +184,21 @@ jobs:
           asset_path: ./motis-${{ matrix.config.preset }}.tar.bz2
           asset_name: motis-${{ matrix.config.preset }}.tar.bz2
           asset_content_type: application/x-tar
+
+      # ==== SAVE CACHE ====
+      - name: Save buildcache Cache
+        if: always()
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ github.workspace }}/.buildcache
+          key: buildcache-${{ matrix.config.cache }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
+
+      - name: Save Dependencies Cache
+        if: always()
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ github.workspace }}/deps
+          key: deps-${{ hashFiles('.pkg') }}
 
   linux:
     runs-on: [ self-hosted, linux, x64, '${{ matrix.config.preset }}' ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,6 +38,7 @@ jobs:
       # ==== RESTORE CACHE ====
       - name: Restore buildcache Cache
         uses: actions/cache/restore@v3
+        id: restore-buildcache
         with:
           path: ${{ github.workspace }}/.buildcache
           key: buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
@@ -48,6 +49,7 @@ jobs:
 
       - name: Restore Dependencies Cache
         uses: actions/cache/restore@v3
+        id: restore-deps-cache
         with:
           path: ${{ github.workspace }}/deps
           key: deps-${{ hashFiles('.pkg') }}
@@ -169,11 +171,11 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: ${{ github.workspace }}/.buildcache
-          key: buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
+          key: ${{ steps.restore-buildcache.outputs.cache-primary-key }}
 
       - name: Save Dependencies Cache
         if: always()
         uses: actions/cache/save@v3
         with:
           path: ${{ github.workspace }}/deps
-          key: deps-${{ hashFiles('.pkg') }}
+          key: ${{ steps.restore-deps-cache.outputs.cache-primary-key }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,8 +35,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: seanmiddleditch/gha-setup-ninja@master
 
-      - name: buildcache Cache
-        uses: actions/cache@v3
+      # ==== RESTORE CACHE ====
+      - name: Restore buildcache Cache
+        uses: actions/cache/restore@v3
         with:
           path: ${{ github.workspace }}/.buildcache
           key: buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
@@ -45,13 +46,14 @@ jobs:
             buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-
             buildcache-wnds-${{ matrix.config.mode }}-
 
-      - name: Dependencies Cache
-        uses: actions/cache@v3
+      - name: Restore Dependencies Cache
+        uses: actions/cache/restore@v3
         with:
           path: ${{ github.workspace }}/deps
           key: deps-${{ hashFiles('.pkg') }}
           restore-keys: deps-
 
+      # ==== BUILD ====
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build
@@ -160,3 +162,18 @@ jobs:
           asset_path: ./motis-windows.zip
           asset_name: motis-windows.zip
           asset_content_type: application/zip
+
+      # ==== SAVE CACHE ====
+      - name: Save buildcache Cache
+        if: always()
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ github.workspace }}/.buildcache
+          key: buildcache-wnds-${{ matrix.config.mode }}-${{ hashFiles('.pkg') }}-${{ hashFiles('**/*.h') }}-${{ hashFiles('**/*.cc') }}
+
+      - name: Save Dependencies Cache
+        if: always()
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ github.workspace }}/deps
+          key: deps-${{ hashFiles('.pkg') }}


### PR DESCRIPTION
Uses the new [cache restore + save](https://github.com/actions/cache/discussions/1020) actions to always save the buildache + deps cache, even if the build fails.