### PR TITLE
Fix station name in nigiri geo lookup responses

### DIFF
--- a/modules/nigiri/src/geo_station_lookup.cc
+++ b/modules/nigiri/src/geo_station_lookup.cc
@@ -31,7 +31,7 @@ motis::module::msg_ptr geo_station_lookup(station_lookup const& index,
                         mc,
                         mc.CreateString(
                             fmt::format("{}{}", station.tag_, station.id_)),
-                        mc.CreateString(station.id_), &pos);
+                        mc.CreateString(station.name_), &pos);
                   })))
           .Union());
   return mm::make_msg(mc);


### PR DESCRIPTION
This was previously returning the id in the name field as well.