### PR TITLE
Fix reading GBFSv3 feeds with a null global_rules key

### DIFF
--- a/src/gbfs/parser.cc
+++ b/src/gbfs/parser.cc
@@ -519,7 +519,8 @@ void load_geofencing_zones(gbfs_provider& provider, json::value const& root) {
 
   //  required in 3.0, but some feeds don't have it
   auto global_rules =
-      root.at("data").as_object().contains("global_rules")
+      root.at("data").as_object().contains("global_rules") &&
+              root.at("data").at("global_rules").is_array()
           ? utl::to_vec(
                 root.at("data").at("global_rules").as_array(),
                 [&](auto const& r) { return parse_rule(provider, version, r); })


### PR DESCRIPTION
We only checked for the presence of the key here, not for its type.

The Finnish national aggregate feed has the key set, but with value null, which caused the entire feed to be discarded.