### PR TITLE
Fix documentation to match code

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,7 +26,7 @@ paths:
         - name: one
           in: query
           required: true
-          description: geo location as latitude,longitude
+          description: geo location as latitude;longitude
           schema:
             type: string
         - name: many


### PR DESCRIPTION
I just noticed, that the documentation does not match the corresponding code. I assume the code is correct.
https://github.com/motis-project/motis/blob/43775cfe76201991399554f6824458fdf552a4c8/src/endpoints/one_to_many.cc#L20