### PR TITLE
More UI improvements

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -70,7 +70,7 @@
 		@apply border-border;
 	}
 	body {
-		@apply bg-background text-foreground;
+		@apply bg-secondary text-foreground;
 	}
 }
 
@@ -100,7 +100,7 @@
 
 .maplibregl-control-container .maplibregl-ctrl-top-left {
 	max-width: 100%;
-	bottom: 1rem;
+	bottom: 0.5rem;
 	display: flex;
 	flex-direction: column;
 	z-index: 3;

--- a/ui/src/lib/RailViz.svelte
+++ b/ui/src/lib/RailViz.svelte
@@ -297,7 +297,7 @@
 	});
 </script>
 
-<Control position={browser && window.innerWidth < 600 ? 'bottom-left' : 'top-right'} class="pb-2">
+<Control position={browser && window.innerWidth < 768 ? 'bottom-left' : 'top-right'} class="pb-4">
 	<Button
 		size="icon"
 		variant={colorMode ? 'default' : 'outline'}
@@ -306,9 +306,9 @@
 		}}
 	>
 		{#if colorMode == 'rt'}
-			<Rss size="icon" class="h-[1.2rem] w-[1.2rem]" />
+			<Rss class="h-[1.2rem] w-[1.2rem]" />
 		{:else}
-			<Palette size="icon" class="h-[1.2rem] w-[1.2rem]" />
+			<Palette class="h-[1.2rem] w-[1.2rem]" />
 		{/if}
 	</Button>
 </Control>

--- a/ui/src/lib/Route.svelte
+++ b/ui/src/lib/Route.svelte
@@ -12,7 +12,7 @@
 		onClickTrip: (tripId: string) => void;
 	} = $props();
 
-	const modeIcon = getModeStyle(l)[0];
+	const modeIcon = $derived(getModeStyle(l)[0]);
 </script>
 
 <button

--- a/ui/src/lib/map/Map.svelte
+++ b/ui/src/lib/map/Map.svelte
@@ -10,13 +10,15 @@
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		bounds = $bindable(),
 		style,
+		attribution,
 		transformRequest,
 		center,
 		children,
 		class: className
 	}: {
 		map?: maplibregl.Map;
-		style: maplibregl.StyleSpecification;
+		style: maplibregl.StyleSpecification | undefined;
+		attribution: string;
 		transformRequest?: maplibregl.RequestTransformFunction;
 		center: maplibregl.LngLatLike;
 		bounds?: maplibregl.LngLatBoundsLike | undefined;
@@ -25,7 +27,7 @@
 		class: string;
 	} = $props();
 
-	let currStyle: maplibregl.StyleSpecification | null = null;
+	let currStyle: maplibregl.StyleSpecification | undefined = undefined;
 	let ctx = $state<{ map: maplibregl.Map | undefined }>({ map: undefined });
 	setContext('map', ctx);
 
@@ -33,7 +35,15 @@
 	let currentCenter: maplibregl.LngLatLike | undefined = undefined;
 
 	const createMap = (container: HTMLElement) => {
-		let tmp = new maplibregl.Map({ container, zoom, bounds, center, style, transformRequest });
+		let tmp = new maplibregl.Map({
+			container,
+			zoom,
+			bounds,
+			center,
+			style,
+			transformRequest,
+			attributionControl: { customAttribution: attribution }
+		});
 
 		tmp.addImage(
 			'shield',
@@ -79,7 +89,7 @@
 
 	$effect(() => {
 		if (style != currStyle && ctx.map) {
-			ctx.map.setStyle(style);
+			ctx.map.setStyle(style || null);
 		}
 	});
 

--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -128,7 +128,7 @@ export const getStyle = (theme: 'light' | 'dark', level: number): StyleSpecifica
 				type: 'vector',
 				tiles: ['/{z}/{x}/{y}.mvt'],
 				maxzoom: 20,
-				attribution: "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>"
+				attribution: ''
 			}
 		},
 		glyphs: '/glyphs/{fontstack}/{range}.pbf',


### PR DESCRIPTION
* Fixes #718 
* Simple way to show map only on demand on mobile
* Slightly rework map attribution to always show OSM even without the map (because it is also used for geocoding etc.) – I think it would be good to also link to the timetable sources (e.g. https://transitous.org/sources) but I haven't yet found a straightforward way to make this configurable

(I would have slightly reduced the font size of the views, but since you seem to have increased the font size even of the intermediate stops again, I refrained from that :)