### PR TITLE
Update README: fix broken/outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The core features are:
   
 More detailed information can be found at [motis-project.de](https://motis-project.de).
 
-To demonstrate the functionalities, an [Android App](https://play.google.com/store/apps/details?id=de.motis_project.demo) and a [web-based information system](https://demo.motis-project.de/) is available. The source code for both front-ends is available as Open Source Software [as well](https://github.com/motis-project/motis/tree/master/scripts).
+To demonstrate the functionalities, an [Android App](https://play.google.com/store/apps/details?id=de.motis_project.demo) and a [web-based information system](https://europe.motis-project.de/) is available. The source code for both front-ends is available as Open Source Software [as well](https://github.com/motis-project/motis/tree/master/ui).
 
-The system can consume schedule timetables in the [GTFS](https://developers.google.com/transit/gtfs/) or [HAFAS](https://www.fahrplanfelder.ch/fileadmin/fap_daten_test/hrdf.pdf) format as well as real time information in the [GTFS-RT](https://developers.google.com/transit/gtfs-realtime/reference) (and RISML, a propriatary format at Deutsche Bahn) as input data. For pedestrian routing (handled by [Per Pedes Routing](https://github.com/motis-project/ppr)) and car routing (handled by [OSRM](https://github.com/Project-OSRM/osrm-backend)) OpenStreetMap data is used.
+The system can consume schedule timetables in the [GTFS](https://developers.google.com/transit/gtfs/) or [HAFAS](https://www.öv-info.ch/sites/default/files/2023-07/hrdf_2_0_5_e.pdf) format as well as real time information in the [GTFS-RT](https://developers.google.com/transit/gtfs-realtime/reference) (and RISML, a propriatary format at Deutsche Bahn) as input data. For pedestrian routing (handled by [Per Pedes Routing](https://github.com/motis-project/ppr)) and car routing (handled by [OSRM](https://github.com/Project-OSRM/osrm-backend)) OpenStreetMap data is used.
 
 # Documentation
 
-  - [Installation and Setup](https://motis-project.de/docs/install)
+  - [Installation and Setup](https://github.com/motis-project/motis/wiki/Installation-and-Setup)
   - [API Documentation](https://motis-project.de/docs/api/)
   - Developer Setup:
     - [Windows Developer Setup](https://github.com/motis-project/motis/wiki/Windows-Developer-Setup)


### PR DESCRIPTION
When I went through the Readme.md I found some 404 or outdated links, which I replaced by my best knowledge with working/ updated links.