### PR TITLE
fix valgrind error reporting in CI

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -286,7 +286,7 @@ jobs:
             skipui: true
           - preset: linux-debug
             skipui: true
-            emulator: valgrind --error-exitcode=1
+            emulator: valgrind --leak-check=full --error-exitcode=1
     env:
       BUILDCACHE_DIR: /buildcache
       BUILDCACHE_DIRECT_MODE: true


### PR DESCRIPTION
valgrind ci: --leak-check=full

"--leak-check=full or yes is critical for --error-exitcode to behave as expected (depending on your use case). Without it, the leak errors will be suppressed and not reported in the exit code (valgrind 3.10 doesn't even report them as suppressed)"

https://stackoverflow.com/questions/19246470/how-to-get-in-script-whether-valgrind-found-memory-leaks#comment41024234_19246806