### PR TITLE
GBFS: Use station parking if no geofencing zones defined

### DIFF
--- a/src/gbfs/osr_mapping.cc
+++ b/src/gbfs/osr_mapping.cc
@@ -69,8 +69,9 @@ struct osr_mapping {
         break;
       }
 
-      if (prod.known_return_constraint_ &&
-          prod.return_constraint_ == return_constraint::kAnyStation) {
+      if (prod.return_constraint_ == return_constraint::kAnyStation &&
+          (prod.known_return_constraint_ ||
+           provider_.geofencing_zones_.zones_.empty())) {
         default_restrictions.station_parking_ = true;
       }
 


### PR DESCRIPTION
Fixes a bug in #733 and should properly fix #731 this time.