### PR TITLE
docs: one-to-many does route, not geocode

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,7 +17,7 @@ paths:
   /api/v1/one-to-many:
     get:
       tags:
-        - geocode
+        - routing
       summary: |
         Street routing from one to many places or many to one.
         The order in the response array corresponds to the order of coordinates of the \`many\` parameter in the query.


### PR DESCRIPTION
Hi,
First of all, thanks for the awsome work done here.

I think I spotted a typo in the docs.
This API should likely be in the routing tab, not the geocoding tab.

![image](https://github.com/user-attachments/assets/bd45ca1b-9a57-4861-b5d4-d976a11566e6)