### PR TITLE
CI Update

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: CMake
         run: |
-          cmake ${{ matrix.config.cross }} \
+          cmake \
             -G Ninja -S . -B build \
             -DCMAKE_C_COMPILER=gcc-12 \
             -DCMAKE_CXX_COMPILER=g++-12 \
@@ -41,7 +41,7 @@ jobs:
             -DMOTIS_CUDA=On \
             -DMOTIS_AVX=Off \
             -DMOTIS_AVX2=Off \
-            -DMOTIS_WITH_WEBUI=${{ matrix.config.webui }}
+            -DMOTIS_WITH_WEBUI=Off
 
       - name: Build
         run: |
@@ -57,7 +57,7 @@ jobs:
         run: mv deps ~
 
       - name: Run Tests
-        run: ${{ matrix.config.emulator }} ./build/motis-test
+        run: ./build/motis-test
 
       - name: Run Integration Tests
-        run: ${{ matrix.config.emulator }} ./build/motis-itest
+        run: ./build/motis-itest

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -26,7 +26,7 @@ jobs:
       CUDACXX: /usr/local/cuda/bin/nvcc
       CLICOLOR_FORCE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get deps
         run: mkdir -p ~/deps && mv ~/deps .

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -97,7 +97,7 @@ jobs:
           path: docs/generated/
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: api-docs
     strategy:
       fail-fast: false
@@ -412,7 +412,7 @@ jobs:
       matrix:
         config:
           - artifact: macos-x86_64-noavx2
-            os: macos-latest
+            os: macos-13
           - artifact: linux-amd64
             os: ubuntu-20.04
           - artifact: linux-x86

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -504,7 +504,7 @@ jobs:
             type=edge
 
       - name: Docker build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           context: .

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install RSL Web Interface Dependencies
         uses: pnpm/action-setup@v3
         with:
-          version: ^8.10.5
+          version: ^8.15.4
           run_install: |
             - cwd: ui/rsl
 
@@ -83,7 +83,7 @@ jobs:
       - name: Install Protocol Tool Dependencies
         uses: pnpm/action-setup@v3
         with:
-          version: ^8.10.5
+          version: ^8.15.4
           run_install: |
             - cwd: tools/protocol
 
@@ -194,7 +194,7 @@ jobs:
       - name: Install RSL Web Interface Dependencies
         uses: pnpm/action-setup@v3
         with:
-          version: ^8.10.5
+          version: ^8.15.4
           run_install: |
             - cwd: ./ui/rsl
 
@@ -347,7 +347,7 @@ jobs:
         uses: pnpm/action-setup@v3
         if: ${{ !matrix.config.skipui }}
         with:
-          version: ^8.10.5
+          version: ^8.15.4
           run_install: |
             - cwd: ./ui/rsl
 

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/motis-project/docker-cpp-build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Format files
         run: |
@@ -38,10 +38,10 @@ jobs:
       run:
         working-directory: ui/rsl
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: pnpm Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ runner.os }}-${{ hashFiles('ui/rsl/pnpm-lock.yaml') }}
@@ -49,7 +49,7 @@ jobs:
             pnpm-${{ runner.os }}-
 
       - name: Install RSL Web Interface Dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: ^8.10.5
           run_install: |
@@ -70,10 +70,10 @@ jobs:
       run:
         working-directory: tools/protocol
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: pnpm Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ runner.os }}-${{ hashFiles('tools/protocol/pnpm-lock.yaml') }}
@@ -81,7 +81,7 @@ jobs:
             pnpm-${{ runner.os }}-
 
       - name: Install Protocol Tool Dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: ^8.10.5
           run_install: |
@@ -91,7 +91,7 @@ jobs:
         run: pnpm start --skip rsl-ui
 
       - name: Upload API Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api-docs
           path: docs/generated/
@@ -122,11 +122,11 @@ jobs:
       ASAN_OPTIONS: alloc_dealloc_mismatch=0
       CLICOLOR_FORCE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # ==== RESTORE CACHE ====
       - name: Restore buildcache Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-buildcache
         with:
           path: ${{ github.workspace }}/.buildcache
@@ -137,7 +137,7 @@ jobs:
             buildcache-${{ matrix.config.cache }}-
 
       - name: Restore Dependencies Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-deps-cache
         with:
           path: ${{ github.workspace }}/deps
@@ -184,7 +184,7 @@ jobs:
         run: cmake --build build --target motis-web-ui || (sleep 10 && cmake --build build --target motis-web-ui)
 
       - name: pnpm Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ runner.os }}-${{ hashFiles('ui/rsl/pnpm-lock.yaml') }}
@@ -192,7 +192,7 @@ jobs:
             pnpm-${{ runner.os }}-
 
       - name: Install RSL Web Interface Dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: ^8.10.5
           run_install: |
@@ -203,7 +203,7 @@ jobs:
         working-directory: ./ui/rsl
 
       - name: Download API Docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: api-docs
           path: docs/generated
@@ -226,7 +226,7 @@ jobs:
           tar cjf motis-${{ matrix.config.preset }}.tar.bz2 motis
 
       - name: Upload Distribution
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: motis-${{ matrix.config.preset }}
           path: motis-${{ matrix.config.preset }}.tar.bz2
@@ -246,14 +246,14 @@ jobs:
       # ==== SAVE CACHE ====
       - name: Save buildcache Cache
         if: always()
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/.buildcache
           key: ${{ steps.restore-buildcache.outputs.cache-primary-key }}
 
       - name: Save Dependencies Cache
         if: always()
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/deps
           key: ${{ steps.restore-deps-cache.outputs.cache-primary-key }}
@@ -299,7 +299,7 @@ jobs:
       BUILDCACHE_MAX_CACHE_SIZE: 2147483648
       BUILDCACHE_LUA_PATH: ${{ github.workspace }}/tools
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get deps
         run: ln -s /deps deps
@@ -344,7 +344,7 @@ jobs:
           cmake --build build --target motis-web-ui || (sleep 10 && cmake --build build --target motis-web-ui)
 
       - name: Install RSL Web Interface Dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         if: ${{ !matrix.config.skipui }}
         with:
           version: ^8.10.5
@@ -358,7 +358,7 @@ jobs:
 
       - name: Download API Docs
         if: matrix.config.artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: api-docs
           path: docs/generated
@@ -387,7 +387,7 @@ jobs:
 
       - name: Upload Distribution
         if: matrix.config.artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: motis-${{ matrix.config.artifact }}
           path: motis-${{ matrix.config.artifact }}.tar.bz2
@@ -434,13 +434,13 @@ jobs:
           sudo apt-get install -y --no-install-recommends ${{ matrix.config.packages }}
 
       - name: Download timetable and OSM dataset
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: motis-project/test-data
           ref: aachen
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: motis-${{ matrix.config.artifact }}
 
@@ -472,18 +472,18 @@ jobs:
     runs-on: ubuntu-20.04
     needs: full-data-set-test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Docker setup-buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         with:
           install: true
 
       - name: Docker Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -491,7 +491,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -504,7 +504,7 @@ jobs:
             type=edge
 
       - name: Docker build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           push: true
           context: .

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -106,7 +106,7 @@ jobs:
         uses: pnpm/action-setup@v3
         if: matrix.config.webui == 'On'
         with:
-          version: ^8.10.5
+          version: ^8.15.4
           run_install: |
             - cwd: ./ui/rsl
 
@@ -120,7 +120,7 @@ jobs:
         if: matrix.config.mode == 'Release'
         uses: pnpm/action-setup@v3
         with:
-          version: ^8.10.5
+          version: ^8.15.4
           run_install: |
             - cwd: tools/protocol
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
       BUILDCACHE_MAX_CACHE_SIZE: 1073741824
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # ==== RESTORE CACHE ====
       - name: Restore buildcache Cache
@@ -103,7 +103,7 @@ jobs:
           rm -r ui/web/src
 
       - name: Install RSL Web Interface Dependencies
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         if: matrix.config.webui == 'On'
         with:
           version: ^8.10.5
@@ -118,7 +118,7 @@ jobs:
       # ==== API DOCS ====
       - name: Install Protocol Tool Dependencies
         if: matrix.config.mode == 'Release'
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: ^8.10.5
           run_install: |
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload Distribution
         if: matrix.config.mode == 'Release'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: motis-windows${{ matrix.config.tag }}
           path: motis-windows${{ matrix.config.tag }}.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -154,20 +154,20 @@ jobs:
 
       - name: Create Distribution
         if: matrix.config.mode == 'Release'
-        run: >
-          7z a motis-windows${{ matrix.config.tag }}.zip
-          .\build\motis.exe
-          .\osrm-profiles
-          .\ppr-profiles
-          .\tiles-profiles
-          .\web
+        run: |
+          mkdir dist
+          mv .\build\motis.exe dist
+          mv .\osrm-profiles dist
+          mv .\ppr-profiles dist
+          mv .\tiles-profiles dist
+          mv .\web dist
 
       - name: Upload Distribution
         if: matrix.config.mode == 'Release'
         uses: actions/upload-artifact@v4
         with:
-          name: motis-windows${{ matrix.config.tag }}
-          path: motis-windows${{ matrix.config.tag }}.zip
+          name: motis-windows
+          path: dist
 
       # ==== RELEASE ====
       - name: Upload Release
@@ -177,6 +177,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./motis-windows${{ matrix.config.tag }}.zip
-          asset_name: motis-windows${{ matrix.config.tag }}.zip
+          asset_path: ./motis-windows.zip
+          asset_name: motis-windows.zip
           asset_content_type: application/zip


### PR DESCRIPTION
- New action versions to fix deprecation warnings:
	- [GitHub Actions: Transitioning from Node 16 to Node 20 - The GitHub Blog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)
	- [Deprecation notice: v1 and v2 of the artifact actions - The GitHub Blog](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
- Switch macOS runner to `macos-13` because of Xcode 15
	- We should probably switch to `macos-14` when it becomes `macos-latest` in Q2 ([roadmap](https://github.com/actions/runner-images/issues/9255)). However, `macos-14` runners use M1 CPUs and only have 7 GB RAM instead of 14 GB ([reference](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)).
- Remove double zip for Windows artifacts (other artifacts are still zipped .tar.bz2 because of permissions)