### PR TITLE
RSL: Various Improvements

### DIFF
--- a/docs/api/schemas/motis/paxmon.yaml
+++ b/docs/api/schemas/motis/paxmon.yaml
@@ -570,6 +570,9 @@ PaxMonFilterTripsTimeFilter:
       in the filter interval
     - `DepartureOrArrivalTime`: The trip id departure or arrival (scheduled departure time at the
       first stop or scheduled arrival time at the last stop) must be in the filter interval
+    - `ActiveTime`: The trip must be active in the filter interval according to the trip id
+      (i.e. the scheduled departure time must be before the interval end and the scheduled
+      arrival time at the last stop must be after the interval begin)
 PaxMonFilterTripsRequest:
   description: Request a list of trips tracked by paxmon
   fields:

--- a/docs/api/schemas/motis/ris.yaml
+++ b/docs/api/schemas/motis/ris.yaml
@@ -346,3 +346,12 @@ TripFormationMessage:
       description: TODO
     sections:
       description: TODO
+RISApplyResponse:
+  description: TODO
+  fields:
+    new_system_time:
+      description: TODO
+    successful:
+      description: TODO
+    failed:
+      description: TODO

--- a/modules/paxforecast/include/motis/paxforecast/error.h
+++ b/modules/paxforecast/include/motis/paxforecast/error.h
@@ -6,7 +6,12 @@
 namespace motis::paxforecast {
 
 namespace error {
-enum error_code_t { ok = 0, unsupported_measure = 1, universe_not_found = 2 };
+enum error_code_t {
+  ok = 0,
+  unsupported_measure = 1,
+  universe_not_found = 2,
+  invalid_rt_update_message = 3
+};
 }  // namespace error
 
 class error_category_impl : public std::error_category {
@@ -19,6 +24,8 @@ public:
       case error::unsupported_measure:
         return "paxforecast: unsupported measure";
       case error::universe_not_found: return "paxforecast: universe not found";
+      case error::invalid_rt_update_message:
+        return "paxforecast: invalid rt update message";
       default: return "paxforecast: unkown error";
     }
   }

--- a/modules/paxmon/include/motis/paxmon/settings/journey_input_settings.h
+++ b/modules/paxmon/include/motis/paxmon/settings/journey_input_settings.h
@@ -15,6 +15,8 @@ struct journey_input_settings {
   double split_groups_size_mean_{1.5};
   double split_groups_size_stddev_{3.0};
   unsigned split_groups_seed_{0};
+
+  unsigned max_station_wait_time_{0};  // minutes
 };
 
 }  // namespace motis::paxmon::settings

--- a/modules/paxmon/src/api/filter_groups.cc
+++ b/modules/paxmon/src/api/filter_groups.cc
@@ -136,14 +136,15 @@ msg_ptr filter_groups(paxmon_data& data, msg_ptr const& msg) {
   auto check_time_filter = [&](fws_compact_journey const cj) {
     auto const dep = cj.legs().front().enter_time_;
     auto const arr = cj.legs().back().exit_time_;
-    if (time_filter_type == PaxMonFilterGroupsTimeFilter_DepartureTime) {
-      return dep >= filter_interval_begin && dep < filter_interval_end;
-    } else if (time_filter_type ==
-               PaxMonFilterGroupsTimeFilter_DepartureOrArrivalTime) {
-      return (dep >= filter_interval_begin && dep < filter_interval_end) ||
-             (arr >= filter_interval_begin && arr < filter_interval_end);
-    } else {
-      return true;
+    switch (time_filter_type) {
+      case PaxMonFilterGroupsTimeFilter_DepartureTime:
+        return dep >= filter_interval_begin && dep < filter_interval_end;
+      case PaxMonFilterGroupsTimeFilter_DepartureOrArrivalTime:
+        return (dep >= filter_interval_begin && dep < filter_interval_end) ||
+               (arr >= filter_interval_begin && arr < filter_interval_end);
+      case PaxMonFilterGroupsTimeFilter_ActiveTime:
+        return dep <= filter_interval_end && arr >= filter_interval_begin;
+      default: return true;
     }
   };
 

--- a/modules/paxmon/src/api/filter_trips.cc
+++ b/modules/paxmon/src/api/filter_trips.cc
@@ -99,15 +99,19 @@ msg_ptr filter_trips(paxmon_data& data, msg_ptr const& msg) {
       }
 
       auto const dep = trp->id_.primary_.get_time();
+      auto const arr = trp->id_.secondary_.target_time_;
       if (filter_by_time == PaxMonFilterTripsTimeFilter_DepartureTime) {
         if (dep < filter_interval_begin || dep >= filter_interval_end) {
           continue;
         }
       } else if (filter_by_time ==
                  PaxMonFilterTripsTimeFilter_DepartureOrArrivalTime) {
-        auto const arr = trp->id_.secondary_.target_time_;
         if ((dep < filter_interval_begin || dep >= filter_interval_end) &&
             (arr < filter_interval_begin || arr >= filter_interval_end)) {
+          continue;
+        }
+      } else if (filter_by_time == PaxMonFilterTripsTimeFilter_ActiveTime) {
+        if (dep > filter_interval_end || arr < filter_interval_begin) {
           continue;
         }
       }

--- a/modules/paxmon/src/paxmon.cc
+++ b/modules/paxmon/src/paxmon.cc
@@ -83,6 +83,9 @@ paxmon::paxmon() : module("Passenger Monitoring", "paxmon"), data_{*this} {
         "split_groups_stddev", "standard deviation for split groups size");
   param(journey_input_settings_.split_groups_seed_, "split_groups_seed",
         "rng seed for splitting groups");
+  param(journey_input_settings_.max_station_wait_time_, "max_station_wait_time",
+        "maximum wait time at a station, if exceeded the journey is split into "
+        "separate journeys (minutes, set to 0 to disable)");
 
   param(generated_capacity_file_, "generated_capacity_file",
         "output for generated capacities");
@@ -358,6 +361,7 @@ void paxmon::init(motis::module::registry& reg) {
                     return api::get_universes(data_, msg);
                   },
                   {});
+
   reg.register_op("/paxmon/get_groups",
                   [&](msg_ptr const& msg) -> msg_ptr {
                     return api::get_groups(data_, msg);

--- a/modules/ris/include/motis/ris/ribasis/ribasis_parser.h
+++ b/modules/ris/include/motis/ris/ribasis/ribasis_parser.h
@@ -8,7 +8,7 @@
 
 namespace motis::ris::ribasis {
 
-void to_ris_message(std::string_view, std::function<void(ris_message&&)> const&,
+bool to_ris_message(std::string_view, std::function<void(ris_message&&)> const&,
                     std::string const& tag = "");
 
 std::vector<ris_message> parse(std::string_view, std::string const& tag = "");

--- a/modules/ris/include/motis/ris/risml/risml_parser.h
+++ b/modules/ris/include/motis/ris/risml/risml_parser.h
@@ -10,7 +10,7 @@
 
 namespace motis::ris::risml {
 
-void to_ris_message(std::string_view, std::function<void(ris_message&&)> const&,
+bool to_ris_message(std::string_view, std::function<void(ris_message&&)> const&,
                     std::string const& tag = "");
 std::vector<ris_message> parse(std::string_view, std::string const& tag = "");
 

--- a/modules/ris/src/ribasis/ribasis_parser.cc
+++ b/modules/ris/src/ribasis/ribasis_parser.cc
@@ -24,7 +24,7 @@ using namespace motis::json;
 
 namespace motis::ris::ribasis {
 
-void to_ris_message(std::string_view s,
+bool to_ris_message(std::string_view s,
                     const std::function<void(ris_message&&)>& cb,
                     std::string const& tag) {
   utl::verify(tag.empty(), "RI Basis does not support multi-schedule");
@@ -35,7 +35,7 @@ void to_ris_message(std::string_view s,
     LOG(error) << "RI Basis: Bad JSON: "
                << rapidjson::GetParseError_En(doc.GetParseError())
                << " at offset " << doc.GetErrorOffset();
-    return;
+    return false;
   }
 
   try {
@@ -51,7 +51,7 @@ void to_ris_message(std::string_view s,
       formation::parse_ribasis_formation(ctx, data);
     } else {
       LOG(error) << "invalid/unsupported RI Basis message";
-      return;
+      return false;
     }
 
     utl::verify(ctx.earliest_ != std::numeric_limits<unixtime>::max(),
@@ -62,7 +62,9 @@ void to_ris_message(std::string_view s,
                    std::move(ctx.b_)});
   } catch (std::runtime_error const& e) {
     LOG(error) << "unable to parse RI Basis message: " << e.what();
+    return false;
   }
+  return true;
 }
 
 std::vector<ris_message> parse(std::string_view s, std::string const& tag) {

--- a/modules/ris/src/risml/risml_parser.cc
+++ b/modules/ris/src/risml/risml_parser.cc
@@ -307,7 +307,7 @@ boost::optional<ris_message> parse_message(xml_node const& msg,
   return {{ctx.earliest_, ctx.latest_, ctx.timestamp_, std::move(ctx.b_)}};
 }
 
-void to_ris_message(std::string_view s,
+bool to_ris_message(std::string_view s,
                     std::function<void(ris_message&&)> const& cb,
                     std::string const& tag) {
   utl::verify(tag.empty(), "risml does not support multi-schedule");
@@ -317,7 +317,7 @@ void to_ris_message(std::string_view s,
     auto r = d.load_buffer(reinterpret_cast<void const*>(s.data()), s.size());
     if (!r) {
       LOG(error) << "bad XML: " << r.description();
-      return;
+      return false;
     }
 
     auto t_out = parse_time(child_attr(d, "Paket", "TOut").value());
@@ -328,9 +328,12 @@ void to_ris_message(std::string_view s,
     }
   } catch (std::exception const& e) {
     LOG(error) << "unable to parse RIS message: " << e.what();
+    return false;
   } catch (...) {
     LOG(error) << "unable to parse RIS message";
+    return false;
   }
+  return true;
 }
 
 std::vector<ris_message> parse(std::string_view s, std::string const& tag) {

--- a/protocol/Message.fbs
+++ b/protocol/Message.fbs
@@ -64,6 +64,7 @@ include "railviz/RailVizTripsRequest.fbs";
 include "revise/ReviseRequest.fbs";
 include "revise/ReviseResponse.fbs";
 include "ris/RISApplyRequest.fbs";
+include "ris/RISApplyResponse.fbs";
 include "ris/RISBatch.fbs";
 include "ris/RISForwardTimeRequest.fbs";
 include "ris/RISGTFSRTMapping.fbs";
@@ -302,7 +303,8 @@ union MsgContent {
   motis.paxmon.PaxMonGroupStatisticsResponse                              = 140,
   motis.paxmon.PaxMonDebugGraphRequest                                    = 141,
   motis.paxmon.PaxMonDebugGraphResponse                                   = 142,
-  motis.paxmon.PaxMonGetUniversesResponse                                 = 143
+  motis.paxmon.PaxMonGetUniversesResponse                                 = 143,
+  motis.ris.RISApplyResponse                                              = 144
 }
 
 // Destination Examples:

--- a/protocol/paxmon/PaxMonFilterGroupsRequest.fbs
+++ b/protocol/paxmon/PaxMonFilterGroupsRequest.fbs
@@ -16,7 +16,8 @@ enum PaxMonFilterGroupsSortOrder : byte {
 enum PaxMonFilterGroupsTimeFilter : byte {
   NoFilter, // don't filter based on time
   DepartureTime, // scheduled departure must be in interval
-  DepartureOrArrivalTime // scheduled departure or arrival must be in interval
+  DepartureOrArrivalTime, // scheduled departure or arrival must be in interval
+  ActiveTime // group must be active in interval according to scheduled times
 }
 
 table PaxMonFilterGroupsRequest {

--- a/protocol/paxmon/PaxMonFilterTripsRequest.fbs
+++ b/protocol/paxmon/PaxMonFilterTripsRequest.fbs
@@ -15,7 +15,8 @@ enum PaxMonFilterTripsSortOrder : byte {
 enum PaxMonFilterTripsTimeFilter : byte {
   NoFilter, // don't filter based on time
   DepartureTime, // trip id departure must be in interval
-  DepartureOrArrivalTime // trip id departure or arrival must be in interval
+  DepartureOrArrivalTime, // trip id departure or arrival must be in interval
+  ActiveTime // trip must be active in interval according to trip id times
 }
 
 table PaxMonFilterTripsRequest {

--- a/protocol/ris/RISApplyResponse.fbs
+++ b/protocol/ris/RISApplyResponse.fbs
@@ -1,0 +1,7 @@
+namespace motis.ris;
+
+table RISApplyResponse {
+  new_system_time: ulong;
+  successful: ulong;
+  failed: ulong;
+}

--- a/ui/rsl/package.json
+++ b/ui/rsl/package.json
@@ -18,10 +18,10 @@
   "dependencies": {
     "@headlessui/react": "^1.7.11",
     "@headlessui/tailwindcss": "^0.1.2",
-    "@heroicons/react": "^2.0.15",
+    "@heroicons/react": "^2.0.16",
     "@radix-ui/react-tooltip": "^1.0.3",
-    "@tanstack/react-query": "^4.24.6",
-    "@tanstack/react-query-devtools": "^4.24.6",
+    "@tanstack/react-query": "^4.24.9",
+    "@tanstack/react-query-devtools": "^4.24.9",
     "@visx/axis": "^3.0.1",
     "@visx/grid": "^3.0.1",
     "@visx/group": "^3.0.0",
@@ -65,6 +65,6 @@
     "prettier": "^2.8.4",
     "tailwindcss": "^3.2.7",
     "typescript": "^4.9.5",
-    "vite": "^4.1.2"
+    "vite": "^4.1.3"
   }
 }

--- a/ui/rsl/pnpm-lock.yaml
+++ b/ui/rsl/pnpm-lock.yaml
@@ -3,12 +3,12 @@ lockfileVersion: 5.4
 specifiers:
   '@headlessui/react': ^1.7.11
   '@headlessui/tailwindcss': ^0.1.2
-  '@heroicons/react': ^2.0.15
+  '@heroicons/react': ^2.0.16
   '@limegrass/eslint-plugin-import-alias': ^1.0.6
   '@radix-ui/react-tooltip': ^1.0.3
   '@tailwindcss/forms': ^0.5.3
-  '@tanstack/react-query': ^4.24.6
-  '@tanstack/react-query-devtools': ^4.24.6
+  '@tanstack/react-query': ^4.24.9
+  '@tanstack/react-query-devtools': ^4.24.9
   '@trivago/prettier-plugin-sort-imports': ^4.0.0
   '@types/d3-array': ^3.0.4
   '@types/d3-force': ^3.0.4
@@ -48,15 +48,15 @@ specifiers:
   tailwindcss: ^3.2.7
   typescript: ^4.9.5
   uuid: ^9.0.0
-  vite: ^4.1.2
+  vite: ^4.1.3
 
 dependencies:
   '@headlessui/react': 1.7.11_biqbaboplfbrettd7655fr4n2y
   '@headlessui/tailwindcss': 0.1.2_tailwindcss@3.2.7
-  '@heroicons/react': 2.0.15_react@18.2.0
+  '@heroicons/react': 2.0.16_react@18.2.0
   '@radix-ui/react-tooltip': 1.0.3_zula6vjvt3wdocc4mwcxqa6nzi
-  '@tanstack/react-query': 4.24.6_biqbaboplfbrettd7655fr4n2y
-  '@tanstack/react-query-devtools': 4.24.6_r32zdxeb7iubg3qfkymfterewe
+  '@tanstack/react-query': 4.24.9_biqbaboplfbrettd7655fr4n2y
+  '@tanstack/react-query-devtools': 4.24.9_bzphmdwvicyhtx5eo3azinrh54
   '@visx/axis': 3.0.1_react@18.2.0
   '@visx/grid': 3.0.1_react@18.2.0
   '@visx/group': 3.0.0_react@18.2.0
@@ -90,7 +90,7 @@ devDependencies:
   '@types/uuid': 9.0.0
   '@typescript-eslint/eslint-plugin': 5.52.0_6cfvjsbua5ptj65675bqcn6oza
   '@typescript-eslint/parser': 5.52.0_7kw3g6rralp5ps6mg3uyzz6azm
-  '@vitejs/plugin-react': 3.1.0_vite@4.1.2
+  '@vitejs/plugin-react': 3.1.0_vite@4.1.3
   autoprefixer: 10.4.13_postcss@8.4.21
   eslint: 8.34.0
   eslint-config-prettier: 8.6.0_eslint@8.34.0
@@ -100,7 +100,7 @@ devDependencies:
   prettier: 2.8.4
   tailwindcss: 3.2.7_postcss@8.4.21
   typescript: 4.9.5
-  vite: 4.1.2
+  vite: 4.1.3
 
 packages:
 
@@ -119,8 +119,8 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
-  /@babel/compat-data/7.20.14:
-    resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
+  /@babel/compat-data/7.21.0:
+    resolution: {integrity: sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -132,8 +132,8 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/generator': 7.17.7
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.17.8
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.13
+      '@babel/helper-module-transforms': 7.21.0
+      '@babel/helpers': 7.21.0
       '@babel/parser': 7.18.9
       '@babel/template': 7.20.7
       '@babel/traverse': 7.17.3
@@ -147,20 +147,20 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/core/7.20.12:
-    resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
+  /@babel/core/7.21.0:
+    resolution: {integrity: sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.13
-      '@babel/parser': 7.20.15
+      '@babel/generator': 7.21.0
+      '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.21.0
+      '@babel/helper-module-transforms': 7.21.0
+      '@babel/helpers': 7.21.0
+      '@babel/parser': 7.21.0
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.0
+      '@babel/types': 7.21.0
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -179,12 +179,13 @@ packages:
       source-map: 0.5.7
     dev: true
 
-  /@babel/generator/7.20.14:
-    resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
+  /@babel/generator/7.21.0:
+    resolution: {integrity: sha512-z/zN3SePOtxN1/vPFdqrkuJGCD2Vx469+dSbNRD+4TF2+6e4Of5exHqAtcfL/2Nwu0RN0QsFwjyDBFwdUMzNSA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
       '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
     dev: true
 
@@ -194,23 +195,23 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.21.0
       '@babel/core': 7.17.8
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
     dev: true
 
-  /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.12:
+  /@babel/helper-compilation-targets/7.20.7_@babel+core@7.21.0:
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.14
-      '@babel/core': 7.20.12
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/compat-data': 7.21.0
+      '@babel/core': 7.21.0
+      '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
@@ -221,30 +222,30 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-function-name/7.19.0:
-    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
+  /@babel/helper-function-name/7.21.0:
+    resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
     dev: true
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
     dev: true
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
     dev: true
 
-  /@babel/helper-module-transforms/7.20.11:
-    resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
+  /@babel/helper-module-transforms/7.21.0:
+    resolution: {integrity: sha512-eD/JQ21IG2i1FraJnTMbUarAUkA7G988ofehG5MDCRXaUU91rEBJuCeSoou2Sk1y4RbLYXzqEg1QLwEmRU4qcQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
@@ -253,8 +254,8 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.0
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -268,14 +269,14 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
     dev: true
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
     dev: true
 
   /@babel/helper-string-parser/7.19.4:
@@ -288,18 +289,18 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-validator-option/7.18.6:
-    resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
+  /@babel/helper-validator-option/7.21.0:
+    resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helpers/7.20.13:
-    resolution: {integrity: sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==}
+  /@babel/helpers/7.21.0:
+    resolution: {integrity: sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.20.7
+      '@babel/traverse': 7.21.0
+      '@babel/types': 7.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -321,36 +322,36 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/parser/7.20.15:
-    resolution: {integrity: sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==}
+  /@babel/parser/7.21.0:
+    resolution: {integrity: sha512-ONjtg4renj14A9pj3iA5T5+r5Eijxbr2eNIkMBTC74occDSsRZUpe8vowmowAjFR1imWlkD8eEmjYXiREZpGZg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.0
     dev: true
 
-  /@babel/plugin-transform-react-jsx-self/7.18.6_@babel+core@7.20.12:
-    resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
+  /@babel/plugin-transform-react-jsx-self/7.21.0_@babel+core@7.21.0:
+    resolution: {integrity: sha512-f/Eq+79JEu+KUANFks9UZCcvydOOGMgF7jBrcwjHa5jTZD8JivnhCJYvmlhR/WTXBWonDExPoW0eO/CR4QJirA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-react-jsx-source/7.19.6_@babel+core@7.20.12:
+  /@babel/plugin-transform-react-jsx-source/7.19.6_@babel+core@7.21.0:
     resolution: {integrity: sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.12
+      '@babel/core': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/runtime/7.20.13:
-    resolution: {integrity: sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==}
+  /@babel/runtime/7.21.0:
+    resolution: {integrity: sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
@@ -361,8 +362,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.20.15
-      '@babel/types': 7.20.7
+      '@babel/parser': 7.21.0
+      '@babel/types': 7.21.0
     dev: true
 
   /@babel/traverse/7.17.3:
@@ -372,7 +373,7 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/generator': 7.17.7
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.18.9
@@ -383,18 +384,18 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/traverse/7.20.13:
-    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
+  /@babel/traverse/7.21.0:
+    resolution: {integrity: sha512-Xdt2P1H4LKTO8ApPfnO1KmzYMFpp7D/EinoXzLYN/cHcBNrVCAkAtGUcXnHXrl/VGktureU6fkQrHSBE2URfoA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
+      '@babel/generator': 7.21.0
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.15
-      '@babel/types': 7.20.7
+      '@babel/parser': 7.21.0
+      '@babel/types': 7.21.0
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
@@ -409,8 +410,8 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@babel/types/7.20.7:
-    resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
+  /@babel/types/7.21.0:
+    resolution: {integrity: sha512-uR7NWq2VNFnDi7EYqiRz2Jv/VQIu38tu64Zy8TX2nQFQ6etJ9V/Rr2msW8BS132mum2rL645qpDrLtAJtVpuow==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
@@ -678,8 +679,8 @@ packages:
       tailwindcss: 3.2.7_postcss@8.4.21
     dev: false
 
-  /@heroicons/react/2.0.15_react@18.2.0:
-    resolution: {integrity: sha512-CZ2dGWgWG3/z5LEoD5D3MEr1syn45JM/OB2aDpw531Ryecgkz2V7TWQ808P0lva7zP003PVW6WlwbofsYyga3A==}
+  /@heroicons/react/2.0.16_react@18.2.0:
+    resolution: {integrity: sha512-x89rFxH3SRdYaA+JCXwfe+RkE1SFTo9GcOkZettHer71Y3T7V+ogKmfw5CjTazgS3d0ClJ7p1NA+SP7VQLQcLw==}
     peerDependencies:
       react: '>= 16'
     dependencies:
@@ -778,7 +779,7 @@ packages:
   /@radix-ui/primitive/1.0.0:
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
     dev: false
 
   /@radix-ui/react-arrow/1.0.1_biqbaboplfbrettd7655fr4n2y:
@@ -787,7 +788,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-primitive': 1.0.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -798,7 +799,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       react: 18.2.0
     dev: false
 
@@ -807,7 +808,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       react: 18.2.0
     dev: false
 
@@ -817,7 +818,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
       '@radix-ui/react-primitive': 1.0.1_biqbaboplfbrettd7655fr4n2y
@@ -832,7 +833,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-use-layout-effect': 1.0.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -843,7 +844,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@floating-ui/react-dom': 0.7.2_zula6vjvt3wdocc4mwcxqa6nzi
       '@radix-ui/react-arrow': 1.0.1_biqbaboplfbrettd7655fr4n2y
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
@@ -866,7 +867,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-primitive': 1.0.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -878,7 +879,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
       '@radix-ui/react-use-layout-effect': 1.0.0_react@18.2.0
       react: 18.2.0
@@ -891,7 +892,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-slot': 1.0.1_react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -902,7 +903,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -913,7 +914,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/primitive': 1.0.0
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
       '@radix-ui/react-context': 1.0.0_react@18.2.0
@@ -937,7 +938,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       react: 18.2.0
     dev: false
 
@@ -946,7 +947,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-use-callback-ref': 1.0.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -956,7 +957,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-use-callback-ref': 1.0.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -966,7 +967,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       react: 18.2.0
     dev: false
 
@@ -975,7 +976,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/rect': 1.0.0
       react: 18.2.0
     dev: false
@@ -985,7 +986,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-use-layout-effect': 1.0.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -996,7 +997,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       '@radix-ui/react-primitive': 1.0.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1005,7 +1006,7 @@ packages:
   /@radix-ui/rect/1.0.0:
     resolution: {integrity: sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==}
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
     dev: false
 
   /@remix-run/router/1.3.2:
@@ -1029,27 +1030,27 @@ packages:
       remove-accents: 0.4.2
     dev: false
 
-  /@tanstack/query-core/4.24.6:
-    resolution: {integrity: sha512-Tfru6YTDTCpX7dKVwHp/sosw/dNjEdzrncduUjIkQxn7n7u+74HT2ZrGtwwrU6Orws4x7zp3FKRqBPWVVhpx9w==}
+  /@tanstack/query-core/4.24.9:
+    resolution: {integrity: sha512-pZQ2NpdaHzx8gPPkAPh06d6zRkjfonUzILSYBXrdHDapP2eaBbGsx5L4/dMF+fyAglFzQZdDDzZgAykbM20QVw==}
     dev: false
 
-  /@tanstack/react-query-devtools/4.24.6_r32zdxeb7iubg3qfkymfterewe:
-    resolution: {integrity: sha512-d8CN4ZTtLkdCNi9x4Hogma0fdhlv7ckknv/RLuV4nbUciUoZEvhg1cI0+vp/1aY4W3jq9vH0BD/eUQKecgY15Q==}
+  /@tanstack/react-query-devtools/4.24.9_bzphmdwvicyhtx5eo3azinrh54:
+    resolution: {integrity: sha512-NPsVf3pLMjH/XNTT5iP1q6isEBNE4kWF/IBSbxNUt0tDWK1nS1qgWr9ySTXwimsAHOWMjHkFuUF8VBRmz+axKg==}
     peerDependencies:
-      '@tanstack/react-query': 4.24.6
+      '@tanstack/react-query': 4.24.9
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@tanstack/match-sorter-utils': 8.7.6
-      '@tanstack/react-query': 4.24.6_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.24.9_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       superjson: 1.12.2
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: false
 
-  /@tanstack/react-query/4.24.6_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-pbJUVZCS4pcXS0kZiY+mVJ01ude0GrH5OXT2g9whcqSveRG/YVup/XdA9NdRpSMGkP2HxDRxxRNsTXkniWeIIA==}
+  /@tanstack/react-query/4.24.9_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-6WLwUT9mrngIinRtcZjrWOUENOuLbWvQpKmU6DZCo2iPQVA+qvv3Ji90Amme4AkUyWQ8ZSSRTnAFq8V2tj2ACg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -1060,7 +1061,7 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@tanstack/query-core': 4.24.6
+      '@tanstack/query-core': 4.24.9
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       use-sync-external-store: 1.2.0_react@18.2.0
@@ -1422,18 +1423,18 @@ packages:
       reduce-css-calc: 1.3.0
     dev: false
 
-  /@vitejs/plugin-react/3.1.0_vite@4.1.2:
+  /@vitejs/plugin-react/3.1.0_vite@4.1.3:
     resolution: {integrity: sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.1.0-beta.0
     dependencies:
-      '@babel/core': 7.20.12
-      '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
+      '@babel/core': 7.21.0
+      '@babel/plugin-transform-react-jsx-self': 7.21.0_@babel+core@7.21.0
+      '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.0
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.1.2
+      vite: 4.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1554,7 +1555,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       browserslist: 4.21.5
-      caniuse-lite: 1.0.30001456
+      caniuse-lite: 1.0.30001457
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -1596,8 +1597,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001456
-      electron-to-chromium: 1.4.301
+      caniuse-lite: 1.0.30001457
+      electron-to-chromium: 1.4.302
       node-releases: 2.0.10
       update-browserslist-db: 1.0.10_browserslist@4.21.5
     dev: true
@@ -1618,8 +1619,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  /caniuse-lite/1.0.30001456:
-    resolution: {integrity: sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==}
+  /caniuse-lite/1.0.30001457:
+    resolution: {integrity: sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==}
     dev: true
 
   /chalk/2.4.2:
@@ -1854,7 +1855,7 @@ packages:
     peerDependencies:
       react: '>=16.12.0'
     dependencies:
-      '@babel/runtime': 7.20.13
+      '@babel/runtime': 7.21.0
       compute-scroll-into-view: 2.0.4
       prop-types: 15.8.1
       react: 18.2.0
@@ -1862,8 +1863,8 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /electron-to-chromium/1.4.301:
-    resolution: {integrity: sha512-bz00ASIIDjcgszZKuEA1JEFhbDjqUNbQ/PEhNEl1wbixzYpeTp2H2QWjsQvAL2T1wJBdOwCF5hE896BoMwYKrA==}
+  /electron-to-chromium/1.4.302:
+    resolution: {integrity: sha512-Uk7C+7aPBryUR1Fwvk9VmipBcN9fVsqBO57jV2ZjTm+IZ6BMNqu7EDVEg2HxCNufk6QcWlFsBkhQyQroB2VWKw==}
     dev: true
 
   /es-abstract/1.21.1:
@@ -3135,8 +3136,8 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup/3.15.0:
-    resolution: {integrity: sha512-F9hrCAhnp5/zx/7HYmftvsNBkMfLfk/dXUh73hPSM2E3CRgap65orDNJbLetoiUFwSAk6iHPLvBrZ5iHYvzqsg==}
+  /rollup/3.17.2:
+    resolution: {integrity: sha512-qMNZdlQPCkWodrAZ3qnJtvCAl4vpQ8q77uEujVCCbC/6CLB7Lcmvjq7HyiOSnf4fxTT9XgsE36oLHJBH49xjqA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -3441,8 +3442,8 @@ packages:
     hasBin: true
     dev: false
 
-  /vite/4.1.2:
-    resolution: {integrity: sha512-MWDb9Rfy3DI8omDQySbMK93nQqStwbsQWejXRY2EBzEWKmLAXWb1mkI9Yw2IJrc+oCvPCI1Os5xSSIBYY6DEAw==}
+  /vite/4.1.3:
+    resolution: {integrity: sha512-0Zqo4/Fr/swSOBmbl+HAAhOjrqNwju+yTtoe4hQX9UsARdcuc9njyOdr6xU0DDnV7YP0RT6mgTTOiRtZgxfCxA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -3469,7 +3470,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.15.0
+      rollup: 3.17.2
     optionalDependencies:
       fsevents: 2.3.2
     dev: true

--- a/ui/rsl/src/api/protocol/motis/paxmon.ts
+++ b/ui/rsl/src/api/protocol/motis/paxmon.ts
@@ -340,7 +340,8 @@ export type PaxMonFilterGroupsSortOrder =
 export type PaxMonFilterGroupsTimeFilter =
   | "NoFilter"
   | "DepartureTime"
-  | "DepartureOrArrivalTime";
+  | "DepartureOrArrivalTime"
+  | "ActiveTime";
 
 // paxmon/PaxMonFilterGroupsRequest.fbs
 export interface PaxMonFilterGroupsRequest {
@@ -393,7 +394,8 @@ export type PaxMonFilterTripsSortOrder =
 export type PaxMonFilterTripsTimeFilter =
   | "NoFilter"
   | "DepartureTime"
-  | "DepartureOrArrivalTime";
+  | "DepartureOrArrivalTime"
+  | "ActiveTime";
 
 // paxmon/PaxMonFilterTripsRequest.fbs
 export interface PaxMonFilterTripsRequest {

--- a/ui/rsl/src/components/groups/GroupList.tsx
+++ b/ui/rsl/src/components/groups/GroupList.tsx
@@ -199,13 +199,9 @@ function GroupList(): JSX.Element {
       refetchOnWindowFocus: true,
       keepPreviousData: true,
       staleTime: 60000,
-      enabled: selectedDate != undefined,
     }
   );
 
-  if (selectedDate == undefined && scheduleInfo) {
-    setSelectedDate(fromUnixTime(scheduleInfo.begin));
-  }
   const minDate = scheduleInfo ? fromUnixTime(scheduleInfo.begin) : undefined;
   const maxDate =
     scheduleInfo && minDate

--- a/ui/rsl/src/components/groups/GroupList.tsx
+++ b/ui/rsl/src/components/groups/GroupList.tsx
@@ -107,7 +107,7 @@ function getFilterGroupsRequest(
     filter_by_group_id: filterGroupIds,
     filter_by_data_source: filterDataSources,
     filter_by_train_nr: filterTrainNrs,
-    filter_by_time: selectedDate ? "DepartureOrArrivalTime" : "NoFilter",
+    filter_by_time: selectedDate ? "ActiveTime" : "NoFilter",
     filter_interval: {
       begin: selectedDate ? getUnixTime(selectedDate) : 0,
       end: selectedDate ? getUnixTime(add(selectedDate, { days: 1 })) : 0,

--- a/ui/rsl/src/components/trips/TripList.tsx
+++ b/ui/rsl/src/components/trips/TripList.tsx
@@ -141,13 +141,9 @@ function TripList(): JSX.Element {
       refetchOnWindowFocus: false,
       keepPreviousData: true,
       staleTime: 60000,
-      enabled: selectedDate != undefined,
     }
   );
 
-  if (selectedDate == undefined && scheduleInfo) {
-    setSelectedDate(fromUnixTime(scheduleInfo.begin));
-  }
   const minDate = scheduleInfo ? fromUnixTime(scheduleInfo.begin) : undefined;
   const maxDate =
     scheduleInfo && minDate

--- a/ui/rsl/src/components/trips/TripList.tsx
+++ b/ui/rsl/src/components/trips/TripList.tsx
@@ -72,7 +72,7 @@ function getFilterTripsRequest(
     sort_by: sortOrder,
     max_results: 100,
     skip_first: pageParam,
-    filter_by_time: selectedDate ? "DepartureOrArrivalTime" : "NoFilter",
+    filter_by_time: selectedDate ? "ActiveTime" : "NoFilter",
     filter_interval: {
       begin: selectedDate ? getUnixTime(selectedDate) : 0,
       end: selectedDate ? getUnixTime(add(selectedDate, { days: 1 })) : 0,


### PR DESCRIPTION
- API:
  - Add new active time filter option for trip + group filter APIs (trip/group must be active/en route in the given time window)
  - `/paxforecast/apply_measures`: Return an error if rt updates can't be parsed (partially applied measures won't be rolled back)
- Web UI:
  - Date filter is now optional for trips + groups
  - The new active time filter is used if a date is selected
- Config:
  - New option to split journeys with long wait times at a station into separate groups: `paxmon.max_station_wait_time`