### PR TITLE
Handle relative HTTP redirects as well

### DIFF
--- a/.pkg
+++ b/.pkg
@@ -89,7 +89,7 @@
 [boost]
   url=git@github.com:motis-project/boost.git
   branch=master
-  commit=be5235eb2258d2ec19e32546ab767a62311d9b46
+  commit=2db0acc02ea3f3775d1f8b48ba6c10f58dd6fcc9
 [mimalloc]
   url=git@github.com:motis-project/mimalloc.git
   branch=master

--- a/base/module/CMakeLists.txt
+++ b/base/module/CMakeLists.txt
@@ -39,5 +39,6 @@ target_link_libraries(motis-module
   wss-client
   cista
   utl
+  boost-url
 )
 target_compile_options(motis-module PRIVATE ${MOTIS_CXX_FLAGS})


### PR DESCRIPTION
Use boost::url::resolve to handle all possible redirect variants. The previous approach only handled redirects to absolute URLs. Some of the US GTFS-RT feeds use relative redirects though which caused an exception and aborted the entire GTFS-RT update then.