### PR TITLE
Group routing endpoints at the top

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14,291 +14,6 @@ externalDocs:
 servers:
   - url: https://europe.motis-project.de
 paths:
-  /api/v1/one-to-many:
-    get:
-      tags:
-        - routing
-      summary: |
-        Street routing from one to many places or many to one.
-        The order in the response array corresponds to the order of coordinates of the \`many\` parameter in the query.
-      operationId: oneToMany
-      parameters:
-        - name: one
-          in: query
-          required: true
-          description: geo location as latitude;longitude
-          schema:
-            type: string
-        - name: many
-          in: query
-          required: true
-          description: geo locations as latitude;longitude,latitude;longitude,...
-          schema:
-            type: array
-            items:
-              type: string
-        - name: mode
-          in: query
-          required: true
-          description: |
-            routing profile to use (currently supported: \`WALK\`, \`BIKE\`, \`CAR\`)
-          schema:
-            $ref: '#/components/schemas/Mode'
-        - name: max
-          in: query
-          required: true
-          description: maximum travel time in seconds
-          schema:
-            type: number
-        - name: maxMatchingDistance
-          in: query
-          required: true
-          description: maximum matching distance in meters to match geo coordinates to the street network
-          schema:
-            type: number
-        - name: arriveBy
-          in: query
-          required: true
-          description: |
-            true = many to one
-            false = one to many
-          schema:
-            type: boolean
-      responses:
-        200:
-          description: |
-            A list of durations.
-            If no path was found, the object is empty.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Duration'
-
-  /api/v1/reverse-geocode:
-    get:
-      tags:
-        - geocode
-      summary: Translate coordinates to the closest address(es)/places/stops.
-      operationId: reverseGeocode
-      parameters:
-        - name: place
-          in: query
-          required: true
-          description: latitude, longitude in degrees
-          schema:
-            type: string
-        - name: type
-          in: query
-          required: false
-          description: |
-            Optional. Default is all types.
-            
-            Only return results of the given type.
-            For example, this can be used to allow only `ADDRESS` and `STOP` results.
-          schema:
-            $ref: '#/components/schemas/LocationType'
-      responses:
-        200:
-          description: A list of guesses to resolve the coordinates to a location
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Match'
-
-  /api/v1/geocode:
-    get:
-      tags:
-        - geocode
-      summary: Autocompletion & geocoding that resolves user input addresses including coordinates
-      operationId: geocode
-      parameters:
-        - name: text
-          in: query
-          required: true
-          description: the (potentially partially typed) address to resolve
-          schema:
-            type: string
-
-        - name: language
-          in: query
-          required: false
-          description: |
-            language tags as used in OpenStreetMap
-            (usually ISO 639-1, or ISO 639-2 if there's no ISO 639-1)
-          schema:
-            type: string
-        - name: type
-          in: query
-          required: false
-          description: |
-            Optional. Default is all types.
-            
-            Only return results of the given types.
-            For example, this can be used to allow only `ADDRESS` and `STOP` results.
-          schema:
-            $ref: '#/components/schemas/LocationType'
-
-      responses:
-        200:
-          description: A list of guesses to resolve the text to a location
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Match'
-
-  /api/v1/trip:
-    get:
-      tags:
-        - timetable
-      summary: Get a trip as itinerary
-      operationId: trip
-      parameters:
-        - name: tripId
-          in: query
-          schema:
-            type: string
-          required: true
-          description: trip identifier (e.g. from an itinerary leg or stop event)
-      responses:
-        200:
-          description: the requested trip as itinerary
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Itinerary'
-
-  /api/v1/stoptimes:
-    get:
-      tags:
-        - timetable
-      summary: Get the next N departures or arrivals of a stop sorted by time
-      operationId: stoptimes
-      parameters:
-        - name: stopId
-          in: query
-          schema:
-            type: string
-          required: true
-          description: stop id of the stop to retrieve departures/arrivals for
-
-        - name: time
-          in: query
-          required: false
-          description: |
-            Optional. Defaults to the current time.
-          schema:
-            type: string
-            format: date-time
-
-        - name: arriveBy
-          in: query
-          required: false
-          schema:
-            type: boolean
-            default: false
-          description: |
-            Optional. Default is `false`.
-            
-              - `arriveBy=true`: the parameters `date` and `time` refer to the arrival time
-              - `arriveBy=false`: the parameters `date` and `time` refer to the departure time
-
-        - name: direction
-          in: query
-          required: false
-          schema:
-            type: string
-            enum:
-              - EARLIER
-              - LATER
-          description: |
-            This parameter will be ignored in case `pageCursor` is set.
-            
-            Optional. Default is
-              - `LATER` for `arriveBy=false`
-              - `EARLIER` for `arriveBy=true`
-            
-            The response will contain the next `n` arrivals / departures
-            in case `EARLIER` is selected and the previous `n`
-            arrivals / departures if `LATER` is selected.
-
-        - name: mode
-          in: query
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/Mode'
-            default:
-              - TRANSIT
-          description: |
-            Optional. Default is all transit modes.
-            
-            Only return arrivals/departures of the given modes.
-
-        - name: n
-          in: query
-          schema:
-            type: integer
-          required: true
-          description: the number of events
-
-        - name: radius
-          in: query
-          schema:
-            type: integer
-          required: false
-          description: |
-            Optional. Radius in meters.
-            
-            Default is that only stop times of the parent of the stop itself
-            and all stops with the same name (+ their child stops) are returned.
-            
-            If set, all stops at parent stations and their child stops in the specified radius
-            are returned.
-
-        - name: pageCursor
-          in: query
-          required: false
-          description: |
-            Use the cursor to go to the next "page" of stop times.
-            Copy the cursor from the last response and keep the original request as is.
-            This will enable you to search for stop times in the next or previous time-window.
-          schema:
-            type: string
-
-      responses:
-        200:
-          description: A list of guesses to resolve the text to a location
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - stopTimes
-                  - previousPageCursor
-                  - nextPageCursor
-                properties:
-                  stopTimes:
-                    description: list of stop times
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/StopTime'
-                  previousPageCursor:
-                    description: |
-                      Use the cursor to get the previous page of results. Insert the cursor into the request and post it to get the previous page.
-                      The previous page is a set of stop times BEFORE the first stop time in the result.
-                    type: string
-                  nextPageCursor:
-                    description: |
-                      Use the cursor to get the next page of results. Insert the cursor into the request and post it to get the next page.
-                      The next page is a set of stop times AFTER the last stop time in this result.
-                    type: string
-
   /api/v1/plan:
     get:
       tags:
@@ -905,6 +620,68 @@ paths:
                       The next page is a set of itineraries departing AFTER the last itinerary in this result.
                     type: string
 
+  /api/v1/one-to-many:
+    get:
+      tags:
+        - routing
+      summary: |
+        Street routing from one to many places or many to one.
+        The order in the response array corresponds to the order of coordinates of the \`many\` parameter in the query.
+      operationId: oneToMany
+      parameters:
+        - name: one
+          in: query
+          required: true
+          description: geo location as latitude;longitude
+          schema:
+            type: string
+        - name: many
+          in: query
+          required: true
+          description: geo locations as latitude;longitude,latitude;longitude,...
+          schema:
+            type: array
+            items:
+              type: string
+        - name: mode
+          in: query
+          required: true
+          description: |
+            routing profile to use (currently supported: \`WALK\`, \`BIKE\`, \`CAR\`)
+          schema:
+            $ref: '#/components/schemas/Mode'
+        - name: max
+          in: query
+          required: true
+          description: maximum travel time in seconds
+          schema:
+            type: number
+        - name: maxMatchingDistance
+          in: query
+          required: true
+          description: maximum matching distance in meters to match geo coordinates to the street network
+          schema:
+            type: number
+        - name: arriveBy
+          in: query
+          required: true
+          description: |
+            true = many to one
+            false = one to many
+          schema:
+            type: boolean
+      responses:
+        200:
+          description: |
+            A list of durations.
+            If no path was found, the object is empty.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Duration'
+
   /api/experimental/one-to-all:
     get:
       tags:
@@ -1046,6 +823,229 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Reachable'
+
+  /api/v1/reverse-geocode:
+    get:
+      tags:
+        - geocode
+      summary: Translate coordinates to the closest address(es)/places/stops.
+      operationId: reverseGeocode
+      parameters:
+        - name: place
+          in: query
+          required: true
+          description: latitude, longitude in degrees
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: false
+          description: |
+            Optional. Default is all types.
+            
+            Only return results of the given type.
+            For example, this can be used to allow only `ADDRESS` and `STOP` results.
+          schema:
+            $ref: '#/components/schemas/LocationType'
+      responses:
+        200:
+          description: A list of guesses to resolve the coordinates to a location
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Match'
+
+  /api/v1/geocode:
+    get:
+      tags:
+        - geocode
+      summary: Autocompletion & geocoding that resolves user input addresses including coordinates
+      operationId: geocode
+      parameters:
+        - name: text
+          in: query
+          required: true
+          description: the (potentially partially typed) address to resolve
+          schema:
+            type: string
+
+        - name: language
+          in: query
+          required: false
+          description: |
+            language tags as used in OpenStreetMap
+            (usually ISO 639-1, or ISO 639-2 if there's no ISO 639-1)
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: false
+          description: |
+            Optional. Default is all types.
+            
+            Only return results of the given types.
+            For example, this can be used to allow only `ADDRESS` and `STOP` results.
+          schema:
+            $ref: '#/components/schemas/LocationType'
+
+      responses:
+        200:
+          description: A list of guesses to resolve the text to a location
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Match'
+
+  /api/v1/trip:
+    get:
+      tags:
+        - timetable
+      summary: Get a trip as itinerary
+      operationId: trip
+      parameters:
+        - name: tripId
+          in: query
+          schema:
+            type: string
+          required: true
+          description: trip identifier (e.g. from an itinerary leg or stop event)
+      responses:
+        200:
+          description: the requested trip as itinerary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Itinerary'
+
+  /api/v1/stoptimes:
+    get:
+      tags:
+        - timetable
+      summary: Get the next N departures or arrivals of a stop sorted by time
+      operationId: stoptimes
+      parameters:
+        - name: stopId
+          in: query
+          schema:
+            type: string
+          required: true
+          description: stop id of the stop to retrieve departures/arrivals for
+
+        - name: time
+          in: query
+          required: false
+          description: |
+            Optional. Defaults to the current time.
+          schema:
+            type: string
+            format: date-time
+
+        - name: arriveBy
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: |
+            Optional. Default is `false`.
+            
+              - `arriveBy=true`: the parameters `date` and `time` refer to the arrival time
+              - `arriveBy=false`: the parameters `date` and `time` refer to the departure time
+
+        - name: direction
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - EARLIER
+              - LATER
+          description: |
+            This parameter will be ignored in case `pageCursor` is set.
+            
+            Optional. Default is
+              - `LATER` for `arriveBy=false`
+              - `EARLIER` for `arriveBy=true`
+            
+            The response will contain the next `n` arrivals / departures
+            in case `EARLIER` is selected and the previous `n`
+            arrivals / departures if `LATER` is selected.
+
+        - name: mode
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Mode'
+            default:
+              - TRANSIT
+          description: |
+            Optional. Default is all transit modes.
+            
+            Only return arrivals/departures of the given modes.
+
+        - name: n
+          in: query
+          schema:
+            type: integer
+          required: true
+          description: the number of events
+
+        - name: radius
+          in: query
+          schema:
+            type: integer
+          required: false
+          description: |
+            Optional. Radius in meters.
+            
+            Default is that only stop times of the parent of the stop itself
+            and all stops with the same name (+ their child stops) are returned.
+            
+            If set, all stops at parent stations and their child stops in the specified radius
+            are returned.
+
+        - name: pageCursor
+          in: query
+          required: false
+          description: |
+            Use the cursor to go to the next "page" of stop times.
+            Copy the cursor from the last response and keep the original request as is.
+            This will enable you to search for stop times in the next or previous time-window.
+          schema:
+            type: string
+
+      responses:
+        200:
+          description: A list of guesses to resolve the text to a location
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - stopTimes
+                  - previousPageCursor
+                  - nextPageCursor
+                properties:
+                  stopTimes:
+                    description: list of stop times
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/StopTime'
+                  previousPageCursor:
+                    description: |
+                      Use the cursor to get the previous page of results. Insert the cursor into the request and post it to get the previous page.
+                      The previous page is a set of stop times BEFORE the first stop time in the result.
+                    type: string
+                  nextPageCursor:
+                    description: |
+                      Use the cursor to get the next page of results. Insert the cursor into the request and post it to get the next page.
+                      The next page is a set of stop times AFTER the last stop time in this result.
+                    type: string
 
   /api/v1/map/trips:
     get:


### PR DESCRIPTION
Change endpoint ordering, as discussed in https://github.com/motis-project/motis/pull/783#discussion_r2003002481

The new ordering will be:

```
/api/v1/plan: routing
/api/v1/one-to-many: routing
/api/experimental/one-to-all: routing
/api/v1/reverse-geocode: geocode
/api/v1/geocode: geocode
/api/v1/trip: timetable
/api/v1/stoptimes: timetable
/api/v1/map/trips: map
/api/v1/map/initial: map
/api/v1/map/stops: map
/api/v1/map/levels: map
/api/debug/footpaths: debug
```