### PR TITLE
RSL: Information about groups with unreachable destinations

### DIFF
--- a/docs/api/schemas/motis/paxmon.yaml
+++ b/docs/api/schemas/motis/paxmon.yaml
@@ -122,6 +122,11 @@ PaxMonRerouteLogEntry:
       description: Index and probabilities of the old route
     new_routes:
       description: Indices and probabilities of the new routes
+    localization:
+      description: |
+        Location of the passenger group at the system time of the reroute.
+
+        Alternative routes are searched from this location.
 PaxMonDataSource:
   description: |
     Passenger group ID based on the input data.
@@ -166,6 +171,11 @@ PaxMonGroupRoute:
         final destination based on real-time information.
     disabled:
       description: For internal use.
+    destination_unreachable:
+      description: |
+        Whether the planned destination is unreachable using this routes.
+
+        If true, this journey ends before reaching the planned destination.
 PaxMonGroup:
   description: >
     Represents a passenger group. A passenger group is a number of
@@ -516,6 +526,8 @@ PaxMonGroupWithStats:
     max_estimated_delay:
       description: TODO
     expected_estimated_delay:
+      description: TODO
+    prob_destination_unreachable:
       description: TODO
 PaxMonFilterGroupsResponse:
   description: TODO
@@ -974,6 +986,8 @@ PaxMonRerouteGroup:
       description: TODO
     override_probabilities:
       description: TODO
+    localization:
+      description: TODO
 PaxMonRerouteGroupsRequest:
   description: TODO
   fields:
@@ -1005,54 +1019,118 @@ PaxMonRerouteGroupsResponse:
     reroutes:
       description: TODO
 PaxMonGroupStatisticsRequest:
-  description: TODO
+  description: Request various statistics about passengers and passenger groups.
   fields:
     universe:
-      description: TODO
+      description: The ID of the universe
     count_passengers:
-      description: TODO
+      description: |
+        Whether to count passengers or passenger groups in the result.
+
+        See the documentation for the response for more information about
+        fields affected by this setting.
+
+        If set to true, passengers are counted (e.g. a passenger group with
+        3 passengers counts as 3), otherwise groups are counted (e.g. a
+        passenger group with 3 passengers counts as 1).
 PaxMonHistogram:
-  description: TODO
+  description: |
+    A histogram plus some additional metrics such as average and median value.
+
+    The histogram data is contained in the `counts` field. The first entry
+    gives the count of `min_value`, the second entry gives the count of
+    `min_value + 1` and so on until the last entry, which gives the count
+    of `max_value`. The bin size is always 1.
+
+    Note that both `min_value` and `max_value` can be < 0 depending on the
+    underlying data (e.g. for delays).
   fields:
     min_value:
-      description: TODO
+      description: Value of the first entry in `counts`.
     max_value:
-      description: TODO
+      description: Value of the last entry in `counts`.
     avg_value:
-      description: TODO
+      description: The average value of the distribution.
     median_value:
-      description: TODO
+      description: The median value of the distribution.
     max_count:
-      description: TODO
+      description: The largest entry in `counts`.
     total_count:
-      description: TODO
+      description: The sum of all entries in `counts`.
     counts:
-      description: TODO
+      description: >
+        The histogram data. Entries give the count for each value. The
+        value for an index `i` is `i + min_value`.
 PaxMonGroupStatisticsResponse:
-  description: TODO
+  description: Contains various statistics about passengers and passenger groups.
   fields:
     group_count:
-      description: TODO
+      description: Number of passengers groups in the universe.
     total_group_route_count:
-      description: TODO
+      description: Number of passenger group routes in the universe.
     active_group_route_count:
-      description: TODO
+      description: >
+        Number of active passenger group routes in the universe. An active
+        route is a route with a probability greater than 0%.
+    unreachable_destination_group_count:
+      description: >
+        Number of passenger groups that have at least one active (i.e.
+        probability greater than 0%) route that does not reach the planned
+        destination.
     total_pax_count:
-      description: TODO
+      description: Number of passengers in the universe.
+    unreachable_destination_pax_count:
+      description: >
+        Number of passengers that have at least one active (i.e.
+        probability greater than 0%) route that does not reach the planned
+        destination.
     min_estimated_delay:
-      description: TODO
+      description: |
+        The lowest possible estimated delays for all passenger groups or
+        passengers in the universe, i.e. the delay of the route with the
+        earliest arrival time for each passenger group.
+
+        Delays are in minutes.
+
+        Routes that don't reach the planned destination are ignored.
+
+        Depending on the value of the `count_passengers` flag in the
+        request, the histogram contains either passengers or passenger groups.
     max_estimated_delay:
-      description: TODO
+      description: |
+        The highest possible estimated delays for all passenger groups or
+        passengers in the universe, i.e. the delay of the route with the
+        latest arrival time for each passenger group.
+
+        Delays are in minutes.
+
+        Routes that don't reach the planned destination are ignored.
+
+        Depending on the value of the `count_passengers` flag in the
+        request, the histogram contains either passengers or passenger groups.
     expected_estimated_delay:
-      description: TODO
+      description: |
+        The expected delays for all passenger groups or
+        passengers in the universe, i.e. the weighted (by route probability)
+        average of the delays of all routes for each passenger group.
+
+        Delays are in minutes.
+
+        Routes that don't reach the planned destination are ignored.
+
+        Depending on the value of the `count_passengers` flag in the
+        request, the histogram contains either passengers or passenger groups.
     routes_per_group:
-      description: TODO
+      description: The total number of group routes per passenger group.
     active_routes_per_group:
-      description: TODO
+      description: >
+        The number of active group routes (i.e. routes with a probability
+        greater than 0%) per passenger group.
     reroutes_per_group:
-      description: TODO
+      description: >
+        The number of reroute log entries per passenger group.
     group_route_probabilities:
-      description: TODO
+      description: The probabilities of all passenger group routes.
 PaxMonDebugGraphRequest:
   description: TODO
   fields:

--- a/modules/paxforecast/include/motis/paxforecast/behavior/util.h
+++ b/modules/paxforecast/include/motis/paxforecast/behavior/util.h
@@ -47,7 +47,11 @@ std::vector<std::size_t> max_indices(std::vector<T> const& v) {
   return selected;
 }
 
-inline void only_keep_best_alternative(std::vector<float>& probabilities) {
+inline void only_keep_best_alternative(std::vector<float>& probabilities,
+                                       float const best_probability = 1.0F) {
+  if (probabilities.empty()) {
+    return;
+  }
   auto best_idx = 0ULL;
   auto best_prob = 0.0F;
   for (auto i = 0ULL; i < probabilities.size(); ++i) {
@@ -58,12 +62,15 @@ inline void only_keep_best_alternative(std::vector<float>& probabilities) {
     }
     probabilities[i] = 0.0F;
   }
-  probabilities[best_idx] = 1.0F;
+  probabilities[best_idx] = best_probability;
 }
 
 inline std::vector<float> calc_new_probabilites(
     float const base_prob, std::vector<float> const& pick_probs,
     float const threshold) {
+  if (pick_probs.empty()) {
+    return {};
+  }
   auto probs = utl::to_vec(
       pick_probs, [&](auto const& pick_prob) { return base_prob * pick_prob; });
   auto total_sum = 0.0F;
@@ -83,6 +90,9 @@ inline std::vector<float> calc_new_probabilites(
     for (auto& p : probs) {
       p /= scale;
     }
+  } else if (kept_sum == 0.0F) {
+    probs = pick_probs;
+    only_keep_best_alternative(probs, base_prob);
   }
   return probs;
 }

--- a/modules/paxforecast/include/motis/paxforecast/revert_forecast.h
+++ b/modules/paxforecast/include/motis/paxforecast/revert_forecast.h
@@ -2,15 +2,24 @@
 
 #include <vector>
 
+#include "motis/hash_map.h"
+
 #include "motis/core/schedule/schedule.h"
 
 #include "motis/paxmon/index_types.h"
+#include "motis/paxmon/localization.h"
 #include "motis/paxmon/universe.h"
+
+#include "motis/paxforecast/simulation_result.h"
 
 namespace motis::paxforecast {
 
 void revert_forecasts(
     motis::paxmon::universe& uv, schedule const& sched,
-    std::vector<motis::paxmon::passenger_group_with_route> const& pgwrs);
+    simulation_result const& sim_result,
+    std::vector<motis::paxmon::passenger_group_with_route> const& pgwrs,
+    mcd::hash_map<motis::paxmon::passenger_group_with_route,
+                  motis::paxmon::passenger_localization const*> const&
+        pgwr_localizations);
 
 }  // namespace motis::paxforecast

--- a/modules/paxforecast/src/paxforecast.cc
+++ b/modules/paxforecast/src/paxforecast.cc
@@ -203,8 +203,7 @@ inline reroute_reason_t to_reroute_reason(monitoring_event_type const met) {
 }
 
 void update_tracked_groups(
-    schedule const& sched, universe const& uv,
-    simulation_result const& sim_result,
+    schedule const& sched, universe& uv, simulation_result const& sim_result,
     std::map<passenger_group_with_route, monitoring_event_type> const&
         pgwr_event_types,
     std::map<passenger_group_with_route,
@@ -246,12 +245,14 @@ void update_tracked_groups(
       }
     }
 
+    auto& gr = uv.passenger_groups_.route(pgwr);
+
     if (result.alternative_probabilities_.empty()) {
       // keep existing group (only reachable part)
       reroute_reason = reroute_reason_t::DESTINATION_UNREACHABLE;
+      gr.destination_unreachable_ = true;
     }
 
-    auto const& gr = uv.passenger_groups_.route(pgwr);
     auto const old_journey =
         uv.passenger_groups_.journey(gr.compact_journey_index_);
     auto const journey_prefix =
@@ -335,6 +336,8 @@ void log_destination_reachable(
     universe& uv, schedule const& sched,
     passenger_group_with_route_and_probability const& pgwrap,
     passenger_localization const& loc) {
+  auto& route = uv.passenger_groups_.route(pgwrap.pgwr_);
+  route.destination_unreachable_ = false;
   if (pgwrap.probability_ == 0.0F) {
     return;
   }

--- a/modules/paxforecast/src/revert_forecast.cc
+++ b/modules/paxforecast/src/revert_forecast.cc
@@ -35,17 +35,8 @@ struct print_log_route_info {
 struct print_log_entry {
   friend std::ostream& operator<<(std::ostream& out, print_log_entry const& p) {
     auto const& e = p.entry_;
-    out << "{old_route=" << print_log_route_info{e.old_route_} << ", reason=";
-    switch (e.reason_) {
-      case reroute_reason_t::MANUAL: out << "MANUAL"; break;
-      case reroute_reason_t::BROKEN_TRANSFER: out << "BROKEN_TRANSFER"; break;
-      case reroute_reason_t::MAJOR_DELAY_EXPECTED:
-        out << "MAJOR_DELAY_EXPECTED";
-        break;
-      case reroute_reason_t::REVERT_FORECAST: out << "REVERT_FORECAST"; break;
-      case reroute_reason_t::SIMULATION: out << "SIMULATION"; break;
-      case reroute_reason_t::UPDATE_FORECAST: out << "UPDATE_FORECAST"; break;
-    }
+    out << "{old_route=" << print_log_route_info{e.old_route_}
+        << ", reason=" << e.reason_;
     auto const new_routes = p.pgc_.log_entry_new_routes_.at(e.index_);
     out << ", new_routes=[";
     for (auto const& nr : new_routes) {
@@ -70,7 +61,8 @@ struct print_log_entry {
 void revert_forecast(universe& uv, schedule const& sched,
                      FlatBufferBuilder& fbb,
                      std::vector<Offset<PaxMonRerouteGroup>>& reroutes,
-                     passenger_group_with_route const& pgwr) {
+                     passenger_group_with_route const& pgwr,
+                     passenger_localization const* loc) {
   auto const& pgc = uv.passenger_groups_;
   auto const log_entries = pgc.reroute_log_entries(pgwr.pg_);
   if (log_entries.empty()) {
@@ -133,15 +125,25 @@ void revert_forecast(universe& uv, schedule const& sched,
                    route_source_flags::NONE, false /* planned */
                }));
   }
+  auto fbs_localization =
+      std::vector<flatbuffers::Offset<PaxMonLocalizationWrapper>>{};
+  if (loc != nullptr) {
+    fbs_localization.emplace_back(
+        to_fbs_localization_wrapper(sched, fbb, *loc));
+  }
   reroutes.emplace_back(CreatePaxMonRerouteGroup(
       fbb, pgwr.pg_, pgwr.route_, fbb.CreateVector(new_routes),
       paxmon::PaxMonRerouteReason_RevertForecast,
-      broken_transfer_info_to_fbs(fbb, sched, std::nullopt), true));
+      broken_transfer_info_to_fbs(fbb, sched, std::nullopt), true,
+      fbb.CreateVector(fbs_localization)));
   std::cout << std::endl;
 }
 
-void revert_forecasts(universe& uv, schedule const& sched,
-                      std::vector<passenger_group_with_route> const& pgwrs) {
+void revert_forecasts(
+    universe& uv, schedule const& sched, simulation_result const& sim_result,
+    std::vector<passenger_group_with_route> const& pgwrs,
+    mcd::hash_map<passenger_group_with_route,
+                  passenger_localization const*> const& pgwr_localizations) {
   auto const constexpr BATCH_SIZE = 5'000;
   // TODO(pablo): refactoring (update_tracked_groups)
   message_creator mc;
@@ -164,12 +166,33 @@ void revert_forecasts(universe& uv, schedule const& sched,
 
   auto last_group = std::numeric_limits<passenger_group_index>::max();
   for (auto const& pgwr : pgwrs) {
+
+    // TODO(pablo): won't work if current p=0
+    /*
+    if (auto it = sim_result.group_route_results_.find(pgwr);
+        it != end(sim_result.group_route_results_)) {
+      std::cout << "revert_forecast: group route " << pgwr.pg_ << "#"
+                << pgwr.route_ << " has "
+                << it->second.alternative_probabilities_.size()
+                << " alternatives" << std::endl;
+    }
+    */
+
     if (pgwr.pg_ == last_group) {
       // TODO(pablo): for now, always revert the earliest route
+      std::cout << "revert_forecast: skipping multiple reverts per group: "
+                << pgwr.pg_ << std::endl;
       continue;
     }
     last_group = pgwr.pg_;
-    revert_forecast(uv, sched, mc, reroutes, pgwr);
+
+    passenger_localization const* loc = nullptr;
+    if (auto const it = pgwr_localizations.find(pgwr);
+        it != end(pgwr_localizations)) {
+      loc = it->second;
+    }
+
+    revert_forecast(uv, sched, mc, reroutes, pgwr, loc);
     if (reroutes.size() >= BATCH_SIZE) {
       send_reroutes();
     }

--- a/modules/paxforecast/src/revert_forecast.cc
+++ b/modules/paxforecast/src/revert_forecast.cc
@@ -167,6 +167,7 @@ void revert_forecasts(
   auto last_group = std::numeric_limits<passenger_group_index>::max();
   for (auto const& pgwr : pgwrs) {
 
+    (void)sim_result;
     // TODO(pablo): won't work if current p=0
     /*
     if (auto it = sim_result.group_route_results_.find(pgwr);

--- a/modules/paxmon/include/motis/paxmon/group_route.h
+++ b/modules/paxmon/include/motis/paxmon/group_route.h
@@ -59,6 +59,7 @@ struct group_route {
   bool broken_{};
   bool disabled_{};  // if true, route is not in the graph
   bool planned_{};
+  bool destination_unreachable_{};
   route_source_flags source_flags_{route_source_flags::NONE};
 };
 
@@ -70,10 +71,18 @@ inline group_route make_group_route(
     route_source_flags const source_flags = route_source_flags::NONE,
     motis::time const planned_arrival_time = INVALID_TIME,
     std::int16_t const estimated_delay = 0, bool const broken = false,
-    bool const disabled = false) {
-  return group_route{
-      gre_index,       probability, cj_index, lgr_index, planned_arrival_time,
-      estimated_delay, broken,      disabled, planned,   source_flags};
+    bool const disabled = false, bool const destination_unreachable = false) {
+  return group_route{gre_index,
+                     probability,
+                     cj_index,
+                     lgr_index,
+                     planned_arrival_time,
+                     estimated_delay,
+                     broken,
+                     disabled,
+                     planned,
+                     destination_unreachable,
+                     source_flags};
 }
 
 }  // namespace motis::paxmon

--- a/modules/paxmon/include/motis/paxmon/localization_conv.h
+++ b/modules/paxmon/include/motis/paxmon/localization_conv.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "motis/paxmon/localization.h"
+#include "motis/paxmon/reroute_log_entry.h"
+
+namespace motis::paxmon {
+
+inline reroute_log_localization to_log_localization(
+    passenger_localization const& loc) {
+  return {loc.in_trip() ? loc.in_trip_->trip_idx_ : 0,
+          loc.at_station_->index_,
+          loc.schedule_arrival_time_,
+          loc.current_arrival_time_,
+          loc.first_station_,
+          loc.in_trip()};
+}
+
+}  // namespace motis::paxmon

--- a/modules/paxmon/include/motis/paxmon/messages.h
+++ b/modules/paxmon/include/motis/paxmon/messages.h
@@ -102,6 +102,8 @@ broken_transfer_info_to_fbs(flatbuffers::FlatBufferBuilder& fbb,
 
 PaxMonLocalization fbs_localization_type(passenger_localization const& loc);
 
+PaxMonLocalization fbs_localization_type(reroute_log_localization const& loc);
+
 flatbuffers::Offset<PaxMonLocalizationWrapper> to_fbs_localization_wrapper(
     schedule const& sched, flatbuffers::FlatBufferBuilder& fbb,
     passenger_localization const& loc);
@@ -109,6 +111,10 @@ flatbuffers::Offset<PaxMonLocalizationWrapper> to_fbs_localization_wrapper(
 flatbuffers::Offset<void> to_fbs(schedule const& sched,
                                  flatbuffers::FlatBufferBuilder& fbb,
                                  passenger_localization const& loc);
+
+flatbuffers::Offset<void> to_fbs(schedule const& sched,
+                                 flatbuffers::FlatBufferBuilder& fbb,
+                                 reroute_log_localization const& loc);
 
 passenger_localization from_fbs(schedule const& sched,
                                 PaxMonLocalization loc_type,

--- a/modules/paxmon/include/motis/paxmon/monitoring_event.h
+++ b/modules/paxmon/include/motis/paxmon/monitoring_event.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <iosfwd>
 #include <optional>
 
 #include "motis/core/schedule/time.h"
@@ -17,6 +18,18 @@ enum class monitoring_event_type : std::uint8_t {
   BROKEN_TRANSFER,
   MAJOR_DELAY_EXPECTED
 };
+
+inline std::ostream& operator<<(std::ostream& out,
+                                monitoring_event_type const met) {
+  switch (met) {
+    case monitoring_event_type::NO_PROBLEM: return out << "NO_PROBLEM";
+    case monitoring_event_type::BROKEN_TRANSFER:
+      return out << "BROKEN_TRANSFER";
+    case monitoring_event_type::MAJOR_DELAY_EXPECTED:
+      return out << "MAJOR_DELAY_EXPECTED";
+  }
+  return out;
+}
 
 struct monitoring_event {
   monitoring_event_type type_{monitoring_event_type::NO_PROBLEM};

--- a/modules/paxmon/include/motis/paxmon/reroute_log_entry.h
+++ b/modules/paxmon/include/motis/paxmon/reroute_log_entry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <iosfwd>
 
 #include "motis/core/common/unixtime.h"
 #include "motis/core/schedule/time.h"
@@ -16,7 +17,9 @@ enum class reroute_reason_t : std::uint8_t {
   MAJOR_DELAY_EXPECTED,
   REVERT_FORECAST,
   SIMULATION,
-  UPDATE_FORECAST
+  UPDATE_FORECAST,
+  DESTINATION_UNREACHABLE,
+  DESTINATION_REACHABLE
 };
 
 struct reroute_log_route_info {
@@ -33,5 +36,23 @@ struct reroute_log_entry {
   reroute_reason_t reason_{reroute_reason_t::MANUAL};
   std::optional<broken_transfer_info> broken_transfer_;
 };
+
+inline std::ostream& operator<<(std::ostream& out,
+                                reroute_reason_t const reason) {
+  switch (reason) {
+    case reroute_reason_t::MANUAL: return out << "MANUAL";
+    case reroute_reason_t::BROKEN_TRANSFER: return out << "BROKEN_TRANSFER";
+    case reroute_reason_t::MAJOR_DELAY_EXPECTED:
+      return out << "MAJOR_DELAY_EXPECTED";
+    case reroute_reason_t::REVERT_FORECAST: return out << "REVERT_FORECAST";
+    case reroute_reason_t::SIMULATION: return out << "SIMULATION";
+    case reroute_reason_t::UPDATE_FORECAST: return out << "UPDATE_FORECAST";
+    case reroute_reason_t::DESTINATION_UNREACHABLE:
+      return out << "DESTINATION_UNREACHABLE";
+    case reroute_reason_t::DESTINATION_REACHABLE:
+      return out << "DESTINATION_REACHABLE";
+  }
+  return out;
+}
 
 }  // namespace motis::paxmon

--- a/modules/paxmon/include/motis/paxmon/reroute_log_entry.h
+++ b/modules/paxmon/include/motis/paxmon/reroute_log_entry.h
@@ -5,6 +5,7 @@
 
 #include "motis/core/common/unixtime.h"
 #include "motis/core/schedule/time.h"
+#include "motis/core/schedule/trip.h"
 
 #include "motis/paxmon/broken_transfer_info.h"
 #include "motis/paxmon/index_types.h"
@@ -28,6 +29,15 @@ struct reroute_log_route_info {
   float new_probability_{};
 };
 
+struct reroute_log_localization {
+  trip_idx_t trip_idx_{};
+  std::uint32_t station_id_{};
+  time schedule_arrival_time_{INVALID_TIME};
+  time current_arrival_time_{INVALID_TIME};
+  bool first_station_{};
+  bool in_trip_{};
+};
+
 struct reroute_log_entry {
   reroute_log_entry_index index_{};  // for new routes lookup
   reroute_log_route_info old_route_{};
@@ -35,6 +45,7 @@ struct reroute_log_entry {
   motis::unixtime reroute_time_{};  // current time
   reroute_reason_t reason_{reroute_reason_t::MANUAL};
   std::optional<broken_transfer_info> broken_transfer_;
+  reroute_log_localization localization_{};
 };
 
 inline std::ostream& operator<<(std::ostream& out,

--- a/modules/paxmon/src/api/filter_groups.cc
+++ b/modules/paxmon/src/api/filter_groups.cc
@@ -34,6 +34,7 @@ struct group_info {
   std::int16_t min_estimated_delay_{std::numeric_limits<std::int16_t>::max()};
   std::int16_t max_estimated_delay_{std::numeric_limits<std::int16_t>::min()};
   float expected_estimated_delay_{};
+  float p_destination_unreachable_{};
   std::uint32_t log_entries_{};
 };
 
@@ -171,6 +172,9 @@ msg_ptr filter_groups(paxmon_data& data, msg_ptr const& msg) {
         gi.max_estimated_delay_ =
             std::max(gi.max_estimated_delay_, gr.estimated_delay_);
         gi.expected_estimated_delay_ += gr.probability_ * gr.estimated_delay_;
+        if (gr.destination_unreachable_) {
+          gi.p_destination_unreachable_ += gr.probability_;
+        }
       }
       if (gr.planned_ && gi.scheduled_departure_ == INVALID_TIME) {
         auto const cj = pgc.journey(gr.compact_journey_index_);
@@ -343,7 +347,8 @@ msg_ptr filter_groups(paxmon_data& data, msg_ptr const& msg) {
                                             include_reroute_log),
                                      gi.min_estimated_delay_,
                                      gi.max_estimated_delay_,
-                                     gi.expected_estimated_delay_);
+                                     gi.expected_estimated_delay_,
+                                     gi.p_destination_unreachable_);
                                })))
                            .Union());
   return make_msg(mc);

--- a/modules/paxmon/src/api/filter_groups.cc
+++ b/modules/paxmon/src/api/filter_groups.cc
@@ -26,12 +26,14 @@ namespace motis::paxmon::api {
 
 namespace {
 
+constexpr auto const MAX_DELAY = std::numeric_limits<std::int16_t>::max();
+
 struct group_info {
   passenger_group_index pgi_{};
 
   time scheduled_departure_{INVALID_TIME};
 
-  std::int16_t min_estimated_delay_{std::numeric_limits<std::int16_t>::max()};
+  std::int16_t min_estimated_delay_{MAX_DELAY};
   std::int16_t max_estimated_delay_{std::numeric_limits<std::int16_t>::min()};
   float expected_estimated_delay_{};
   float p_destination_unreachable_{};
@@ -167,11 +169,11 @@ msg_ptr filter_groups(paxmon_data& data, msg_ptr const& msg) {
 
     for (auto const& gr : pgc.routes(pgi)) {
       if (gr.probability_ != 0) {
-        gi.min_estimated_delay_ =
-            std::min(gi.min_estimated_delay_, gr.estimated_delay_);
-        gi.max_estimated_delay_ =
-            std::max(gi.max_estimated_delay_, gr.estimated_delay_);
-        gi.expected_estimated_delay_ += gr.probability_ * gr.estimated_delay_;
+        auto const est_delay =
+            gr.destination_unreachable_ ? MAX_DELAY : gr.estimated_delay_;
+        gi.min_estimated_delay_ = std::min(gi.min_estimated_delay_, est_delay);
+        gi.max_estimated_delay_ = std::max(gi.max_estimated_delay_, est_delay);
+        gi.expected_estimated_delay_ += gr.probability_ * est_delay;
         if (gr.destination_unreachable_) {
           gi.p_destination_unreachable_ += gr.probability_;
         }

--- a/modules/paxmon/src/api/group_statistics.cc
+++ b/modules/paxmon/src/api/group_statistics.cc
@@ -110,6 +110,7 @@ msg_ptr group_statistics(paxmon_data& data, motis::module::msg_ptr const& msg) {
 
   auto total_group_route_count = 0U;
   auto active_group_route_count = 0U;
+  auto unreachable_dest_group_count = 0U;
   auto total_pax_count = 0ULL;
 
   for (auto const& pg : pgc) {
@@ -124,6 +125,7 @@ msg_ptr group_statistics(paxmon_data& data, motis::module::msg_ptr const& msg) {
     auto max_estimated_delay = LOWEST_ALLOWED_DELAY;
     auto expected_estimated_delay = 0.F;
     auto active_routes = 0U;
+    auto has_unreachable_dest_routes = false;
     for (auto const& gr : routes) {
       if (gr.probability_ == 0) {
         continue;
@@ -138,10 +140,16 @@ msg_ptr group_statistics(paxmon_data& data, motis::module::msg_ptr const& msg) {
       expected_estimated_delay += gr.probability_ * gr.estimated_delay_;
       h_group_route_probabilities.add(
           static_cast<int>(std::round(gr.probability_ * 100)));
+      if (gr.destination_unreachable_) {
+        has_unreachable_dest_routes = true;
+      }
     }
     h_active_routes_per_group.add(active_routes);
     total_group_route_count += routes.size();
     active_group_route_count += active_routes;
+    if (has_unreachable_dest_routes) {
+      ++unreachable_dest_group_count;
+    }
     if (active_routes == 0) {
       continue;
     }
@@ -167,8 +175,9 @@ msg_ptr group_statistics(paxmon_data& data, motis::module::msg_ptr const& msg) {
       MsgContent_PaxMonGroupStatisticsResponse,
       CreatePaxMonGroupStatisticsResponse(
           mc, uv.passenger_groups_.size(), total_group_route_count,
-          active_group_route_count, total_pax_count,
-          histogram_to_fbs(h_min_est_delay), histogram_to_fbs(h_max_est_delay),
+          active_group_route_count, unreachable_dest_group_count,
+          total_pax_count, histogram_to_fbs(h_min_est_delay),
+          histogram_to_fbs(h_max_est_delay),
           histogram_to_fbs(h_expected_est_delay),
           histogram_to_fbs(h_routes_per_group),
           histogram_to_fbs(h_active_routes_per_group),

--- a/modules/paxmon/src/api/group_statistics.cc
+++ b/modules/paxmon/src/api/group_statistics.cc
@@ -38,6 +38,17 @@ struct histogram {
   }
 
   void finish() {
+    avg_value_ = 0;
+    median_value_ = 0;
+    max_count_ = 0;
+
+    if (total_count_ == 0) {
+      min_value_ = 0;
+      max_value_ = 0;
+      counts_.resize(1);
+      return;
+    }
+
     if (min_value_ > -offset_) {
       auto const empty_beginning = min_value_ + offset_;
       counts_.erase(counts_.begin(),
@@ -50,9 +61,6 @@ struct histogram {
       counts_.resize(counts_.size() - empty_end);
     }
 
-    avg_value_ = 0;
-    median_value_ = 0;
-    max_count_ = 0;
     auto count_sum = 0.;
     auto const half_total_count = static_cast<double>(total_count_) / 2.0;
     auto calc_median = true;

--- a/modules/paxmon/src/api/group_statistics.cc
+++ b/modules/paxmon/src/api/group_statistics.cc
@@ -112,6 +112,7 @@ msg_ptr group_statistics(paxmon_data& data, motis::module::msg_ptr const& msg) {
   auto active_group_route_count = 0U;
   auto unreachable_dest_group_count = 0U;
   auto total_pax_count = 0ULL;
+  auto unreachable_dest_pax_count = 0ULL;
 
   for (auto const& pg : pgc) {
     auto const pgi = pg->id_;
@@ -149,6 +150,7 @@ msg_ptr group_statistics(paxmon_data& data, motis::module::msg_ptr const& msg) {
     active_group_route_count += active_routes;
     if (has_unreachable_dest_routes) {
       ++unreachable_dest_group_count;
+      unreachable_dest_pax_count += pg->passengers_;
     }
     if (active_routes == 0) {
       continue;
@@ -176,8 +178,8 @@ msg_ptr group_statistics(paxmon_data& data, motis::module::msg_ptr const& msg) {
       CreatePaxMonGroupStatisticsResponse(
           mc, uv.passenger_groups_.size(), total_group_route_count,
           active_group_route_count, unreachable_dest_group_count,
-          total_pax_count, histogram_to_fbs(h_min_est_delay),
-          histogram_to_fbs(h_max_est_delay),
+          total_pax_count, unreachable_dest_pax_count,
+          histogram_to_fbs(h_min_est_delay), histogram_to_fbs(h_max_est_delay),
           histogram_to_fbs(h_expected_est_delay),
           histogram_to_fbs(h_routes_per_group),
           histogram_to_fbs(h_active_routes_per_group),

--- a/modules/paxmon/src/api/reroute_groups.cc
+++ b/modules/paxmon/src/api/reroute_groups.cc
@@ -12,6 +12,10 @@
 #include "motis/paxmon/get_universe.h"
 #include "motis/paxmon/messages.h"
 
+#include "motis/paxmon/localization.h"
+#include "motis/paxmon/localization_conv.h"
+#include "motis/paxmon/reachability.h"
+
 using namespace motis::module;
 using namespace motis::paxmon;
 
@@ -27,6 +31,25 @@ inline void before_journey_load_updated(universe& uv,
   }
 }
 
+passenger_localization get_localization(universe const& uv,
+                                        schedule const& sched,
+                                        PaxMonRerouteGroup const* rr,
+                                        time const current_time) {
+  if (rr->localization()->size() != 0) {
+    return from_fbs(sched, rr->localization()->Get(0));
+  } else {
+    auto const reachability = get_reachability(
+        uv, uv.passenger_groups_.journey(
+                uv.passenger_groups_
+                    .route(passenger_group_with_route{
+                        static_cast<passenger_group_index>(rr->group()),
+                        static_cast<local_group_route_index>(
+                            rr->old_route_index())})
+                    .compact_journey_index_));
+    return localize(sched, reachability, current_time);
+  }
+}
+
 struct log_entry_info {
   reroute_log_entry& entry_;
   typename dynamic_fws_multimap<reroute_log_route_info>::mutable_bucket
@@ -38,7 +61,8 @@ inline log_entry_info append_or_extend_log_entry(
     universe& uv, schedule const& sched, passenger_group_index const pgi,
     local_group_route_index const old_route_idx,
     float const old_route_probability, reroute_reason_t const reason,
-    std::optional<broken_transfer_info> const& bti, bool const has_new_routes) {
+    std::optional<broken_transfer_info> const& bti, bool const has_new_routes,
+    passenger_localization const& loc) {
   auto& pgc = uv.passenger_groups_;
   auto const system_time = sched.system_time_;
   auto log_entries = pgc.reroute_log_entries(pgi);
@@ -59,7 +83,7 @@ inline log_entry_info append_or_extend_log_entry(
   log_entries.emplace_back(reroute_log_entry{
       static_cast<reroute_log_entry_index>(log_new_routes.index()),
       reroute_log_route_info{old_route_idx, old_route_probability, 0},
-      system_time, now(), reason, bti});
+      system_time, now(), reason, bti, to_log_localization(loc)});
   return {log_entries.back(), log_new_routes, false};
 }
 
@@ -72,6 +96,8 @@ msg_ptr reroute_groups(paxmon_data& data, msg_ptr const& msg) {
   auto const& sched = uv_access.sched_;
   auto& uv = uv_access.uv_;
   auto const tracking_updates = uv.update_tracker_.is_tracking();
+  auto const current_time =
+      unix_to_motistime(sched.schedule_begin_, sched.system_time_);
 
   message_creator mc;
 
@@ -82,6 +108,7 @@ msg_ptr reroute_groups(paxmon_data& data, msg_ptr const& msg) {
     auto const reason = static_cast<reroute_reason_t>(rr->reason());
     auto const bti = from_fbs(sched, rr->broken_transfer());
     auto const override_probabilities = rr->override_probabilities();
+    auto const localization = get_localization(uv, sched, rr, current_time);
     auto routes = uv.passenger_groups_.routes(pgi);
 
     auto routes_backup = utl::to_vec(
@@ -89,9 +116,9 @@ msg_ptr reroute_groups(paxmon_data& data, msg_ptr const& msg) {
 
     auto& old_route = routes.at(old_route_idx);
     auto const old_route_probability = old_route.probability_;
-    auto lei = append_or_extend_log_entry(uv, sched, pgi, old_route_idx,
-                                          old_route_probability, reason, bti,
-                                          rr->new_routes()->size() != 0);
+    auto lei = append_or_extend_log_entry(
+        uv, sched, pgi, old_route_idx, old_route_probability, reason, bti,
+        rr->new_routes()->size() != 0, localization);
 
     if (reason != reroute_reason_t::DESTINATION_UNREACHABLE &&
         reason != reroute_reason_t::DESTINATION_REACHABLE) {

--- a/modules/paxmon/src/messages.cc
+++ b/modules/paxmon/src/messages.cc
@@ -114,7 +114,8 @@ Offset<PaxMonGroupRoute> to_fbs(schedule const& sched, FlatBufferBuilder& fbb,
       to_fbs(sched, fbb, tgr.journey_), tgr.probability_,
       to_fbs_time(sched, tgr.planned_arrival_time_), tgr.estimated_delay_,
       static_cast<std::uint8_t>(tgr.source_flags_), tgr.planned_,
-      false /* broken */, false /* disabled */);
+      false /* broken */, false /* disabled */,
+      false /* destination_unreachable */);
 }
 
 Offset<PaxMonGroupRoute> to_fbs(schedule const& sched,
@@ -125,7 +126,7 @@ Offset<PaxMonGroupRoute> to_fbs(schedule const& sched,
       to_fbs(sched, fbb, pgc.journey(gr.compact_journey_index_)),
       gr.probability_, to_fbs_time(sched, gr.planned_arrival_time_),
       gr.estimated_delay_, static_cast<std::uint8_t>(gr.source_flags_),
-      gr.planned_, gr.broken_, gr.disabled_);
+      gr.planned_, gr.broken_, gr.disabled_, gr.destination_unreachable_);
 }
 
 temp_group_route from_fbs(schedule const& sched, PaxMonGroupRoute const* gr) {

--- a/protocol/paxmon/PaxMonFilterGroupsResponse.fbs
+++ b/protocol/paxmon/PaxMonFilterGroupsResponse.fbs
@@ -7,6 +7,7 @@ table PaxMonGroupWithStats {
   min_estimated_delay: short;
   max_estimated_delay: short;
   expected_estimated_delay: float;
+  prob_destination_unreachable: float;
 }
 
 table PaxMonFilterGroupsResponse {

--- a/protocol/paxmon/PaxMonGroup.fbs
+++ b/protocol/paxmon/PaxMonGroup.fbs
@@ -18,6 +18,7 @@ table PaxMonGroupRoute {
   planned: bool;
   broken: bool;
   disabled: bool;
+  destination_unreachable: bool;
 }
 
 table PaxMonGroup {

--- a/protocol/paxmon/PaxMonGroupStatisticsResponse.fbs
+++ b/protocol/paxmon/PaxMonGroupStatisticsResponse.fbs
@@ -16,6 +16,7 @@ table PaxMonGroupStatisticsResponse {
   group_count: uint;
   total_group_route_count: uint;
   active_group_route_count: uint;
+  groups_with_unreachable_destination: uint;
 
   total_pax_count: ulong;
 

--- a/protocol/paxmon/PaxMonGroupStatisticsResponse.fbs
+++ b/protocol/paxmon/PaxMonGroupStatisticsResponse.fbs
@@ -16,9 +16,10 @@ table PaxMonGroupStatisticsResponse {
   group_count: uint;
   total_group_route_count: uint;
   active_group_route_count: uint;
-  groups_with_unreachable_destination: uint;
+  unreachable_destination_group_count: uint;
 
   total_pax_count: ulong;
+  unreachable_destination_pax_count: ulong;
 
   // groups or passengers (if count_passengers set in request)
   min_estimated_delay: PaxMonHistogram;

--- a/protocol/paxmon/PaxMonRerouteGroupsRequest.fbs
+++ b/protocol/paxmon/PaxMonRerouteGroupsRequest.fbs
@@ -1,6 +1,7 @@
 include "paxmon/PaxMonGroup.fbs";
 include "paxmon/PaxMonRerouteReason.fbs";
 include "paxmon/PaxMonBrokenTransferInfo.fbs";
+include "paxmon/PaxMonLocalization.fbs";
 
 namespace motis.paxmon;
 
@@ -11,6 +12,7 @@ table PaxMonRerouteGroup {
   reason: PaxMonRerouteReason;
   broken_transfer: [PaxMonBrokenTransferInfo]; // optional (0 or 1)
   override_probabilities: bool;
+  localization: [PaxMonLocalizationWrapper]; // optional (0 or 1)
 }
 
 table PaxMonRerouteGroupsRequest {

--- a/protocol/paxmon/PaxMonRerouteLog.fbs
+++ b/protocol/paxmon/PaxMonRerouteLog.fbs
@@ -1,5 +1,6 @@
 include "paxmon/PaxMonRerouteReason.fbs";
 include "paxmon/PaxMonBrokenTransferInfo.fbs";
+include "paxmon/PaxMonLocalization.fbs";
 
 namespace motis.paxmon;
 
@@ -16,4 +17,5 @@ table PaxMonRerouteLogEntry {
   broken_transfer: [PaxMonBrokenTransferInfo]; // optional (0 or 1)
   old_route: PaxMonRerouteLogRoute;
   new_routes: [PaxMonRerouteLogRoute];
+  localization: PaxMonLocalization;
 }

--- a/protocol/paxmon/PaxMonRerouteReason.fbs
+++ b/protocol/paxmon/PaxMonRerouteReason.fbs
@@ -6,5 +6,7 @@ enum PaxMonRerouteReason : byte {
   MajorDelayExpected,
   RevertForecast,
   Simulation,
-  UpdateForecast
+  UpdateForecast,
+  DestinationUnreachable,
+  DestinationReachable
 }

--- a/ui/rsl/src/api/protocol/motis/paxmon.ts
+++ b/ui/rsl/src/api/protocol/motis/paxmon.ts
@@ -124,6 +124,7 @@ export interface PaxMonGroupRoute {
   planned: boolean;
   broken: boolean;
   disabled: boolean;
+  destination_unreachable: boolean;
 }
 
 // paxmon/PaxMonGroup.fbs
@@ -354,6 +355,7 @@ export interface PaxMonGroupWithStats {
   min_estimated_delay: number;
   max_estimated_delay: number;
   expected_estimated_delay: number;
+  prob_destination_unreachable: number;
 }
 
 // paxmon/PaxMonFilterGroupsResponse.fbs
@@ -691,6 +693,7 @@ export interface PaxMonGroupStatisticsResponse {
   group_count: number;
   total_group_route_count: number;
   active_group_route_count: number;
+  groups_with_unreachable_destination: number;
   total_pax_count: number;
   min_estimated_delay: PaxMonHistogram;
   max_estimated_delay: PaxMonHistogram;

--- a/ui/rsl/src/api/protocol/motis/paxmon.ts
+++ b/ui/rsl/src/api/protocol/motis/paxmon.ts
@@ -61,6 +61,33 @@ export interface PaxMonBrokenTransferInfo {
   departure_canceled: boolean;
 }
 
+// paxmon/PaxMonLocalization.fbs
+export interface PaxMonAtStation {
+  station: Station;
+  schedule_arrival_time: number;
+  current_arrival_time: number;
+  first_station: boolean;
+}
+
+// paxmon/PaxMonLocalization.fbs
+export interface PaxMonInTrip {
+  trip: TripId;
+  next_station: Station;
+  schedule_arrival_time: number;
+  current_arrival_time: number;
+}
+
+// paxmon/PaxMonLocalization.fbs
+export type PaxMonLocalization = PaxMonAtStation | PaxMonInTrip;
+
+export type PaxMonLocalizationType = "PaxMonAtStation" | "PaxMonInTrip";
+
+// paxmon/PaxMonLocalization.fbs
+export interface PaxMonLocalizationWrapper {
+  localization_type: PaxMonLocalizationType;
+  localization: PaxMonLocalization;
+}
+
 // paxmon/PaxMonRerouteLog.fbs
 export interface PaxMonRerouteLogRoute {
   index: number;
@@ -76,6 +103,8 @@ export interface PaxMonRerouteLogEntry {
   broken_transfer: PaxMonBrokenTransferInfo[];
   old_route: PaxMonRerouteLogRoute;
   new_routes: PaxMonRerouteLogRoute[];
+  localization_type: PaxMonLocalizationType;
+  localization: PaxMonLocalization;
 }
 
 // paxmon/PaxMonGroup.fbs
@@ -135,33 +164,6 @@ export interface PaxMonGroupRouteUpdateInfo {
   n: number;
   p: number;
   pp: number;
-}
-
-// paxmon/PaxMonLocalization.fbs
-export interface PaxMonAtStation {
-  station: Station;
-  schedule_arrival_time: number;
-  current_arrival_time: number;
-  first_station: boolean;
-}
-
-// paxmon/PaxMonLocalization.fbs
-export interface PaxMonInTrip {
-  trip: TripId;
-  next_station: Station;
-  schedule_arrival_time: number;
-  current_arrival_time: number;
-}
-
-// paxmon/PaxMonLocalization.fbs
-export type PaxMonLocalization = PaxMonAtStation | PaxMonInTrip;
-
-export type PaxMonLocalizationType = "PaxMonAtStation" | "PaxMonInTrip";
-
-// paxmon/PaxMonLocalization.fbs
-export interface PaxMonLocalizationWrapper {
-  localization_type: PaxMonLocalizationType;
-  localization: PaxMonLocalization;
 }
 
 // paxmon/PaxMonReachability.fbs
@@ -639,6 +641,7 @@ export interface PaxMonRerouteGroup {
   reason: PaxMonRerouteReason;
   broken_transfer: PaxMonBrokenTransferInfo[];
   override_probabilities: boolean;
+  localization: PaxMonLocalizationWrapper[];
 }
 
 // paxmon/PaxMonRerouteGroupsRequest.fbs

--- a/ui/rsl/src/api/protocol/motis/paxmon.ts
+++ b/ui/rsl/src/api/protocol/motis/paxmon.ts
@@ -43,7 +43,9 @@ export type PaxMonRerouteReason =
   | "MajorDelayExpected"
   | "RevertForecast"
   | "Simulation"
-  | "UpdateForecast";
+  | "UpdateForecast"
+  | "DestinationUnreachable"
+  | "DestinationReachable";
 
 // paxmon/PaxMonBrokenTransferInfo.fbs
 export type PaxMonTransferDirection = "Enter" | "Exit";

--- a/ui/rsl/src/api/protocol/motis/paxmon.ts
+++ b/ui/rsl/src/api/protocol/motis/paxmon.ts
@@ -693,8 +693,9 @@ export interface PaxMonGroupStatisticsResponse {
   group_count: number;
   total_group_route_count: number;
   active_group_route_count: number;
-  groups_with_unreachable_destination: number;
+  unreachable_destination_group_count: number;
   total_pax_count: number;
+  unreachable_destination_pax_count: number;
   min_estimated_delay: PaxMonHistogram;
   max_estimated_delay: PaxMonHistogram;
   expected_estimated_delay: PaxMonHistogram;

--- a/ui/rsl/src/components/groups/GroupDetails.tsx
+++ b/ui/rsl/src/components/groups/GroupDetails.tsx
@@ -16,9 +16,11 @@ import React, { useEffect } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import {
+  PaxMonAtStation,
   PaxMonCompactJourneyLeg,
   PaxMonGroup,
   PaxMonGroupRoute,
+  PaxMonInTrip,
   PaxMonRerouteLogEntry,
   PaxMonRerouteReason,
   PaxMonTransferInfo,
@@ -32,7 +34,7 @@ import { formatPercent } from "@/data/numberFormat";
 import { mostRecentlySelectedGroupAtom } from "@/data/selectedGroup";
 
 import classNames from "@/util/classNames";
-import { formatDateTime } from "@/util/dateFormat";
+import { formatDateTime, formatTime } from "@/util/dateFormat";
 
 import TripServiceInfoView from "@/components/TripServiceInfoView";
 import Delay from "@/components/util/Delay";
@@ -306,6 +308,7 @@ function RerouteLogEntry({ log, logIndex }: RerouteLogEntryProps): JSX.Element {
             {formatDateTime(log.system_time)}
           </span>
         </div>
+        <RerouteLogEntryLocalization log={log} />
         {show_reroutes ? (
           <>
             <div>
@@ -368,6 +371,36 @@ function RerouteLogEntry({ log, logIndex }: RerouteLogEntryProps): JSX.Element {
       </div>
     </div>
   );
+}
+
+type RerouteLogEntryLocalizationProps = {
+  log: PaxMonRerouteLogEntry;
+};
+
+function RerouteLogEntryLocalization({
+  log,
+}: RerouteLogEntryLocalizationProps): JSX.Element {
+  switch (log.localization_type) {
+    case "PaxMonAtStation": {
+      const loc = log.localization as PaxMonAtStation;
+      return (
+        <div>
+          Reisende an Station {loc.station.name} um{" "}
+          {formatTime(loc.current_arrival_time)}
+          {loc.first_station ? " (Reisebeginn)" : ""}
+        </div>
+      );
+    }
+    case "PaxMonInTrip": {
+      const loc = log.localization as PaxMonInTrip;
+      return (
+        <div>
+          Reisende in Zug {loc.trip.train_nr}, nächster Halt:{" "}
+          {loc.next_station.name} um {formatTime(loc.current_arrival_time)}
+        </div>
+      );
+    }
+  }
 }
 
 type RerouteReasonIcon = {

--- a/ui/rsl/src/components/groups/GroupDetails.tsx
+++ b/ui/rsl/src/components/groups/GroupDetails.tsx
@@ -1,12 +1,14 @@
 import {
   ArrowPathIcon,
   ArrowUturnUpIcon,
+  CheckCircleIcon,
   ClockIcon,
   CpuChipIcon,
   ExclamationTriangleIcon,
   TicketIcon,
   UsersIcon,
   WrenchIcon,
+  XCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useAtom } from "jotai";
 import { useUpdateAtom } from "jotai/utils";
@@ -266,6 +268,10 @@ function rerouteReasonText(reason: PaxMonRerouteReason): string {
       return "Simulation";
     case "UpdateForecast":
       return "Neuberechnung der Vorhersage";
+    case "DestinationUnreachable":
+      return "Ziel nicht mehr erreichbar";
+    case "DestinationReachable":
+      return "Ziel wieder erreichbar";
   }
 }
 
@@ -278,6 +284,7 @@ type RerouteLogEntryProps = {
 function RerouteLogEntry({ log, logIndex }: RerouteLogEntryProps): JSX.Element {
   const broken_transfer =
     log.broken_transfer.length === 1 ? log.broken_transfer[0] : undefined;
+  const show_reroutes = log.new_routes.length > 0;
   const { icon, bgColor } = getRerouteReasonIcon(log.reason);
 
   return (
@@ -299,19 +306,29 @@ function RerouteLogEntry({ log, logIndex }: RerouteLogEntryProps): JSX.Element {
             {formatDateTime(log.system_time)}
           </span>
         </div>
-        <div>
-          Umleitung von Route #{log.old_route.index} (
-          {formatPercent(log.old_route.previous_probability)} &rarr;{" "}
-          {formatPercent(log.old_route.new_probability)}) auf:
-        </div>
-        <div className="pl-4">
-          {log.new_routes.map((route) => (
-            <div key={route.index}>
-              Route #{route.index}: {formatPercent(route.previous_probability)}{" "}
-              &rarr; {formatPercent(route.new_probability)}
+        {show_reroutes ? (
+          <>
+            <div>
+              Umleitung von Route #{log.old_route.index} (
+              {formatPercent(log.old_route.previous_probability)} &rarr;{" "}
+              {formatPercent(log.old_route.new_probability)}) auf:
             </div>
-          ))}
-        </div>
+            <div className="pl-4">
+              {log.new_routes.map((route) => (
+                <div key={route.index}>
+                  Route #{route.index}:{" "}
+                  {formatPercent(route.previous_probability)} &rarr;{" "}
+                  {formatPercent(route.new_probability)}
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div>
+            Route #{log.old_route.index} (
+            {formatPercent(log.old_route.previous_probability)})
+          </div>
+        )}
         {broken_transfer && (
           <div>
             <div className="space-x-1">
@@ -384,12 +401,22 @@ function getRerouteReasonIcon(reason: PaxMonRerouteReason): RerouteReasonIcon {
     case "Simulation":
       return {
         icon: <CpuChipIcon className={style} />,
-        bgColor: "bg-green-500",
+        bgColor: "bg-teal-500",
       };
     case "UpdateForecast":
       return {
         icon: <ArrowPathIcon className={style} />,
         bgColor: "bg-teal-500",
+      };
+    case "DestinationUnreachable":
+      return {
+        icon: <XCircleIcon className={style} />,
+        bgColor: "bg-fuchsia-500",
+      };
+    case "DestinationReachable":
+      return {
+        icon: <CheckCircleIcon className={style} />,
+        bgColor: "bg-green-500",
       };
   }
 }

--- a/ui/rsl/src/components/groups/GroupList.tsx
+++ b/ui/rsl/src/components/groups/GroupList.tsx
@@ -4,7 +4,7 @@ import {
   CheckIcon,
   ChevronUpDownIcon,
 } from "@heroicons/react/20/solid";
-import { MapIcon, UsersIcon } from "@heroicons/react/24/outline";
+import { MapIcon, UsersIcon, XCircleIcon } from "@heroicons/react/24/outline";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { add, fromUnixTime, getUnixTime, max, sub } from "date-fns";
 import { useAtom } from "jotai";
@@ -26,7 +26,7 @@ import { useLookupScheduleInfoQuery } from "@/api/lookup";
 import { sendPaxMonFilterGroupsRequest } from "@/api/paxmon";
 
 import { universeAtom } from "@/data/multiverse";
-import { formatNumber } from "@/data/numberFormat";
+import { formatNumber, formatPercent } from "@/data/numberFormat";
 
 import classNames from "@/util/classNames";
 import { formatISODate, formatTime } from "@/util/dateFormat";
@@ -553,17 +553,25 @@ function GroupListEntry({
         </div>
         {firstRoute && <GroupRouteInfo route={firstRoute} />}
         <div className="flex justify-between">
-          <div className="flex gap-1">
-            Verspätung:
-            <Delay minutes={groupWithStats.expected_estimated_delay} />
-            {groupWithStats.min_estimated_delay !=
-            groupWithStats.max_estimated_delay ? (
-              <div>
-                (<Delay minutes={groupWithStats.min_estimated_delay} /> –{" "}
-                <Delay minutes={groupWithStats.max_estimated_delay} />)
-              </div>
-            ) : null}
-          </div>
+          {groupWithStats.prob_destination_unreachable == 0 ? (
+            <div className="flex gap-1">
+              Verspätung:
+              <Delay minutes={groupWithStats.expected_estimated_delay} />
+              {groupWithStats.min_estimated_delay !=
+              groupWithStats.max_estimated_delay ? (
+                <div>
+                  (<Delay minutes={groupWithStats.min_estimated_delay} /> –{" "}
+                  <Delay minutes={groupWithStats.max_estimated_delay} />)
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <div className="flex items-center gap-x-1 text-fuchsia-600">
+              <XCircleIcon className="w-5 h-5" aria-hidden="true" />
+              Ziel nicht erreichbar (
+              {formatPercent(groupWithStats.prob_destination_unreachable)})
+            </div>
+          )}
           <div className="flex items-center gap-x-1">
             <MapIcon
               className="w-5 h-5 text-db-cool-gray-500"

--- a/ui/rsl/src/components/groups/GroupList.tsx
+++ b/ui/rsl/src/components/groups/GroupList.tsx
@@ -66,6 +66,22 @@ const sortOptions: Array<LabeledSortOrder> = [
 
 type GroupIdType = "internal" | "source";
 
+type LabeledRerouteReason = {
+  reason: PaxMonRerouteReason;
+  label: string;
+};
+
+const rerouteReasonOptions: Array<LabeledRerouteReason> = [
+  { reason: "BrokenTransfer", label: "Gebrochener Umstieg" },
+  { reason: "MajorDelayExpected", label: "Hohe erwartete Zielverspätung" },
+  { reason: "Simulation", label: "Simulation" },
+  { reason: "Manual", label: "Manuelle Umleitung" },
+  { reason: "RevertForecast", label: "Rücknahme einer Vorhersage" },
+  { reason: "UpdateForecast", label: "Neuberechnung einer Vorhersage" },
+  { reason: "DestinationUnreachable", label: "Ziel nicht mehr erreichbar" },
+  { reason: "DestinationReachable", label: "Ziel wieder erreichbar" },
+];
+
 function getFilterGroupsRequest(
   pageParam: number,
   universe: number,
@@ -116,14 +132,7 @@ function GroupList(): JSX.Element {
   const [filterByRerouteReason, setFilterByRerouteReason] = useState(false);
   const [rerouteReasonFilter, setRerouteReasonFilter] = useState<
     PaxMonRerouteReason[]
-  >([
-    "Manual",
-    "BrokenTransfer",
-    "MajorDelayExpected",
-    "RevertForecast",
-    "Simulation",
-    "UpdateForecast",
-  ]);
+  >(rerouteReasonOptions.map((r) => r.reason));
 
   const filterTrainNrs = extractNumbers(trainNrFilter);
 
@@ -398,20 +407,6 @@ function GroupList(): JSX.Element {
     </div>
   );
 }
-
-type LabeledRerouteReason = {
-  reason: PaxMonRerouteReason;
-  label: string;
-};
-
-const rerouteReasonOptions: Array<LabeledRerouteReason> = [
-  { reason: "BrokenTransfer", label: "Gebrochener Umstieg" },
-  { reason: "MajorDelayExpected", label: "Hohe erwartete Zielverspätung" },
-  { reason: "Simulation", label: "Simulation" },
-  { reason: "Manual", label: "Manuelle Umleitung" },
-  { reason: "RevertForecast", label: "Rücknahme einer Vorhersage" },
-  { reason: "UpdateForecast", label: "Neuberechnung einer Vorhersage" },
-];
 
 type RerouteReasonOptionsProps = {
   rerouteReasonFilter: PaxMonRerouteReason[];

--- a/ui/rsl/src/components/stats/GroupStatistics.tsx
+++ b/ui/rsl/src/components/stats/GroupStatistics.tsx
@@ -27,7 +27,9 @@ function GroupStatistics(): JSX.Element {
       <h1 className="text-xl font-semibold">Gruppenstatistiken</h1>
       <p>
         Reisendengruppen: {formatNumber(data.group_count)}, Reisende:{" "}
-        {formatNumber(data.total_pax_count)}
+        {formatNumber(data.total_pax_count)}, Möglicherweise gestrandete
+        Reisendengruppen:{" "}
+        {formatNumber(data.groups_with_unreachable_destination)}
       </p>
       <p>
         Reiseketten: {formatNumber(data.total_group_route_count)} gesamt,{" "}

--- a/ui/rsl/src/components/stats/GroupStatistics.tsx
+++ b/ui/rsl/src/components/stats/GroupStatistics.tsx
@@ -28,8 +28,9 @@ function GroupStatistics(): JSX.Element {
       <p>
         Reisendengruppen: {formatNumber(data.group_count)}, Reisende:{" "}
         {formatNumber(data.total_pax_count)}, Möglicherweise gestrandete
-        Reisendengruppen:{" "}
-        {formatNumber(data.groups_with_unreachable_destination)}
+        Reisende: {formatNumber(data.unreachable_destination_pax_count)} (
+        {formatNumber(data.unreachable_destination_group_count)}{" "}
+        Reisendengruppen)
       </p>
       <p>
         Reiseketten: {formatNumber(data.total_group_route_count)} gesamt,{" "}


### PR DESCRIPTION
Adds information about group routes with unreachable destinations ("stranded passengers") to various APIs and internal data structures:

- Group Statistics API: Number of passengers + groups with unreachable destinations
- Group Reroute Log:
  - Now contains log entries whenever a destination becomes unreachable (no alternatives found) and whenever a destination becomes reachable again
  - Now also stores the passenger group location at the time the entry was generated (this is the location used for the alternative routing request)
- Group List API: New filters for unreachable reroute log entries

Also fixes a bug where sometimes group routes with very low probabilities could be lost - in these cases, the most likely alternative is now always picked with a probabiltiy of 100%.

The detection of unreachable destinations currently doesn't work if all alternatives only consist of a footpath or end in a footpath (will be fixed later).