### PR TITLE
clang-tidy: disable identifier checks

### DIFF
--- a/.clang-tidy.in
+++ b/.clang-tidy.in
@@ -73,7 +73,12 @@ Checks: "*,\
 -cppcoreguidelines-avoid-const-or-ref-data-members,\
 -cppcoreguidelines-avoid-do-while,\
 -altera-struct-pack-align,\
--bugprone-unchecked-optional-access"
+-bugprone-unchecked-optional-access,\
+-readability-identifier-naming,\
+-cert-dcl37-c,\
+-bugprone-reserved-identifier,\
+-cert-dcl51-cpp,\
+-misc-confusable-identifiers"
 WarningsAsErrors: '*'
 HeaderFilterRegex: '^${RELATIVE_SOURCE_DIR}(base|modules|test)/'
 AnalyzeTemporaryDtors: false

--- a/modules/ris/src/ris.cc
+++ b/modules/ris/src/ris.cc
@@ -379,8 +379,9 @@ struct ris::impl {
 
     if (config_.clear_db_ && fs::exists(config_.db_path_)) {
       LOG(info) << "clearing database path " << config_.db_path_;
-      fs::remove_all(config_.db_path_);
-      fs::remove_all(config_.db_path_ + "-lock");
+      std::error_code ec;
+      fs::remove_all(config_.db_path_, ec);
+      fs::remove_all(config_.db_path_ + "-lock", ec);
     }
 
     env_.set_maxdbs(6);

--- a/modules/routing/src/eval/xtract.cc
+++ b/modules/routing/src/eval/xtract.cc
@@ -105,9 +105,10 @@ void create_base_copy(schedule_format const format, fs::path const& src,
   };
 
   auto const abs_src = absolute(src);
+  auto ec = std::error_code{};
   switch (format) {
     case schedule_format::kGTFS:
-      fs::remove_all(dest);
+      fs::remove_all(dest, ec);
       fs::create_directories(dest);
       link_if_exists(abs_src / AGENCY_FILE, dest / AGENCY_FILE);
       link_if_exists(abs_src / STOPS_FILE, dest / STOPS_FILE);
@@ -121,7 +122,7 @@ void create_base_copy(schedule_format const format, fs::path const& src,
       break;
 
     case schedule_format::kHRD:
-      fs::remove_all(dest);
+      fs::remove_all(dest, ec);
       fs::create_directories(dest / SCHEDULE_DATA);
       fs::create_symlink(abs_src / CORE_DATA, dest / CORE_DATA);
       std::ofstream{dest / SCHEDULE_DATA / "services.txt"}.write("", 0);


### PR DESCRIPTION
profiling result: https://gist.github.com/felixguendling/d0b34bf4d5e15773c0bf83c291124c9f

TODO: enable when performance improves

https://github.com/llvm/llvm-project/issues/61418
https://discourse.llvm.org/t/rfc-exclude-issues-from-system-headers-as-early-as-posible/68483/10