### PR TITLE
Add handling for invalid commands in main.cc

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -131,6 +131,10 @@ int main(int ac, char** av) {
         return 1;
       }
     }
+
+    default:
+      fmt::println("Invalid command. Type motis --help for a list of commands.");
+      return 1;
   }
 
   google::protobuf::ShutdownProtobufLibrary();

--- a/exe/main.cc
+++ b/exe/main.cc
@@ -55,12 +55,14 @@ int main(int ac, char** av) {
   --ac;
   ++av;
 
+  auto return_value = 0;
+
   // Execute command.
   auto const cmd = std::string_view{av[0]};
   switch (cista::hash(cmd)) {
-    case cista::hash("generate"): return generate(ac, av);
-    case cista::hash("batch"): return batch(ac, av);
-    case cista::hash("compare"): return compare(ac, av);
+    case cista::hash("generate"): return_value = generate(ac, av); break;
+    case cista::hash("batch"): return_value = batch(ac, av); break;
+    case cista::hash("compare"): return_value = compare(ac, av); break;
 
     case cista::hash("config"): {
       auto paths = std::vector<std::string>{};
@@ -80,10 +82,12 @@ int main(int ac, char** av) {
             "\n\n"
             "Example: motis config germany-latest.osm.pbf "
             "germany.gtfs.zip\n");
-        return paths.empty() ? 1 : 0;
+        return_value = paths.empty() ? 1 : 0;
+        break;
       }
       std::ofstream{"config.yml"} << config::read_simple(paths) << "\n";
-      return 0;
+      return_value = 0;
+      break;
     }
 
     case cista::hash("server"):
@@ -95,14 +99,17 @@ int main(int ac, char** av) {
         auto vm = parse_opt(ac, av, desc);
         if (vm.count("help")) {
           std::cout << desc << "\n";
-          return 0;
+          return_value = 0;
+          break;
         }
 
         auto const c = config::read(data_path / "config.yml");
-        return server(data{data_path, c}, c);
+        return_value = server(data{data_path, c}, c);
+        break;
       } catch (std::exception const& e) {
         std::cerr << "unable to start server: " << e.what() << "\n";
-        return 1;
+        return_value = 1;
+        break;
       }
 
     case cista::hash("import"): {
@@ -117,25 +124,30 @@ int main(int ac, char** av) {
         auto vm = parse_opt(ac, av, desc);
         if (vm.count("help")) {
           std::cout << desc << "\n";
-          return 0;
+          return_value = 0;
+          break;
         }
 
         c = config_path.extension() == ".ini" ? config::read_legacy(config_path)
                                               : config::read(config_path);
         auto const bars = utl::global_progress_bars{false};
         import(c, std::move(data_path));
-        return 0;
+        return_value = 0;
+        break;
       } catch (std::exception const& e) {
         fmt::println("unable to import: {}", e.what());
         fmt::println("config:\n{}", fmt::streamed(c));
-        return 1;
+        return_value = 1;
+        break;
       }
     }
 
     default:
       fmt::println("Invalid command. Type motis --help for a list of commands.");
-      return 1;
+      return_value = 1;
+      break;
   }
 
   google::protobuf::ShutdownProtobufLibrary();
+  return return_value;
 }


### PR DESCRIPTION
**This is a minor change**
### Description
This PR improves the user experience by adding handling for invalid commands in  `exe/main.cc`. When a user enters an unrecognized command, the program will now print "Invalid command. Type motis --help for a list of commands."