### PR TITLE
Fixes for RI Basis + RSL RT

### DIFF
--- a/base/loader/include/motis/loader/graph_builder.h
+++ b/base/loader/include/motis/loader/graph_builder.h
@@ -240,7 +240,7 @@ struct graph_builder {
                 deep_ptr_eq<connection>>
       connections_;
   mcd::hash_map<flatbuffers64::String const*, mcd::string*> filenames_;
-  mcd::hash_set<full_trip_id> added_full_trip_ids_;
+  mcd::hash_map<full_trip_id, trip_idx_t> added_full_trip_ids_;
   schedule& sched_;
   int first_day_{0}, last_day_{0};
   bool apply_rules_{false};

--- a/base/loader/include/motis/loader/graph_builder.h
+++ b/base/loader/include/motis/loader/graph_builder.h
@@ -3,6 +3,7 @@
 #include <ctime>
 #include <array>
 #include <map>
+#include <optional>
 #include <set>
 
 #include "flatbuffers/flatbuffers.h"
@@ -135,9 +136,10 @@ struct graph_builder {
 
   full_trip_id get_full_trip_id(Service const* s, int day, int section_idx = 0);
 
-  merged_trips_idx create_merged_trips(Service const* s, int day_idx);
+  std::optional<merged_trips_idx> create_merged_trips(Service const* s,
+                                                      int day_idx);
 
-  trip* register_service(Service const* s, int day_idx);
+  trip* register_service(Service const* s, int day_idx, bool allow_duplicates);
 
   void add_services(
       flatbuffers64::Vector<flatbuffers64::Offset<Service>> const* services);
@@ -238,6 +240,7 @@ struct graph_builder {
                 deep_ptr_eq<connection>>
       connections_;
   mcd::hash_map<flatbuffers64::String const*, mcd::string*> filenames_;
+  mcd::hash_set<full_trip_id> added_full_trip_ids_;
   schedule& sched_;
   int first_day_{0}, last_day_{0};
   bool apply_rules_{false};

--- a/base/loader/src/rule_service_graph_builder.cc
+++ b/base/loader/src/rule_service_graph_builder.cc
@@ -6,12 +6,13 @@
 #include <set>
 #include <vector>
 
+#include "utl/get_or_create.h"
+
 #include "motis/core/common/logging.h"
 #include "motis/core/schedule/price.h"
 #include "motis/core/schedule/trip.h"
 #include "motis/core/access/trip_iterator.h"
 #include "motis/loader/util.h"
-#include "utl/get_or_create.h"
 
 #include "motis/schedule-format/Schedule_generated.h"
 
@@ -304,8 +305,9 @@ struct rule_service_route_builder {
                         return ptr<trip>{utl::get_or_create(
                             single_trips_,
                             std::make_pair(sp.service_, s_day_idx), [&]() {
+                              // TODO(pablo): handle duplicate trip id
                               return gb_.register_service(sp.service_,
-                                                          s_day_idx);
+                                                          s_day_idx, true);
                             })};
                       })));
     });

--- a/base/loader/src/rule_service_graph_builder.cc
+++ b/base/loader/src/rule_service_graph_builder.cc
@@ -546,11 +546,20 @@ struct rule_service_route_builder {
         return;
       }
     }
-    utl::verify(std::find_if(begin(s1_node->edges_), end(s1_node->edges_),
-                             [](edge const& e) {
-                               return e.type() == edge::THROUGH_EDGE;
-                             }) == end(s1_node->edges_),
-                "multiple outgoing through edges");
+    if (std::find_if(begin(s1_node->edges_), end(s1_node->edges_),
+                     [](edge const& e) {
+                       return e.type() == edge::THROUGH_EDGE;
+                     }) != end(s1_node->edges_)) {
+      auto const s1_debug = r->service1()->debug();
+      auto const s2_debug = r->service2()->debug();
+      LOG(warn) << "multiple outgoing through edges: "
+                << s1_debug->file()->view() << " lines "
+                << s1_debug->line_from() << "-" << s1_debug->line_to() << " -> "
+                << s2_debug->file()->view() << " lines "
+                << s2_debug->line_from() << "-" << s2_debug->line_to()
+                << " at station " << r->from()->id()->view() << " "
+                << r->from()->name()->view();
+    }
     s1_node->edges_.push_back(make_through_edge(s1_node, s2_node));
     through_target_nodes_.insert(s2_node);
   }

--- a/modules/paxmon/include/motis/paxmon/checks.h
+++ b/modules/paxmon/include/motis/paxmon/checks.h
@@ -9,7 +9,8 @@ namespace motis::paxmon {
 bool check_graph_integrity(universe const& uv, schedule const& sched);
 
 bool check_trip_in_sync(universe const& uv, schedule const& sched,
-                        trip const* trp, trip_data_index const tdi);
+                        trip const* trp, trip_data_index tdi,
+                        bool check_times = true);
 
 bool check_graph_times(universe const& uv, schedule const& sched);
 

--- a/modules/paxmon/src/capacity.cc
+++ b/modules/paxmon/src/capacity.cc
@@ -186,18 +186,15 @@ std::optional<std::pair<std::uint16_t, capacity_source>> get_trip_capacity(
 
 trip_formation const* get_trip_formation(capacity_maps const& caps,
                                          trip const* trp) {
-  auto trip_uuid = trp->uuid_;
-  if (trip_uuid.is_nil()) {
-    if (auto const it = caps.trip_uuid_map_.find(trp->id_.primary_);
-        it != end(caps.trip_uuid_map_)) {
-      trip_uuid = it->second;
+  if (auto const it = caps.trip_uuid_map_.find(trp->id_.primary_);
+      it != end(caps.trip_uuid_map_)) {
+    auto const trip_uuid = it->second;
+    if (auto const it = caps.trip_formation_map_.find(trip_uuid);
+        it != end(caps.trip_formation_map_)) {
+      return &it->second;
     } else {
       return nullptr;
     }
-  }
-  if (auto const it = caps.trip_formation_map_.find(trip_uuid);
-      it != end(caps.trip_formation_map_)) {
-    return &it->second;
   } else {
     return nullptr;
   }

--- a/modules/paxmon/src/checks.cc
+++ b/modules/paxmon/src/checks.cc
@@ -10,7 +10,10 @@
 
 #include "motis/core/access/realtime_access.h"
 #include "motis/core/access/trip_access.h"
+#include "motis/core/conv/trip_conv.h"
 #include "motis/core/debug/trip.h"
+
+#include "motis/module/context/motis_call.h"
 
 #include "motis/paxmon/debug.h"
 #include "motis/paxmon/reachability.h"
@@ -205,7 +208,8 @@ bool check_graph_integrity(universe const& uv, schedule const& sched) {
 }
 
 bool check_trip_in_sync(universe const& uv, schedule const& sched,
-                        trip const* trp, trip_data_index const tdi) {
+                        trip const* trp, trip_data_index const tdi,
+                        bool const check_times) {
   auto trip_ok = true;
   std::vector<event_node const*> nodes;
   auto const edges = uv.trip_data_.edges(tdi);
@@ -238,29 +242,31 @@ bool check_trip_in_sync(universe const& uv, schedule const& sched,
       }
       if (pm_from->station_idx() == ev_from.get_station_idx() &&
           pm_to->station_idx() == ev_to.get_station_idx()) {
-        if (pm_from->schedule_time() != get_schedule_time(sched, ev_from)) {
-          std::cout << "!! schedule time mismatch @dep "
-                    << sched.stations_.at(pm_from->station_idx())->name_.str()
-                    << "\n";
-          trip_ok = false;
-        }
-        if (pm_to->schedule_time() != get_schedule_time(sched, ev_to)) {
-          std::cout << "!! schedule time mismatch @arr "
-                    << sched.stations_.at(pm_to->station_idx())->name_.str()
-                    << "\n";
-          trip_ok = false;
-        }
-        if (pm_from->current_time() != ev_from.get_time()) {
-          std::cout << "!! current time mismatch @dep "
-                    << sched.stations_.at(pm_from->station_idx())->name_.str()
-                    << "\n";
-          trip_ok = false;
-        }
-        if (pm_to->current_time() != ev_to.get_time()) {
-          std::cout << "!! current time mismatch @arr "
-                    << sched.stations_.at(pm_to->station_idx())->name_.str()
-                    << "\n";
-          trip_ok = false;
+        if (check_times) {
+          if (pm_from->schedule_time() != get_schedule_time(sched, ev_from)) {
+            std::cout << "!! schedule time mismatch @dep "
+                      << sched.stations_.at(pm_from->station_idx())->name_.str()
+                      << "\n";
+            trip_ok = false;
+          }
+          if (pm_to->schedule_time() != get_schedule_time(sched, ev_to)) {
+            std::cout << "!! schedule time mismatch @arr "
+                      << sched.stations_.at(pm_to->station_idx())->name_.str()
+                      << "\n";
+            trip_ok = false;
+          }
+          if (pm_from->current_time() != ev_from.get_time()) {
+            std::cout << "!! current time mismatch @dep "
+                      << sched.stations_.at(pm_from->station_idx())->name_.str()
+                      << "\n";
+            trip_ok = false;
+          }
+          if (pm_to->current_time() != ev_to.get_time()) {
+            std::cout << "!! current time mismatch @arr "
+                      << sched.stations_.at(pm_to->station_idx())->name_.str()
+                      << "\n";
+            trip_ok = false;
+          }
         }
       } else {
         std::cout << "!! station mismatch: section " << node_idx / 2
@@ -292,10 +298,49 @@ bool check_trip_in_sync(universe const& uv, schedule const& sched,
     print_trip(sched, trp);
     std::cout << "  sections: " << std::distance(begin(sections), end(sections))
               << ", td edges: " << edges.size()
-              << ", event nodes: " << nodes.size() << std::endl;
+              << ", event nodes: " << nodes.size() << ", tdi: " << tdi
+              << std::endl;
 
     print_trip_sections(uv, sched, trp, tdi);
-    std::cout << "\n" << std::endl;
+
+    mcd::hash_set<trip const*> merged_trips;
+    merged_trips.insert(trp);
+
+    for (auto const ei : edges) {
+      for (auto const& mt :
+           *sched.merged_trips_.at(ei.get(uv)->get_merged_trips_idx())) {
+        merged_trips.insert(mt);
+      }
+    }
+
+    for (auto const& sec : sections) {
+      for (auto const& mt : *sched.merged_trips_.at(sec.lcon().trips_)) {
+        merged_trips.insert(mt);
+      }
+    }
+
+    for (auto const mt : merged_trips) {
+      std::cout << "\nrt updates for " << debug::trip{sched, mt} << ":\n";
+      try {
+        using namespace motis::module;
+        using namespace motis::rt;
+        message_creator mc;
+        mc.create_and_finish(
+            MsgContent_RtMessageHistoryRequest,
+            CreateRtMessageHistoryRequest(mc, 0, to_fbs(sched, mc, mt)).Union(),
+            "/rt/message_history");
+        auto const req = make_msg(mc);
+        auto const res = motis_call(req)->val();
+        std::cout << res->to_json(json_format::CONTENT_ONLY_TYPES_IN_UNIONS)
+                  << std::endl;
+      } catch (std::system_error const& e) {
+        std::cout << "could not get message history for trip (system_error): "
+                  << e.what() << std::endl;
+      } catch (std::runtime_error const& e) {
+        std::cout << "could not get message history for trip (runtime_error): "
+                  << e.what() << std::endl;
+      }
+    }
   }
 
   return trip_ok;

--- a/modules/paxmon/src/debug.cc
+++ b/modules/paxmon/src/debug.cc
@@ -12,13 +12,15 @@ namespace motis::paxmon {
 
 void print_trip(schedule const& sched, trip const* trp) {
   fmt::print(
-      "    trip: {:7} / {:10} / {:5} / {:7} / {:10} / {} [ptr={}, debug={}]\n",
+      "    trip: {:7} / {:10} / {:5} / {:7} / {:10} / {} [idx={}, ptr={}, "
+      "debug={}]\n",
       sched.stations_.at(trp->id_.primary_.get_station_id())->eva_nr_.view(),
       format_time(trp->id_.primary_.get_time()), trp->id_.primary_.train_nr_,
       sched.stations_.at(trp->id_.secondary_.target_station_id_)
           ->eva_nr_.view(),
       format_time(trp->id_.secondary_.target_time_),
-      trp->id_.secondary_.line_id_, static_cast<void const*>(trp), trp->dbg_);
+      trp->id_.secondary_.line_id_, trp->trip_idx_,
+      static_cast<void const*>(trp), trp->dbg_);
   fmt::print("    {}\n", debug::to_fbs_json(sched, trp));
 }
 
@@ -53,6 +55,18 @@ void print_final_footpath(schedule const& sched, final_footpath const& fp) {
   }
 }
 
+void print_merged_trips(mcd::vector<ptr<trip>> const* merged_trips) {
+  if (merged_trips->size() > 1) {
+    fmt::print(" [{} trips:", merged_trips->size());
+    for (auto const& mt : *merged_trips) {
+      fmt::print(" {}", mt->trip_idx_);
+    }
+    fmt::print("]\n");
+  } else {
+    fmt::print("\n");
+  }
+}
+
 void print_trip_section(schedule const& sched,
                         motis::access::trip_section const& ts) {
   auto const cur_dep_time = ts.ev_key_from().get_time();
@@ -61,7 +75,7 @@ void print_trip_section(schedule const& sched,
   auto const cur_arr_time = ts.ev_key_to().get_time();
   auto const sched_arr_time = get_schedule_time(sched, ts.ev_key_to());
   auto const& to_station = ts.to_station(sched);
-  auto const& merged_trips = sched.merged_trips_.at(ts.lcon().trips_);
+  auto const merged_trips = sched.merged_trips_.at(ts.lcon().trips_).get();
   fmt::print(
       "  {:7} [{:7}] {:7} {:50} -> {:7} [{:7}] {:7} {:50} [lc={}, "
       "merged_trips={}]",
@@ -70,11 +84,7 @@ void print_trip_section(schedule const& sched,
       format_time(cur_arr_time), format_time(sched_arr_time),
       to_station.eva_nr_.str(), to_station.name_.str(),
       static_cast<void const*>(&ts.lcon()), ts.lcon().trips_);
-  if (merged_trips->size() > 1) {
-    fmt::print(" [{} trips]\n", merged_trips->size());
-  } else {
-    fmt::print("\n");
-  }
+  print_merged_trips(merged_trips);
 }
 
 void print_trip_edge(schedule const& sched, universe const& uv, edge const* e) {
@@ -84,17 +94,14 @@ void print_trip_edge(schedule const& sched, universe const& uv, edge const* e) {
   auto const cur_arr_time = e->to(uv)->current_time();
   auto const sched_arr_time = e->to(uv)->schedule_time();
   auto const& to_station = e->to(uv)->get_station(sched);
-  auto const& merged_trips = sched.merged_trips_.at(e->get_merged_trips_idx());
+  auto const& merged_trips =
+      sched.merged_trips_.at(e->get_merged_trips_idx()).get();
   fmt::print("  {:7} [{:7}] {:7} {:50} -> {:7} [{:7}] {:7} {:50}",
              format_time(cur_dep_time), format_time(cur_sched_time),
              from_station.eva_nr_.str(), from_station.name_.str(),
              format_time(cur_arr_time), format_time(sched_arr_time),
              to_station.eva_nr_.str(), to_station.name_.str());
-  if (merged_trips->size() > 1) {
-    fmt::print(" [{} trips]\n", merged_trips->size());
-  } else {
-    fmt::print("\n");
-  }
+  print_merged_trips(merged_trips);
 }
 
 void print_trip_sections(universe const& uv, schedule const& sched,

--- a/modules/paxmon/src/trip_formation_update.cc
+++ b/modules/paxmon/src/trip_formation_update.cc
@@ -92,8 +92,8 @@ void update_trip_formation(schedule const& sched, universe& uv,
                            motis::ris::TripFormationMessage const* tfm) {
   auto const trip_uuid = parse_uuid(view(tfm->trip_id()->uuid()));
   primary_trip_id ptid;
-  auto has_ptid = false;
-  if ((has_ptid = get_primary_trip_id(sched, tfm->trip_id(), ptid))) {
+  auto const has_ptid = get_primary_trip_id(sched, tfm->trip_id(), ptid);
+  if (has_ptid) {
     if (auto it = uv.capacity_maps_.trip_uuid_map_.find(ptid);
         it != end(uv.capacity_maps_.trip_uuid_map_)) {
       if (it->second != trip_uuid) {

--- a/modules/paxmon/src/trip_formation_update.cc
+++ b/modules/paxmon/src/trip_formation_update.cc
@@ -1,7 +1,13 @@
 #include "motis/paxmon/trip_formation_update.h"
 
 #include <algorithm>
+#include <iostream>
 #include <string_view>
+
+#include "boost/uuid/uuid_io.hpp"
+
+#include "motis/core/common/date_time_util.h"
+#include "motis/core/debug/trip.h"
 
 #include "motis/rt/util.h"
 #include "motis/vector.h"
@@ -55,12 +61,75 @@ trip_formation_section to_trip_formation_section(
   return sec;
 }
 
+trip* find_trip_by_primary_trip_id(schedule const& sched,
+                                   primary_trip_id const& ptid,
+                                   boost::uuids::uuid const& trip_uuid) {
+  trip* result = nullptr;
+  auto matching_trips = 0;
+  for (auto it =
+           std::lower_bound(begin(sched.trips_), end(sched.trips_),
+                            std::make_pair(ptid, static_cast<trip*>(nullptr)));
+       it != end(sched.trips_) && it->first == ptid; ++it) {
+    result = it->second;
+    ++matching_trips;
+  }
+  if (matching_trips > 1) {
+    std::cout << "[UTF-06] found " << matching_trips
+              << " matching trips by primary id: (formation trip uuid: "
+              << trip_uuid << ")" << std::endl;
+    for (auto it = std::lower_bound(
+             begin(sched.trips_), end(sched.trips_),
+             std::make_pair(ptid, static_cast<trip*>(nullptr)));
+         it != end(sched.trips_) && it->first == ptid; ++it) {
+      std::cout << "  " << debug::trip{sched, it->second} << std::endl;
+    }
+  }
+  // only return trip if there is an unambiguous match
+  return matching_trips == 1 ? result : nullptr;
+}
+
 void update_trip_formation(schedule const& sched, universe& uv,
                            motis::ris::TripFormationMessage const* tfm) {
   auto const trip_uuid = parse_uuid(view(tfm->trip_id()->uuid()));
   primary_trip_id ptid;
-  if (get_primary_trip_id(sched, tfm->trip_id(), ptid)) {
+  auto has_ptid = false;
+  if ((has_ptid = get_primary_trip_id(sched, tfm->trip_id(), ptid))) {
+    if (auto it = uv.capacity_maps_.trip_uuid_map_.find(ptid);
+        it != end(uv.capacity_maps_.trip_uuid_map_)) {
+      if (it->second != trip_uuid) {
+        std::cout << "[UTF-01] trip uuid CHANGED: " << it->second << " -> "
+                  << trip_uuid << "\n  ptid: train_nr=" << ptid.get_train_nr()
+                  << ", station="
+                  << sched.stations_[ptid.get_station_id()]->name_
+                  << ", time=" << format_time(ptid.get_time()) << std::endl;
+      }
+      if (auto tf_it = uv.capacity_maps_.trip_formation_map_.find(trip_uuid);
+          tf_it == end(uv.capacity_maps_.trip_formation_map_)) {
+        std::cout << "[UTF-02] trip primary id found, but uuid not found: uuid="
+                  << trip_uuid << ", train_nr=" << ptid.get_train_nr()
+                  << ", station="
+                  << sched.stations_[ptid.get_station_id()]->name_
+                  << ", time=" << format_time(ptid.get_time()) << std::endl;
+      }
+    } else {
+      if (auto tf_it = uv.capacity_maps_.trip_formation_map_.find(trip_uuid);
+          tf_it != end(uv.capacity_maps_.trip_formation_map_)) {
+        std::cout << "[UTF-03] trip primary id not found, but uuid found: uuid="
+                  << trip_uuid << ", train_nr=" << ptid.get_train_nr()
+                  << ", station="
+                  << sched.stations_[ptid.get_station_id()]->name_
+                  << ", time=" << format_time(ptid.get_time()) << std::endl;
+      }
+    }
     uv.capacity_maps_.trip_uuid_map_[ptid] = trip_uuid;
+  } else {
+    auto const& tid = tfm->trip_id()->id();
+    std::cout << "[UTF-04] station from trip id not found: {station_id="
+              << tid->station_id()->str() << ", train_nr=" << tid->train_nr()
+              << ", time=" << tid->time() << " ("
+              << format_unix_time(tid->time())
+              << ")}, uuid=" << tfm->trip_id()->uuid()->str() << ", "
+              << tfm->sections()->size() << " sections" << std::endl;
   }
 
   auto& formation = uv.capacity_maps_.trip_formation_map_[trip_uuid];
@@ -69,9 +138,11 @@ void update_trip_formation(schedule const& sched, universe& uv,
         return to_trip_formation_section(sched, sec);
       });
 
-  if (auto const it = sched.uuid_to_trip_.find(trip_uuid);
-      it != end(sched.uuid_to_trip_)) {
-    update_trip_capacity(uv, sched, it->second);
+  if (has_ptid) {
+    if (auto* trp = find_trip_by_primary_trip_id(sched, ptid, trip_uuid);
+        trp != nullptr) {
+      update_trip_capacity(uv, sched, trp);
+    }
   }
 }
 

--- a/modules/rt/include/motis/rt/trip_formation_handler.h
+++ b/modules/rt/include/motis/rt/trip_formation_handler.h
@@ -1,10 +1,5 @@
 #pragma once
 
-#include <map>
-#include <vector>
-
-#include "motis/core/schedule/schedule.h"
-
 #include "motis/module/message.h"
 
 #include "motis/rt/statistics.h"
@@ -12,7 +7,7 @@
 
 namespace motis::rt {
 
-void handle_trip_formation_msg(statistics& stats, schedule& sched,
+void handle_trip_formation_msg(statistics& stats,
                                update_msg_builder& update_builder,
                                ris::TripFormationMessage const* msg);
 

--- a/modules/rt/src/full_trip_handler.cc
+++ b/modules/rt/src/full_trip_handler.cc
@@ -145,10 +145,6 @@ struct full_trip_handler {
 
       if (rule_service) {
         ++stats_.reroute_rule_service_not_supported_;
-        if (debug_) {
-          LOG(info) << "[FTH] ignoring message because reroute of rule "
-                       "services is not supported";
-        }
         return;
       }
 

--- a/modules/rt/src/full_trip_handler.cc
+++ b/modules/rt/src/full_trip_handler.cc
@@ -129,6 +129,7 @@ struct full_trip_handler {
     result_.is_reroute_ = !is_same_route(existing_sections, sections);
 
     if (is_reroute()) {
+      auto const rule_service = is_rule_service(result_.trp_);
       if (is_new_trip()) {
         ++stats_.additional_msgs_;
         ++stats_.additional_total_;
@@ -137,11 +138,18 @@ struct full_trip_handler {
         ++stats_.cancel_msgs_;
       } else {
         ++stats_.reroute_msgs_;
-        if (is_rule_service(result_.trp_)) {
-          ++stats_.reroute_rule_service_not_supported_;
-          return;
+        if (!rule_service) {
+          ++stats_.reroute_ok_;
         }
-        ++stats_.reroute_ok_;
+      }
+
+      if (rule_service) {
+        ++stats_.reroute_rule_service_not_supported_;
+        if (debug_) {
+          LOG(info) << "[FTH] ignoring message because reroute of rule "
+                       "services is not supported";
+        }
+        return;
       }
 
       auto const canceled_ev_keys =

--- a/modules/rt/src/rt_handler.cc
+++ b/modules/rt/src/rt_handler.cc
@@ -278,7 +278,7 @@ void rt_handler::update(motis::ris::RISMessage const* m,
 
     case ris::RISMessageUnion_TripFormationMessage: {
       handle_trip_formation_msg(
-          stats_, sched_, update_builder_,
+          stats_, update_builder_,
           reinterpret_cast<ris::TripFormationMessage const*>(c));
       break;
     }

--- a/modules/rt/src/trip_formation_handler.cc
+++ b/modules/rt/src/trip_formation_handler.cc
@@ -1,25 +1,8 @@
 #include "motis/rt/trip_formation_handler.h"
 
-#include "motis/rt/util.h"
-
 namespace motis::rt {
 
-trip* find_trip_by_primary_trip_id(schedule const& sched,
-                                   primary_trip_id const& ptid) {
-  trip* result = nullptr;
-  auto matching_trips = 0;
-  for (auto it =
-           std::lower_bound(begin(sched.trips_), end(sched.trips_),
-                            std::make_pair(ptid, static_cast<trip*>(nullptr)));
-       it != end(sched.trips_) && it->first == ptid; ++it) {
-    result = it->second;
-    ++matching_trips;
-  }
-  // only return trip if there is an unambiguous match
-  return matching_trips == 1 ? result : nullptr;
-}
-
-void handle_trip_formation_msg(statistics& stats, schedule& sched,
+void handle_trip_formation_msg(statistics& stats,
                                update_msg_builder& update_builder,
                                ris::TripFormationMessage const* msg) {
   ++stats.trip_formation_msgs_;

--- a/modules/rt/src/trip_formation_handler.cc
+++ b/modules/rt/src/trip_formation_handler.cc
@@ -24,21 +24,6 @@ void handle_trip_formation_msg(statistics& stats, schedule& sched,
                                ris::TripFormationMessage const* msg) {
   ++stats.trip_formation_msgs_;
   update_builder.trip_formation_message(msg);
-
-  // store trip uuid mapping
-  primary_trip_id ptid;
-  if (get_primary_trip_id(sched, msg->trip_id(), ptid)) {
-    auto const trip_uuid = parse_uuid(view(msg->trip_id()->uuid()));
-    if (sched.uuid_to_trip_.find(trip_uuid) != end(sched.uuid_to_trip_)) {
-      return;
-    }
-    if (auto* trp = find_trip_by_primary_trip_id(sched, ptid); trp != nullptr) {
-      sched.uuid_to_trip_[trip_uuid] = trp;
-      if (trp->uuid_.is_nil()) {
-        trp->uuid_ = trip_uuid;
-      }
-    }
-  }
 }
 
 }  // namespace motis::rt

--- a/modules/rt/src/update_msg_builder.cc
+++ b/modules/rt/src/update_msg_builder.cc
@@ -291,7 +291,7 @@ msg_ptr update_msg_builder::finish() {
           schedule_res_id_)
           .Union(),
       "/rt/update", DestinationType_Topic);
-  auto const msg = make_msg(fbb_);
+  auto msg = make_msg(fbb_);
   reset();
   return msg;
 }

--- a/modules/rt/src/update_msg_builder.cc
+++ b/modules/rt/src/update_msg_builder.cc
@@ -166,6 +166,7 @@ void update_msg_builder::reset() {
   separated_trips_.clear();
   previous_reroute_update_.clear();
   previous_trip_formation_update_.clear();
+  previous_track_update_.clear();
   delay_count_ = 0;
   reroute_count_ = 0;
 }
@@ -290,7 +291,9 @@ msg_ptr update_msg_builder::finish() {
           schedule_res_id_)
           .Union(),
       "/rt/update", DestinationType_Topic);
-  return make_msg(fbb_);
+  auto const msg = make_msg(fbb_);
+  reset();
+  return msg;
 }
 
 }  // namespace motis::rt


### PR DESCRIPTION
- RT: Fix intermediate update flag
- RI Basis: Ignore cancellations for rule services
- Graph Builder: Don't create services with duplicate trip ids (currently only for non rule services)
- Allow multiple outgoing through edges (error changed to warning)
- Fixes for Ri Basis Fahrt + Formation support (RT + RSL)