### PR TITLE
ui: web: Allow passing preselected start and destination

### DIFF
--- a/ui/web/js/main.js
+++ b/ui/web/js/main.js
@@ -45,6 +45,9 @@
       simulationTime = initialPermalink.timestamp;
     }
 
+    let fromLocation = params.get("fromLocation")
+    let toLocation = params.get("toLocation")
+
     let langParam = params.get("lang");
     let language = langParam || "de";
 
@@ -56,8 +59,8 @@
       motisParam: params.get("motis"),
       timeParam: timeParam,
       langParam: langParam,
-      fromLocation: null,
-      toLocation: null,
+      fromLocation: fromLocation,
+      toLocation: toLocation,
       fromModes: null,
       toModes: null,
       intermodalPprMode: null,


### PR DESCRIPTION
I plan to use this to provide a search box on the future Transitous website.

The parameter accepts a json object like
```json
{"type": "Station", "station": { "id": "", "name": "", "pos": {"lat": 0, "lng": 0}}}
```
or a search string.