### PR TITLE
ui/web: disable path module calls

### DIFF
--- a/ui/web/js/map.js
+++ b/ui/web/js/map.js
@@ -262,14 +262,16 @@ function initPorts(app, apiEndpoint, tilesEndpoint, initialPermalink, style) {
     syncMaps(map_bg, map_fg);
 
     map_fg.on("load", () => {
-      RailViz.Path.Base.init(map_fg, apiEndpoint);
+      //RailViz.Path.Base.init(map_fg, apiEndpoint);
       RailViz.GBFS.init(map_fg, apiEndpoint);
 
       map_fg.addLayer(new RailVizCustomLayer());
 
-      RailViz.Path.Extra.init(map_fg, "railviz-base-stations");
-      RailViz.Path.Detail.init(map_fg, "railviz-base-stations");
-      RailViz.Path.Connections.init(map_fg, "railviz-base-stations");
+      //const before = "railviz-base-stations";
+      const before = null;
+      RailViz.Path.Extra.init(map_fg, before);
+      RailViz.Path.Detail.init(map_fg, before);
+      RailViz.Path.Connections.init(map_fg, before);
     });
 
     ["click", "mousemove", "mouseout"].forEach((t) =>

--- a/ui/web/js/railviz/main.js
+++ b/ui/web/js/railviz/main.js
@@ -186,7 +186,7 @@ RailViz.Main = (function () {
 
   function showFullData() {
     showingDetailData = false;
-    RailViz.Path.Base.setEnabled(trainsEnabled);
+    //RailViz.Path.Base.setEnabled(trainsEnabled);
     RailViz.Path.Extra.setData(fullData);
     RailViz.Path.Extra.setEnabled(trainsEnabled);
     RailViz.Path.Detail.setEnabled(false);
@@ -199,7 +199,7 @@ RailViz.Main = (function () {
 
   function showDetailData() {
     showingDetailData = true;
-    RailViz.Path.Base.setEnabled(false);
+    //RailViz.Path.Base.setEnabled(false);
     RailViz.Path.Extra.setEnabled(false);
     RailViz.Path.Detail.setData(detailFilter, detailTrips);
     RailViz.Path.Detail.setEnabled(true);
@@ -214,7 +214,7 @@ RailViz.Main = (function () {
 
   function showTrains(b) {
     trainsEnabled = b;
-    RailViz.Path.Base.setEnabled(!showingDetailData && trainsEnabled);
+    //RailViz.Path.Base.setEnabled(!showingDetailData && trainsEnabled);
     RailViz.Path.Extra.setEnabled(!showingDetailData && trainsEnabled);
     RailViz.Path.Detail.setEnabled(showingDetailData && trainsEnabled);
     RailViz.Render.setTrainsEnabled(trainsEnabled);


### PR DESCRIPTION
Disable the API calls to the no longer available `path` module.