### PR TITLE
cmake: Add option to pass flags not used for host tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,3 +198,9 @@ add_custom_target(motis-web-ui
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ui"
         VERBATIM
 )
+
+foreach(t mimalloc adr osr nigiri gtfsrt
+        geo tiles tiles-import-library
+        motis motis-api motislib)
+    target_compile_options(${t} PUBLIC ${MOTIS_TARGET_FLAGS})
+endforeach()


### PR DESCRIPTION
This allows to target machines that support more instructions than the build machine.

Not sure if this is a good way to achieve this, but it at least doesn't require significant changes.