### PR TITLE
Set HTTP Accept-Encoding header

### DIFF
--- a/base/module/src/context/motis_http_req.cc
+++ b/base/module/src/context/motis_http_req.cc
@@ -30,6 +30,7 @@ struct http_request_executor
       net::http::client::method_to_str(req.req_method),
       fmt::streamed(req.address));
     request_url_ = req.address;
+    req.headers["Accept-Encoding"] = "gzip";
 
     auto cb = [self = shared_from_this()](auto&& a,
                                           net::http::client::response&& res,


### PR DESCRIPTION
We can deal with gzip content encoding, and the Finish national railway GTFS-RT feed insists on that.

Fixes #473.