### PR TITLE
UI URL, START/END, dates, no WebGL

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -74,6 +74,14 @@
 	}
 }
 
+body {
+	font:
+		12px / 20px Helvetica Neue,
+		Arial,
+		Helvetica,
+		sans-serif;
+}
+
 .maplibregl-popup-anchor-top .maplibregl-popup-tip,
 .maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
 .maplibregl-popup-anchor-top-right .maplibregl-popup-tip {

--- a/ui/src/lib/ConnectionDetail.svelte
+++ b/ui/src/lib/ConnectionDetail.svelte
@@ -32,6 +32,7 @@
 	<Time
 		variant="schedule"
 		class="font-semibold w-16"
+		queriedTime={timestamp}
 		{isRealtime}
 		{timestamp}
 		{scheduledTimestamp}

--- a/ui/src/lib/ItineraryList.svelte
+++ b/ui/src/lib/ItineraryList.svelte
@@ -22,12 +22,14 @@
 		routingResponses,
 		baseResponse,
 		baseQuery,
-		selectItinerary
+		selectItinerary,
+		updateStartDest
 	}: {
 		routingResponses: Array<Promise<PlanResponse>>;
 		baseResponse: Promise<PlanResponse> | undefined;
 		baseQuery: PlanData | undefined;
 		selectItinerary: (it: Itinerary) => void;
+		updateStartDest: (r: { data: PlanResponse | undefined; error: unknown }) => PlanResponse;
 	} = $props();
 
 	const throwOnError = (promise: RequestResult<PlanResponse, PlanError, false>) =>
@@ -37,7 +39,7 @@
 				throw new Error(
 					String((response.error as Record<string, unknown>).error ?? response.error)
 				);
-			return response.data!;
+			return response;
 		});
 </script>
 
@@ -96,7 +98,7 @@
 												plan({
 													query: { ...baseQuery.query, pageCursor: r.previousPageCursor }
 												})
-											)
+											).then(updateStartDest)
 										);
 									}}
 									class="px-2 py-1 bg-blue-600 hover:!bg-blue-700 text-white font-bold text-sm border rounded-lg text-nowrap"
@@ -121,6 +123,7 @@
 												timestamp={it.startTime}
 												scheduledTimestamp={it.legs[0].scheduledStartTime}
 												variant={'realtime-show-always'}
+												queriedTime={baseQuery?.query.time}
 											/>
 										</div>
 										<Separator orientation="vertical" />
@@ -131,6 +134,7 @@
 												timestamp={it.endTime}
 												scheduledTimestamp={it.legs[it.legs.length - 1].scheduledEndTime}
 												variant={'realtime-show-always'}
+												queriedTime={it.startTime}
 											/>
 										</div>
 										<Separator orientation="vertical" />
@@ -165,7 +169,7 @@
 												plan({
 													query: { ...baseQuery.query, pageCursor: r.nextPageCursor }
 												})
-											)
+											).then(updateStartDest)
 										);
 									}}
 									class="px-2 py-1 bg-blue-600 hover:!bg-blue-700 text-white text-sm font-bold border rounded-lg text-nowrap"

--- a/ui/src/lib/LevelSelect.svelte
+++ b/ui/src/lib/LevelSelect.svelte
@@ -45,8 +45,8 @@
 </script>
 
 {#if availableLevels.length > 1}
-	<Control>
-		<RadioGroup class="flex flex-col space-y-1" bind:value>
+	<Control position="bottom-right">
+		<RadioGroup class="flex flex-col items-end space-y-1" bind:value>
 			{#each availableLevels as l}
 				<Label
 					for={`level-${l}`}

--- a/ui/src/lib/StopTimes.svelte
+++ b/ui/src/lib/StopTimes.svelte
@@ -93,7 +93,13 @@
 					? t.place.scheduledArrival!
 					: t.place.scheduledDeparture!}
 				<Route class="w-fit max-w-32 text-ellipsis overflow-hidden" l={t} {onClickTrip} />
-				<Time variant="schedule" isRealtime={t.realTime} {timestamp} {scheduledTimestamp} />
+				<Time
+					variant="schedule"
+					isRealtime={t.realTime}
+					{timestamp}
+					{scheduledTimestamp}
+					queriedTime={queryTime.toISOString()}
+				/>
 				<Time variant="realtime" isRealtime={t.realTime} {timestamp} {scheduledTimestamp} />
 				<div class="flex items-center text-muted-foreground min-w-0">
 					<div><ArrowRight class="stroke-muted-foreground h-4 w-4" /></div>

--- a/ui/src/lib/Time.svelte
+++ b/ui/src/lib/Time.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { language } from '$lib/i18n/translation';
 	import { formatTime } from './toDateTime';
 	import { cn } from './utils';
 
@@ -7,13 +8,15 @@
 		timestamp,
 		scheduledTimestamp,
 		isRealtime,
-		variant
+		variant,
+		queriedTime
 	}: {
 		class?: string;
 		timestamp: string;
 		scheduledTimestamp: string;
 		isRealtime: boolean;
 		variant: 'schedule' | 'realtime' | 'realtime-show-always';
+		queriedTime?: string | undefined;
 	} = $props();
 
 	const t = $derived(new Date(timestamp));
@@ -21,14 +24,29 @@
 	const delayMinutes = $derived((t.getTime() - scheduled.getTime()) / 60000);
 	const highDelay = $derived(isRealtime && delayMinutes > 3);
 	const lowDelay = $derived(isRealtime && delayMinutes <= 3);
+
+	function weekday(time: Date) {
+		if (variant === 'realtime') {
+			return '';
+		}
+		if (queriedTime === undefined) {
+			return time.toLocaleDateString(language);
+		}
+		const base = new Date(queriedTime);
+		return base.toLocaleDateString() === time.toLocaleDateString()
+			? ''
+			: `(${time.toLocaleString(language, { weekday: 'short' })})`;
+	}
 </script>
 
 <div class={cn('text-nowrap', className)}>
 	{#if variant == 'schedule'}
 		{formatTime(scheduled)}
+		{weekday(scheduled)}
 	{:else if variant === 'realtime-show-always' || (variant === 'realtime' && isRealtime)}
-		<div class:text-destructive={highDelay} class:text-green-600={lowDelay}>
+		<span class:text-destructive={highDelay} class:text-green-600={lowDelay}>
 			{formatTime(t)}
-		</div>
+		</span>
+		{weekday(t)}
 	{/if}
 </div>

--- a/ui/src/lib/i18n/translation.ts
+++ b/ui/src/lib/i18n/translation.ts
@@ -73,5 +73,9 @@ const translations: Map<string, Translations> = new Map(
 	})
 );
 
-export const language = (browser ? navigator.languages.find((l) => l.length == 2) : 'en') ?? 'en';
-export const t = translations.get(language) ?? en;
+const translationsKey = (
+	browser ? (navigator.languages.find((l) => translations.has(l.slice(0, 2))) ?? 'en') : 'en'
+)?.slice(0, 2);
+
+export const language = translationsKey ?? (browser ? navigator.language : 'en');
+export const t = translationsKey ? translations.get(translationsKey)! : en;

--- a/ui/src/lib/map/Control.svelte
+++ b/ui/src/lib/map/Control.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		children,
-		position = 'top-right',
+		position,
 		class: className
 	}: {
 		children?: Snippet;
@@ -31,7 +31,7 @@
 	let ctx: { map: Map | null } = getContext('map');
 
 	$effect(() => {
-		if (ctx.map && el) {
+		if (ctx.map && el && position != undefined) {
 			ctx.map.addControl(ctrl, position);
 			initialized = true;
 		}
@@ -41,7 +41,7 @@
 </script>
 
 <div
-	class:hidden={!initialized}
+	class:hidden={!initialized && position != undefined}
 	class={cn('clear-both pointer-events-auto pt-2 md:pt-4 px-2 md:px-4 max-w-full', className)}
 	bind:this={el}
 >

--- a/ui/src/lib/map/Map.svelte
+++ b/ui/src/lib/map/Map.svelte
@@ -27,7 +27,8 @@
 		class: string;
 	} = $props();
 
-	let currStyle: maplibregl.StyleSpecification | undefined = undefined;
+	let el: HTMLElement | null = null;
+	let currStyle: maplibregl.StyleSpecification | undefined = style;
 	let ctx = $state<{ map: maplibregl.Map | undefined }>({ map: undefined });
 	setContext('map', ctx);
 
@@ -35,61 +36,73 @@
 	let currentCenter: maplibregl.LngLatLike | undefined = undefined;
 
 	const createMap = (container: HTMLElement) => {
-		let tmp = new maplibregl.Map({
-			container,
-			zoom,
-			bounds,
-			center,
-			style,
-			transformRequest,
-			attributionControl: { customAttribution: attribution }
-		});
+		if (!style) {
+			return;
+		}
+		let tmp: maplibregl.Map;
+		try {
+			tmp = new maplibregl.Map({
+				container,
+				zoom,
+				bounds,
+				center,
+				style,
+				transformRequest,
+				attributionControl: { customAttribution: attribution }
+			});
 
-		tmp.addImage(
-			'shield',
-			...createShield({
-				fill: 'hsl(0, 0%, 98%)',
-				stroke: 'hsl(0, 0%, 75%)'
-			})
-		);
+			tmp.addImage(
+				'shield',
+				...createShield({
+					fill: 'hsl(0, 0%, 98%)',
+					stroke: 'hsl(0, 0%, 75%)'
+				})
+			);
 
-		tmp.addImage(
-			'shield-dark',
-			...createShield({
-				fill: 'hsl(0, 0%, 16%)',
-				stroke: 'hsl(0, 0%, 30%)'
-			})
-		);
+			tmp.addImage(
+				'shield-dark',
+				...createShield({
+					fill: 'hsl(0, 0%, 16%)',
+					stroke: 'hsl(0, 0%, 30%)'
+				})
+			);
 
-		tmp.on('load', () => {
-			tmp.setZoom(zoom);
-			tmp.setCenter(center);
-			currentZoom = zoom;
-			currentCenter = center;
-			bounds = tmp.getBounds();
-			map = tmp;
-			ctx.map = tmp;
-			currStyle = style;
-			currentZoom = zoom;
-		});
+			tmp.on('load', () => {
+				tmp.setZoom(zoom);
+				tmp.setCenter(center);
+				currentZoom = zoom;
+				currentCenter = center;
+				bounds = tmp.getBounds();
+				currStyle = style;
+				map = tmp;
+				ctx.map = tmp;
+				currentZoom = zoom;
+			});
 
-		tmp.on('moveend', async () => {
-			zoom = tmp.getZoom();
-			currentZoom = zoom;
-			bounds = tmp.getBounds();
-		});
+			tmp.on('moveend', async () => {
+				zoom = tmp.getZoom();
+				currentZoom = zoom;
+				bounds = tmp.getBounds();
+			});
+		} catch (e) {
+			console.log(e);
+		}
 
 		return {
 			destroy() {
-				tmp.remove();
+				tmp?.remove();
 				ctx.map = undefined;
 			}
 		};
 	};
 
 	$effect(() => {
-		if (style != currStyle && ctx.map) {
-			ctx.map.setStyle(style || null);
+		if (style != currStyle) {
+			if (!ctx.map && el) {
+				createMap(el);
+			} else if (ctx.map) {
+				ctx.map.setStyle(style || null);
+			}
 		}
 	});
 
@@ -108,7 +121,7 @@
 	});
 </script>
 
-<div use:createMap class={className}>
+<div use:createMap bind:this={el} class={className}>
 	{#if children}
 		{@render children()}
 	{/if}

--- a/ui/src/lib/updateStartDest.ts
+++ b/ui/src/lib/updateStartDest.ts
@@ -1,0 +1,19 @@
+import type { Itinerary, PlanResponse } from '$lib/openapi';
+import type { Location } from '$lib/Location';
+
+export const updateStartDest = (from: Location, to: Location) => {
+	return (r: { data: PlanResponse | undefined; error: unknown }) => {
+		if (r.error) throw new Error(String(r.error));
+
+		r.data!.itineraries.forEach((it: Itinerary) => {
+			if (it.legs[0].from.name === 'START') {
+				it.legs[0].from.name = from.label!;
+			}
+			if (it.legs[it.legs.length - 1].to.name === 'END') {
+				it.legs[it.legs.length - 1].to.name = to.label!;
+			}
+		});
+
+		return r.data!;
+	};
+};

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -328,116 +328,122 @@
 		</Control>
 	{/if}
 
-	<Control
-		position="top-left"
-		class={isSmallScreen && (page.state.selectedItinerary || page.state.selectedStop) ? 'hide' : ''}
-	>
-		<Card class="w-[520px] overflow-y-auto overflow-x-hidden bg-background rounded-lg">
-			<SearchMask
-				bind:from
-				bind:to
-				bind:time
-				bind:timeType
-				bind:wheelchair
-				bind:bikeRental
-				bind:bikeCarriage
-				bind:selectedModes={selectedTransitModes}
-			/>
-		</Card>
-	</Control>
-
 	<LevelSelect {bounds} {zoom} bind:level />
 
-	{#if routingResponses.length !== 0}
-		<Control
-			position="top-left"
-			class="min-h-0 md:mb-2 {page.state.selectedItinerary ? 'hide' : ''}"
-		>
-			<Card
-				class="w-[520px] h-full md:max-h-[70vh] overflow-y-auto overflow-x-hidden bg-background rounded-lg"
+	<div class="maplibregl-control-container">
+		<div class="maplibregl-ctrl-top-left">
+			<Control
+				class={isSmallScreen && (page.state.selectedItinerary || page.state.selectedStop)
+					? 'hide'
+					: ''}
 			>
-				<ItineraryList
-					{baseResponse}
-					{routingResponses}
-					{baseQuery}
-					selectItinerary={(selectedItinerary) => pushState('', { selectedItinerary })}
-					updateStartDest={updateStartDest(from, to)}
-				/>
-			</Card>
-		</Control>
-	{/if}
-
-	{#if page.state.selectedItinerary && !page.state.selectedStop}
-		<Control position="top-left" class="min-h-0 mb-12 md:mb-2">
-			<Card class="w-[520px] h-full bg-background rounded-lg flex flex-col">
-				<div class="w-full flex justify-between items-center shadow-md pl-1 mb-1">
-					<h2 class="ml-2 text-base font-semibold">{t.journeyDetails}</h2>
-					<Button
-						variant="ghost"
-						onclick={() => {
-							pushStateWithQueryString({}, {});
-						}}
-					>
-						<X />
-					</Button>
-				</div>
-				<div
-					class={'p-2 md:p-4 overflow-y-auto overflow-x-hidden min-h-0 ' +
-						(showMap ? 'max-h-[40vh] md:max-h-[70vh]' : '')}
-				>
-					<ConnectionDetail itinerary={page.state.selectedItinerary} {onClickStop} {onClickTrip} />
-				</div>
-			</Card>
-		</Control>
-		{#if showMap}
-			<ItineraryGeoJson itinerary={page.state.selectedItinerary} {level} />
-		{/if}
-	{/if}
-
-	{#if page.state.selectedStop}
-		<Control position="top-left" class="min-h-0 md:mb-2">
-			<Card class="w-[520px] h-full bg-background rounded-lg flex flex-col">
-				<div class="w-full flex justify-between items-center shadow-md pl-1 mb-1">
-					<h2 class="ml-2 text-base font-semibold">
-						{#if page.state.stopArriveBy}
-							{t.arrivals}
-						{:else}
-							{t.departures}
-						{/if}
-						in
-						{stopNameFromResponse}
-					</h2>
-					<Button
-						variant="ghost"
-						onclick={() => {
-							pushStateWithQueryString(
-								{ tripId: page.state.tripId },
-								{ selectedItinerary: page.state.selectedItinerary }
-							);
-						}}
-					>
-						<X />
-					</Button>
-				</div>
-				<div class="p-2 md:p-4 overflow-y-auto overflow-x-hidden min-h-0 md:max-h-[70vh]">
-					<StopTimes
-						stopId={page.state.selectedStop.stopId}
-						time={page.state.selectedStop.time}
-						bind:stopNameFromResponse
-						arriveBy={page.state.stopArriveBy}
-						setArriveBy={(arriveBy) =>
-							onClickStop(
-								page.state.selectedStop!.name,
-								page.state.selectedStop!.stopId,
-								page.state.selectedStop!.time,
-								arriveBy
-							)}
-						{onClickTrip}
+				<Card class="w-[520px] overflow-y-auto overflow-x-hidden bg-background rounded-lg">
+					<SearchMask
+						bind:from
+						bind:to
+						bind:time
+						bind:timeType
+						bind:wheelchair
+						bind:bikeRental
+						bind:bikeCarriage
+						bind:selectedModes={selectedTransitModes}
 					/>
-				</div>
-			</Card>
-		</Control>
-	{/if}
+				</Card>
+			</Control>
+
+			{#if routingResponses.length !== 0}
+				<Control class="min-h-0 md:mb-2 {page.state.selectedItinerary ? 'hide' : ''}">
+					<Card
+						class="w-[520px] h-full md:max-h-[70vh] overflow-y-auto overflow-x-hidden bg-background rounded-lg"
+					>
+						<ItineraryList
+							{baseResponse}
+							{routingResponses}
+							{baseQuery}
+							selectItinerary={(selectedItinerary) => pushState('', { selectedItinerary })}
+							updateStartDest={updateStartDest(from, to)}
+						/>
+					</Card>
+				</Control>
+			{/if}
+
+			{#if page.state.selectedItinerary && !page.state.selectedStop}
+				<Control class="min-h-0 mb-12 md:mb-2">
+					<Card class="w-[520px] h-full bg-background rounded-lg flex flex-col">
+						<div class="w-full flex justify-between items-center shadow-md pl-1 mb-1">
+							<h2 class="ml-2 text-base font-semibold">{t.journeyDetails}</h2>
+							<Button
+								variant="ghost"
+								onclick={() => {
+									pushStateWithQueryString({}, {});
+								}}
+							>
+								<X />
+							</Button>
+						</div>
+						<div
+							class={'p-2 md:p-4 overflow-y-auto overflow-x-hidden min-h-0 ' +
+								(showMap ? 'max-h-[40vh] md:max-h-[70vh]' : '')}
+						>
+							<ConnectionDetail
+								itinerary={page.state.selectedItinerary}
+								{onClickStop}
+								{onClickTrip}
+							/>
+						</div>
+					</Card>
+				</Control>
+				{#if showMap}
+					<ItineraryGeoJson itinerary={page.state.selectedItinerary} {level} />
+				{/if}
+			{/if}
+
+			{#if page.state.selectedStop}
+				<Control class="min-h-0 md:mb-2">
+					<Card class="w-[520px] h-full bg-background rounded-lg flex flex-col">
+						<div class="w-full flex justify-between items-center shadow-md pl-1 mb-1">
+							<h2 class="ml-2 text-base font-semibold">
+								{#if page.state.stopArriveBy}
+									{t.arrivals}
+								{:else}
+									{t.departures}
+								{/if}
+								in
+								{stopNameFromResponse}
+							</h2>
+							<Button
+								variant="ghost"
+								onclick={() => {
+									pushStateWithQueryString(
+										{ tripId: page.state.tripId },
+										{ selectedItinerary: page.state.selectedItinerary }
+									);
+								}}
+							>
+								<X />
+							</Button>
+						</div>
+						<div class="p-2 md:p-4 overflow-y-auto overflow-x-hidden min-h-0 md:max-h-[70vh]">
+							<StopTimes
+								stopId={page.state.selectedStop.stopId}
+								time={page.state.selectedStop.time}
+								bind:stopNameFromResponse
+								arriveBy={page.state.stopArriveBy}
+								setArriveBy={(arriveBy) =>
+									onClickStop(
+										page.state.selectedStop!.name,
+										page.state.selectedStop!.stopId,
+										page.state.selectedStop!.time,
+										arriveBy
+									)}
+								{onClickTrip}
+							/>
+						</div>
+					</Card>
+				</Control>
+			{/if}
+		</div>
+	</div>
 
 	{#if showMap}
 		<RailViz {map} {bounds} {zoom} {onClickTrip} />
@@ -458,17 +464,21 @@
 			<Marker color="red" draggable={true} {level} bind:location={to} bind:marker={toMarker} />
 		{/if}
 	{:else}
-		<Control position="bottom-left" class="pb-4">
-			<Button
-				size="icon"
-				variant="default"
-				onclick={() => {
-					showMap = true;
-					flyToSelectedItinerary();
-				}}
-			>
-				<MapIcon class="h-[1.2rem] w-[1.2rem]" />
-			</Button>
-		</Control>
+		<div class="maplibregl-control-container">
+			<div class="maplibregl-ctrl-bottom-left">
+				<Control class="pb-4">
+					<Button
+						size="icon"
+						variant="default"
+						onclick={() => {
+							showMap = true;
+							flyToSelectedItinerary();
+						}}
+					>
+						<MapIcon class="h-[1.2rem] w-[1.2rem]" />
+					</Button>
+				</Control>
+			</div>
+		</div>
 	{/if}
 </Map>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -35,6 +35,7 @@
 	import { t } from '$lib/i18n/translation';
 	import { pushState, replaceState } from '$app/navigation';
 	import { page } from '$app/state';
+	import { updateStartDest } from '$lib/updateStartDest';
 
 	const urlParams = browser ? new URLSearchParams(window.location.search) : undefined;
 	const hasDebug = urlParams && urlParams.has('debug');
@@ -165,10 +166,7 @@
 		if (baseQuery) {
 			clearTimeout(searchDebounceTimer);
 			searchDebounceTimer = setTimeout(() => {
-				const base = plan(baseQuery).then((response) => {
-					if (response.error) throw new Error(String(response.error));
-					return response.data!;
-				});
+				const base = plan(baseQuery).then(updateStartDest(from, to));
 				baseResponse = base;
 				routingResponses = [base];
 				pushStateWithQueryString(
@@ -363,6 +361,7 @@
 					{routingResponses}
 					{baseQuery}
 					selectItinerary={(selectedItinerary) => pushState('', { selectedItinerary })}
+					updateStartDest={updateStartDest(from, to)}
 				/>
 			</Card>
 		</Control>


### PR DESCRIPTION
* prima backports, closes #725, START/END filling as per #740 
* if we agree that we restrict ourselves to enable linking to a search and not to specific results/itineraries, closes https://github.com/public-transport/transitous/issues/899 (with a very ugly/long URL based on the existing JSON.stringified from/to params)
* preserves debug/dark/motis url params
* support for viewing UI without webgl (also used in mobile mode)