### PR TITLE
ODM tweaks

### DIFF
--- a/include/motis/odm/mixer.h
+++ b/include/motis/odm/mixer.h
@@ -31,6 +31,7 @@ struct mixer {
 
   double alpha_;
   double direct_taxi_penalty_;
+  std::int32_t max_distance_;
   std::vector<cost_threshold> walk_cost_;
   std::vector<cost_threshold> taxi_cost_;
   std::vector<cost_threshold> transfer_cost_;

--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -166,8 +166,7 @@ n::duration_t init_direct(std::vector<direct_ride>& direct_rides,
       e, gbfs, from_p, to_p, {api::ModeEnum::CAR}, std::nullopt, std::nullopt,
       std::nullopt, intvl.from_,
       query.pedestrianProfile_ == api::PedestrianProfileEnum::WHEELCHAIR,
-      std::chrono::seconds{kODMMaxDuration}, query.maxMatchingDistance_,
-      query.fastestDirectFactor_);
+      kODMMaxDuration, query.maxMatchingDistance_, query.fastestDirectFactor_);
 
   if (kODMDirectImprovement * taxi_duration > fastest_direct) {
     fmt::println(

--- a/src/odm/mixer.cc
+++ b/src/odm/mixer.cc
@@ -45,9 +45,9 @@ std::int32_t distance(nr::journey const& a, nr::journey const& b) {
 }
 
 std::string label(nr::journey const& j) {
-  return std::format("[dep: {}, arr: {}, dur: {}, transfers: {}]",
+  return std::format("[dep: {}, arr: {}, dur: {}, transfers: {}, odm_time: {}]",
                      j.departure_time(), j.arrival_time(), j.travel_time(),
-                     std::uint32_t{j.transfers_});
+                     std::uint32_t{j.transfers_}, odm_time(j));
 }
 
 double mixer::cost(nr::journey const& j) const {
@@ -101,7 +101,7 @@ bool mixer::cost_dominates(nr::journey const& a, nr::journey const& b) const {
                           static_cast<double>(b.travel_time().count());
   auto const dist = distance(a, b);
   auto const alpha_term = alpha_ * time_ratio * dist;
-  auto const ret = cost_a + alpha_term < cost_b;
+  auto const ret = dist < max_distance_ && cost_a + alpha_term < cost_b;
   if (kMixerTracing && ret) {
     fmt::println("{} cost-dominates {}, ratio: {}, dist: {}, {} + {} < {}",
                  label(a), label(b), time_ratio, dist, cost_a, alpha_term,
@@ -181,8 +181,9 @@ void mixer::mix(n::pareto_set<nr::journey> const& pt_journeys,
 }
 
 mixer get_default_mixer() {
-  return mixer{.alpha_ = 1.5,
+  return mixer{.alpha_ = 5.2,
                .direct_taxi_penalty_ = 200,
+               .max_distance_ = 90,
                .walk_cost_ = {{0, 1}, {15, 10}},
                .taxi_cost_ = {{0, 35}, {1, 12}},
                .transfer_cost_ = {{0, 10}}};

--- a/src/odm/mixer.cc
+++ b/src/odm/mixer.cc
@@ -181,7 +181,7 @@ void mixer::mix(n::pareto_set<nr::journey> const& pt_journeys,
 }
 
 mixer get_default_mixer() {
-  return mixer{.alpha_ = 5.2,
+  return mixer{.alpha_ = 5.3,
                .direct_taxi_penalty_ = 200,
                .max_distance_ = 90,
                .walk_cost_ = {{0, 1}, {15, 10}},

--- a/test/odm_test.cc
+++ b/test/odm_test.cc
@@ -82,7 +82,7 @@ TEST(odm, pt_taxi_no_direct) {
 
   get_default_mixer().mix(pt_journeys, odm_journeys);
 
-  ASSERT_EQ(odm_journeys.size(), 2U);
+  ASSERT_EQ(odm_journeys.size(), 3U);
   EXPECT_NE(utl::find(odm_journeys, pt), end(odm_journeys));
   EXPECT_NE(utl::find(odm_journeys, pt_taxi), end(odm_journeys));
 }


### PR DESCRIPTION
- max. ODM time set to 1h
- max. distance for cost-domination between ODM journeys set to 90 min
- testing increase of alpha to 5.2 to offer more ODM alternatives