### PR TITLE
RiBasisFormation: Fix for new version

### DIFF
--- a/libs/json/include/motis/json/json.h
+++ b/libs/json/include/motis/json/json.h
@@ -17,6 +17,9 @@ bool has_key(rapidjson::Value const& parent, char const* key);
 rapidjson::Value const& get_value(rapidjson::Value const& parent,
                                   char const* key);
 
+rapidjson::Value const* get_optional_value(rapidjson::Value const& parent,
+                                           char const* key);
+
 rapidjson::Value const& get_obj(rapidjson::Value const& parent,
                                 char const* key);
 

--- a/libs/json/src/json.cc
+++ b/libs/json/src/json.cc
@@ -15,6 +15,12 @@ rapidjson::Value const& get_value(rapidjson::Value const& parent,
   return member->value;
 }
 
+rapidjson::Value const* get_optional_value(rapidjson::Value const& parent,
+                                           char const* key) {
+  auto const member = parent.FindMember(key);
+  return (member != parent.MemberEnd()) ? &member->value : nullptr;
+}
+
 rapidjson::Value const& get_obj(rapidjson::Value const& parent,
                                 char const* key) {
   auto const& value = get_value(parent, key);

--- a/modules/ris/src/ribasis/ribasis_formation_parser.cc
+++ b/modules/ris/src/ribasis/ribasis_formation_parser.cc
@@ -82,9 +82,9 @@ Offset<VehicleGroup> parse_vehicle_group(context& ctx,
   }
 
   auto dep_uuid = default_dep_uuid;
-  auto const& dep = get_value(vg, "abfahrtAbweichend");
-  if (dep.IsObject()) {
-    dep_uuid = ctx.ris_.b_.CreateString(get_optional_str(dep, "abfahrtID"));
+  auto const& dep = get_optional_value(vg, "abfahrtAbweichend");
+  if (dep != nullptr && dep->IsObject()) {
+    dep_uuid = ctx.ris_.b_.CreateString(get_optional_str(*dep, "abfahrtID"));
   }
 
   return CreateVehicleGroup(


### PR DESCRIPTION
Apparently there is a new RiBasisFormation version that drops a previously available field. With this change, at least some messages can be processed. May require further changes.