### PR TITLE
Allow to set a timeout for searches

### DIFF
--- a/modules/intermodal/include/motis/intermodal/intermodal.h
+++ b/modules/intermodal/include/motis/intermodal/intermodal.h
@@ -26,6 +26,7 @@ private:
 
   std::string router_{"routing"};
   bool revise_{false};
+  unsigned timeout_{0};
   ppr_profiles ppr_profiles_;
 };
 

--- a/modules/intermodal/src/intermodal.cc
+++ b/modules/intermodal/src/intermodal.cc
@@ -38,6 +38,7 @@ namespace motis::intermodal {
 intermodal::intermodal() : module("Intermodal Options", "intermodal") {
   param(router_, "router", "routing module");
   param(revise_, "revise", "revise connections");
+  param(timeout_, "timeout", "routing timeout in seconds (0 = no timeout)");
 }
 
 intermodal::~intermodal() = default;
@@ -535,7 +536,8 @@ msg_ptr intermodal::route(msg_ptr const& msg) {
         CreateRoutingRequest(mc, start.start_type_, start.start_, dest.station_,
                              req->search_type(), req->search_dir(),
                              mc.CreateVector(std::vector<Offset<Via>>{}),
-                             mc.CreateVector(edges))
+                             mc.CreateVector(edges), true, true, true, 0,
+                             timeout_)
             .Union(),
         router);
 

--- a/protocol/routing/RoutingRequest.fbs
+++ b/protocol/routing/RoutingRequest.fbs
@@ -114,4 +114,5 @@ table RoutingRequest {
   use_dest_metas: bool = true;
   use_start_footpaths: bool = true;
   schedule: ulong; // schedule id (0 = default)
+  timeout: int = 0; // 0 = none
 }


### PR DESCRIPTION
If supported by the chosen router, it will stop expanding its search interval after the given timeout.

Depends on https://github.com/motis-project/nigiri/pull/68

Workarounds https://github.com/motis-project/motis/issues/443 enough to not be a blocker for public hosting.

Let me know if this is generally something you want, and if I should change anything about the implementation.