### PR TITLE
Fix index out of range for stop_times last arrival of multi-section run

### DIFF
--- a/include/motis/tag_lookup.h
+++ b/include/motis/tag_lookup.h
@@ -20,7 +20,7 @@ struct tag_lookup {
   std::string id(nigiri::timetable const&, nigiri::location_idx_t) const;
   std::string id(nigiri::timetable const&,
                  nigiri::rt::run_stop,
-                 nigiri::event_type const) const;
+                 nigiri::event_type) const;
   nigiri::location_idx_t get_location(nigiri::timetable const&,
                                       std::string_view) const;
   std::pair<nigiri::rt::run, nigiri::trip_idx_t> get_trip(

--- a/include/motis/tag_lookup.h
+++ b/include/motis/tag_lookup.h
@@ -18,7 +18,9 @@ struct tag_lookup {
   nigiri::source_idx_t get_src(std::string_view tag) const;
   std::string_view get_tag(nigiri::source_idx_t) const;
   std::string id(nigiri::timetable const&, nigiri::location_idx_t) const;
-  std::string id(nigiri::timetable const&, nigiri::rt::run_stop) const;
+  std::string id(nigiri::timetable const&,
+                 nigiri::rt::run_stop,
+                 nigiri::event_type const) const;
   nigiri::location_idx_t get_location(nigiri::timetable const&,
                                       std::string_view) const;
   std::pair<nigiri::rt::run, nigiri::trip_idx_t> get_trip(

--- a/src/endpoints/stop_times.cc
+++ b/src/endpoints/stop_times.cc
@@ -356,7 +356,7 @@ api::stoptimes_response stop_times::operator()(
                 .routeColor_ = to_str(s.get_route_color(ev_type).color_),
                 .routeTextColor_ =
                     to_str(s.get_route_color(ev_type).text_color_),
-                .tripId_ = tags_.id(tt_, s),
+                .tripId_ = tags_.id(tt_, s, ev_type),
                 .routeShortName_ = std::string{s.trip_display_name(ev_type)},
                 .source_ = fmt::format("{}", fmt::streamed(fr.dbg()))};
           }),

--- a/src/journey_to_response.cc
+++ b/src/journey_to_response.cc
@@ -123,7 +123,7 @@ api::Itinerary journey_to_response(osr::ways const* w,
                   .agencyName_ = {std::string{agency.long_name_}},
                   .agencyUrl_ = {std::string{agency.url_}},
                   .agencyId_ = {std::string{agency.short_name_}},
-                  .tripId_ = tags.id(tt, enter_stop),
+                  .tripId_ = tags.id(tt, enter_stop, n::event_type::kDep),
                   .routeShortName_ = {std::string{
                       enter_stop.trip_display_name()}},
                   .source_ = fmt::to_string(fr.dbg())});

--- a/src/railviz.cc
+++ b/src/railviz.cc
@@ -370,7 +370,7 @@ api::trips_response get_trains(tag_lookup const& tags,
                             [&](auto&& p) { enc.push(p); });
 
     return {.trips_ = {api::TripInfo{
-                .tripId_ = tags.id(tt, from),
+                .tripId_ = tags.id(tt, from, n::event_type::kDep),
                 .routeShortName_ =
                     std::string{from.trip_display_name(n::event_type::kDep)}}},
             .routeColor_ =

--- a/src/tag_lookup.cc
+++ b/src/tag_lookup.cc
@@ -49,10 +49,11 @@ std::string tag_lookup::id(nigiri::timetable const& tt,
 }
 
 std::string tag_lookup::id(nigiri::timetable const& tt,
-                           n::rt::run_stop s) const {
+                           n::rt::run_stop s,
+                           n::event_type const ev_type) const {
   if (s.fr_->is_scheduled()) {
     // trip id
-    auto const t = s.get_trip_idx(n::event_type::kDep);
+    auto const t = s.get_trip_idx(ev_type);
     auto const id_idx = tt.trip_ids_[t].front();
     auto const id = tt.trip_id_strings_[id_idx].view();
     auto const src = tt.trip_id_src_[id_idx];


### PR DESCRIPTION
I stumbled upon a motis crash `libc++abi: terminating due to uncaught exception of type cista::cista_exception: bucket::at: index out of range` with the 06.01.2025 DELFI GTFS and this query (didn't dare to try it out on one of the public instances...):
`/api/v1/stoptimes?stopId=gtfs_de%3A03159%3A33817%3A%3A8&time=2025-01-18T13%3A08%3A00.000Z&arriveBy=true&n=10` 

Occurs in [nigiri/src/rt/frun.cc#L105](https://github.com/motis-project/nigiri/blob/0861ed983e0b84062f49e82c416b2e4aa000e972/src/rt/frun.cc#L105) for the last stop of multi-section trips, because [it would always look for a `event_type::kDep`](https://github.com/motis-project/motis/commit/9902350695aca90516d6b8f25ee0861408b5e74f#diff-ffee06f9f27f250abca7b76072cbdd73f6f7768946170f1b5d2817004081897dL55).
I.e. an alternative fix with less (interface) changes would be to make [`get_trip_index(ev_type)` in nigiri](https://github.com/motis-project/nigiri/blob/0861ed983e0b84062f49e82c416b2e4aa000e972/src/rt/frun.cc#L105) more robust, but would then still lead to wrong results for the `trip_id` at stops where the `trip_id` switches (if I understand correctly).
