### PR TITLE
Shorten ODM along the connected PT route

### DIFF
--- a/include/motis/odm/meta_router.h
+++ b/include/motis/odm/meta_router.h
@@ -68,7 +68,6 @@ private:
       nigiri::interval<nigiri::unixtime_t> const&) const;
   std::vector<routing_result> search_interval(
       std::vector<nigiri::routing::query> const&) const;
-  void shorten_odm() const;
   void add_direct() const;
 
   ep::routing const& r_;

--- a/include/motis/odm/meta_router.h
+++ b/include/motis/odm/meta_router.h
@@ -68,6 +68,7 @@ private:
       nigiri::interval<nigiri::unixtime_t> const&) const;
   std::vector<routing_result> search_interval(
       std::vector<nigiri::routing::query> const&) const;
+  void shorten_odm() const;
   void add_direct() const;
 
   ep::routing const& r_;

--- a/include/motis/odm/odm.h
+++ b/include/motis/odm/odm.h
@@ -28,4 +28,6 @@ nigiri::duration_t odm_time(nigiri::routing::journey const&);
 
 nigiri::duration_t duration(nigiri::routing::start const&);
 
+std::string odm_label(nigiri::routing::journey const&);
+
 }  // namespace motis::odm

--- a/include/motis/odm/odm.h
+++ b/include/motis/odm/odm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nigiri/routing/journey.h"
+#include "nigiri/routing/start_times.h"
 #include "nigiri/types.h"
 
 #include "motis-api/motis-api.h"
@@ -24,5 +25,7 @@ bool is_direct_odm(nigiri::routing::journey const&);
 nigiri::duration_t odm_time(nigiri::routing::journey::leg const&);
 
 nigiri::duration_t odm_time(nigiri::routing::journey const&);
+
+nigiri::duration_t duration(nigiri::routing::start const&);
 
 }  // namespace motis::odm

--- a/include/motis/odm/shorten.h
+++ b/include/motis/odm/shorten.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace motis::odm {
+
+void shorten(std::vector<nigiri::routing::journey>&,
+             std::vector<nigiri::routing::start> const& from_rides,
+             std::vector<nigiri::routing::start> const& to_rides,
+             nigiri::timetable const&,
+             nigiri::rt_timetable const*,
+             api::plan_params const&);
+
+}  // namespace motis::odm

--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -39,6 +39,7 @@
 #include "motis/odm/mixer.h"
 #include "motis/odm/odm.h"
 #include "motis/odm/prima.h"
+#include "motis/odm/shorten.h"
 #include "motis/place.h"
 #include "motis/street_routing.h"
 #include "motis/timetable/modes_to_clasz_mask.h"
@@ -438,147 +439,6 @@ void collect_odm_journeys(
                p->odm_journeys_.size());
 }
 
-void meta_router::shorten_odm() const {
-  auto const duration = [](n::routing::start const& ride) {
-    return std::chrono::abs(ride.time_at_stop_ - ride.time_at_start_);
-  };
-
-  auto const shorten_first_leg = [&](n::routing::journey& j) {
-    if (!is_odm_leg(begin(j.legs_)[0]) ||
-        !std::holds_alternative<n::routing::journey::run_enter_exit>(
-            begin(j.legs_)[1].uses_)) {
-      return;
-    }
-    auto& odm_leg = begin(j.legs_)[0];
-    auto& pt_leg = begin(j.legs_)[1];
-    auto run = nigiri::rt::frun(
-        *tt_, rtt_,
-        std::get<n::routing::journey::run_enter_exit>(pt_leg.uses_).r_);
-    auto min_stop_idx = run.stop_range_.from_;
-    run.stop_range_.from_ = n::stop_idx_t{0U};
-    auto min_odm_duration = odm_time(odm_leg);
-    auto shorter_ride = std::optional<n::routing::start>{};
-    for (auto const stop : run) {
-      if (stop.is_canceled() ||
-          !stop.in_allowed(query_.pedestrianProfile_ ==
-                           api::PedestrianProfileEnum::WHEELCHAIR) ||
-          (query_.requireBikeTransport_ &&
-           !stop.bikes_allowed(n::event_type::kDep))) {
-        continue;
-      }
-      for (auto& ride : p->from_rides_) {
-        if (n::routing::matches(*tt_,
-                                n::routing::location_match_mode::kEquivalent,
-                                ride.stop_, stop.get_location_idx()) &&
-            ride.time_at_stop_ == stop.time(n::event_type::kDep)) {
-          auto const cur_odm_duration = duration(ride);
-          if (cur_odm_duration < min_odm_duration) {
-            min_stop_idx = stop.stop_idx_;
-            min_odm_duration = cur_odm_duration;
-            shorter_ride = ride;
-          }
-          break;
-        }
-      }
-    }
-    if (shorter_ride) {
-      std::println("Found a shorter ODM first leg: [{},{}]",
-                   tt_->locations_.get(shorter_ride->stop_).name_,
-                   min_odm_duration);
-      auto& odm_offset = std::get<n::routing::offset>(odm_leg.uses_);
-      auto& pt_run_enter_exit =
-          std::get<n::routing::journey::run_enter_exit>(pt_leg.uses_);
-      j.start_time_ = odm_leg.dep_time_ = shorter_ride->time_at_start_;
-      odm_offset.duration_ = min_odm_duration;
-      odm_leg.arr_time_ = pt_leg.dep_time_ = shorter_ride->time_at_stop_;
-      odm_leg.to_ = odm_offset.target_ = pt_leg.from_ = shorter_ride->stop_;
-      pt_run_enter_exit.stop_range_.from_ =
-          pt_run_enter_exit.r_.stop_range_.from_ = min_stop_idx;
-    }
-  };
-
-  auto const shorten_last_leg = [&](n::routing::journey& j) {
-    auto const get_max_stop_idx = [&](n::rt::frun const& r) -> n::stop_idx_t {
-      if (r.is_rt()) {
-        return static_cast<n::stop_idx_t>(
-            rtt_->rt_transport_location_seq_[r.rt_].size());
-      } else if (r.is_scheduled()) {
-        return static_cast<n::stop_idx_t>(
-            tt_->route_location_seq_[tt_->transport_route_[r.t_.t_idx_]]
-                .size());
-      } else {
-        std::unreachable();
-      }
-    };
-
-    if (!is_odm_leg(rbegin(j.legs_)[0]) ||
-        !std::holds_alternative<n::routing::journey::run_enter_exit>(
-            rbegin(j.legs_)[1].uses_)) {
-      return;
-    }
-
-    auto& odm_leg = rbegin(j.legs_)[0];
-    auto& pt_leg = rbegin(j.legs_)[1];
-    auto run = nigiri::rt::frun(
-        *tt_, rtt_,
-        std::get<n::routing::journey::run_enter_exit>(pt_leg.uses_).r_);
-    auto min_stop_idx = run.stop_range_.to_;
-    run.stop_range_.to_ = get_max_stop_idx(run);
-    auto min_odm_duration = odm_time(odm_leg);
-    auto shorter_ride = std::optional<n::routing::start>{};
-    std::println("\nmin_start: {},{}", tt_->locations_.get(odm_leg.from_).name_,
-                 min_odm_duration);
-    for (auto const stop : run) {
-      std::println("examining stop: {}", stop.name());
-      if (stop.is_canceled() ||
-          !stop.out_allowed(query_.pedestrianProfile_ ==
-                            api::PedestrianProfileEnum::WHEELCHAIR) ||
-          (query_.requireBikeTransport_ &&
-           !stop.bikes_allowed(n::event_type::kArr))) {
-        continue;
-      }
-      for (auto& ride : p->to_rides_) {
-        if (n::routing::matches(*tt_,
-                                n::routing::location_match_mode::kEquivalent,
-                                ride.stop_, stop.get_location_idx()) &&
-            ride.time_at_stop_ == stop.time(n::event_type::kArr)) {
-          auto const cur_odm_duration = duration(ride);
-          std::println("odm_duration: {}", cur_odm_duration);
-          if (cur_odm_duration <= min_odm_duration) {
-            min_stop_idx = stop.stop_idx_;
-            min_odm_duration = cur_odm_duration;
-            shorter_ride = ride;
-          }
-          break;
-        }
-      }
-    }
-    if (shorter_ride) {
-      std::println("Found a shorter ODM last leg: [{}, {}, {}]", min_stop_idx,
-                   tt_->locations_.get(shorter_ride->stop_).name_,
-                   min_odm_duration);
-      auto& odm_offset = std::get<n::routing::offset>(odm_leg.uses_);
-      auto& pt_run_enter_exit =
-          std::get<n::routing::journey::run_enter_exit>(pt_leg.uses_);
-      pt_run_enter_exit.stop_range_.to_ = pt_run_enter_exit.r_.stop_range_.to_ =
-          min_stop_idx + 1U;
-      pt_leg.to_ = odm_leg.from_ = odm_offset.target_ = shorter_ride->stop_;
-      pt_leg.arr_time_ = odm_leg.dep_time_ = shorter_ride->time_at_stop_;
-      odm_offset.duration_ = min_odm_duration;
-      j.dest_time_ = odm_leg.arr_time_ = shorter_ride->time_at_start_;
-    }
-  };
-
-  for (auto& j : p->odm_journeys_) {
-    if (j.legs_.empty()) {
-      fmt::println("shorten_odm: journey without legs");
-      continue;
-    }
-    shorten_first_leg(j);
-    shorten_last_leg(j);
-  }
-}
-
 void extract_rides() {
   p->from_rides_.clear();
   p->to_rides_.clear();
@@ -789,7 +649,7 @@ api::plan_response meta_router::run() {
   auto const results = search_interval(sub_queries);
   auto const& pt_result = results.front();
   collect_odm_journeys(results);
-  shorten_odm();
+  shorten(p->odm_journeys_, p->from_rides_, p->to_rides_, *tt_, rtt_, query_);
   fmt::println("[routing] interval searched: {}", pt_result.interval_);
   print_time(routing_start, "[routing]");
 

--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -638,6 +638,16 @@ api::plan_response meta_router::run() {
   auto const& pt_result = results.front();
   collect_odm_journeys(results);
   shorten(p->odm_journeys_, p->from_rides_, p->to_rides_, *tt_, rtt_, query_);
+  utl::erase_duplicates(
+      p->odm_journeys_,
+      [](auto const& a, auto const& b) {
+        return a.start_time_ < b.start_time_;
+      },
+      [](auto const& a, auto const& b) {
+        return a == b &&
+               odm_time(a.legs_.front()) == odm_time(b.legs_.front()) &&
+               odm_time(a.legs_.back()) == odm_time(b.legs_.back());
+      });
   fmt::println("[routing] interval searched: {}", pt_result.interval_);
   print_time(routing_start, "[routing]");
 

--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -18,7 +18,6 @@
 
 #include "utl/erase_duplicates.h"
 
-#include "nigiri/for_each_meta.h"
 #include "nigiri/routing/journey.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/query.h"

--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -272,28 +272,17 @@ bool ride_comp(n::routing::start const& a, n::routing::start const& b) {
 }
 
 auto ride_time_halves(std::vector<n::routing::start>& rides) {
-  auto const duration = [](auto const& ride) {
-    return std::chrono::abs(ride.time_at_stop_ - ride.time_at_start_);
-  };
-
   auto const by_duration = [&](auto const& a, auto const& b) {
     return duration(a) < duration(b);
   };
 
   utl::sort(rides, by_duration);
   auto const split =
-      rides.empty()
-          ? 0
-          : std::distance(
-                begin(rides),
-                std::upper_bound(
-                    begin(rides), end(rides),
-                    n::routing::start{
-                        .time_at_start_ = n::unixtime_t{},
-                        .time_at_stop_ =
-                            n::unixtime_t{} + duration(rides.front()) + 1min,
-                        .stop_ = n::location_idx_t::invalid()},
-                    by_duration));
+      rides.empty() ? 0
+                    : std::distance(begin(rides),
+                                    std::upper_bound(begin(rides), end(rides),
+                                                     rides[rides.size() / 2],
+                                                     by_duration));
 
   auto lo = rides | std::views::take(split);
   auto hi = rides | std::views::drop(split);

--- a/src/odm/odm.cc
+++ b/src/odm/odm.cc
@@ -36,4 +36,8 @@ n::duration_t odm_time(nr::journey const& j) {
                                [](auto const& l) { return odm_time(l); });
 }
 
+n::duration_t duration(nr::start const& ride) {
+  return std::chrono::abs(ride.time_at_stop_ - ride.time_at_start_);
+};
+
 }  // namespace motis::odm

--- a/src/odm/odm.cc
+++ b/src/odm/odm.cc
@@ -38,6 +38,13 @@ n::duration_t odm_time(nr::journey const& j) {
 
 n::duration_t duration(nr::start const& ride) {
   return std::chrono::abs(ride.time_at_stop_ - ride.time_at_start_);
-};
+}
+
+std::string odm_label(nr::journey const& j) {
+  return fmt::format(
+      "[dep: {}, arr: {}, transfers: {}, start_odm: {}, dest_odm: {}]",
+      j.start_time_, j.dest_time_, j.transfers_, odm_time(j.legs_.front()),
+      odm_time(j.legs_.back()));
+}
 
 }  // namespace motis::odm

--- a/src/odm/shorten.cc
+++ b/src/odm/shorten.cc
@@ -1,0 +1,146 @@
+#include "motis/odm/odm.h"
+
+#include "nigiri/for_each_meta.h"
+#include "nigiri/rt/frun.h"
+#include "nigiri/rt/rt_timetable.h"
+#include "nigiri/timetable.h"
+
+#include "motis-api/motis-api.h"
+
+namespace motis::odm {
+
+namespace n = nigiri;
+namespace nr = nigiri::routing;
+
+void shorten(std::vector<nr::journey>& odm_journeys,
+             std::vector<nr::start> const& from_rides,
+             std::vector<nr::start> const& to_rides,
+             n::timetable const& tt,
+             n::rt_timetable const* rtt,
+             api::plan_params const& query) {
+
+  auto const shorten_first_leg = [&](n::routing::journey& j) {
+    auto& odm_leg = begin(j.legs_)[0];
+    auto& pt_leg = begin(j.legs_)[1];
+
+    if (!is_odm_leg(odm_leg) ||
+        !std::holds_alternative<nr::journey::run_enter_exit>(pt_leg.uses_)) {
+      return;
+    }
+
+    auto const& ree = std::get<nr::journey::run_enter_exit>(pt_leg.uses_);
+    auto run = n::rt::frun(tt, rtt, ree.r_);
+    run.stop_range_.to_ = ree.stop_range_.to_;
+    auto min_stop_idx = ree.stop_range_.from_;
+    auto min_odm_duration = odm_time(odm_leg);
+    auto shorter_ride = std::optional<n::routing::start>{};
+    for (auto const stop : run) {
+      if (stop.is_canceled() ||
+          !stop.in_allowed(query.pedestrianProfile_ ==
+                           api::PedestrianProfileEnum::WHEELCHAIR) ||
+          (query.requireBikeTransport_ &&
+           !stop.bikes_allowed(n::event_type::kDep))) {
+        continue;
+      }
+      for (auto& ride : from_rides) {
+        if (n::routing::matches(tt,
+                                n::routing::location_match_mode::kEquivalent,
+                                ride.stop_, stop.get_location_idx()) &&
+            ride.time_at_stop_ == stop.time(n::event_type::kDep)) {
+          auto const cur_odm_duration = duration(ride);
+          if (cur_odm_duration < min_odm_duration) {
+            min_stop_idx = stop.stop_idx_;
+            min_odm_duration = cur_odm_duration;
+            shorter_ride = ride;
+          }
+          break;
+        }
+      }
+    }
+    if (shorter_ride) {
+      std::println("Found a shorter ODM first leg: [{},{}]",
+                   tt.locations_.get(shorter_ride->stop_).name_,
+                   min_odm_duration);
+      auto& odm_offset = std::get<n::routing::offset>(odm_leg.uses_);
+      auto& pt_run_enter_exit =
+          std::get<n::routing::journey::run_enter_exit>(pt_leg.uses_);
+      j.start_time_ = odm_leg.dep_time_ = shorter_ride->time_at_start_;
+      odm_offset.duration_ = min_odm_duration;
+      odm_leg.arr_time_ = pt_leg.dep_time_ = shorter_ride->time_at_stop_;
+      odm_leg.to_ = odm_offset.target_ = pt_leg.from_ = shorter_ride->stop_;
+      pt_run_enter_exit.stop_range_.from_ =
+          pt_run_enter_exit.r_.stop_range_.from_ = min_stop_idx;
+    }
+  };
+
+  auto const shorten_last_leg = [&](n::routing::journey& j) {
+    auto& odm_leg = rbegin(j.legs_)[0];
+    auto& pt_leg = rbegin(j.legs_)[1];
+
+    if (!is_odm_leg(odm_leg) ||
+        !std::holds_alternative<n::routing::journey::run_enter_exit>(
+            pt_leg.uses_)) {
+      return;
+    }
+
+    auto const& ree =
+        std::get<n::routing::journey::run_enter_exit>(pt_leg.uses_);
+    auto run = nigiri::rt::frun(tt, rtt, ree.r_);
+    run.stop_range_.from_ = ree.stop_range_.from_ + 1U;
+    auto min_stop_idx = static_cast<n::stop_idx_t>(ree.stop_range_.to_ - 1U);
+    auto min_odm_duration = odm_time(odm_leg);
+    auto shorter_ride = std::optional<n::routing::start>{};
+    std::println("\nmin_start: {},{}", tt.locations_.get(odm_leg.from_).name_,
+                 min_odm_duration);
+    for (auto const stop : run) {
+      std::println("examining stop: {}", stop.name());
+      if (stop.is_canceled() ||
+          !stop.out_allowed(query.pedestrianProfile_ ==
+                            api::PedestrianProfileEnum::WHEELCHAIR) ||
+          (query.requireBikeTransport_ &&
+           !stop.bikes_allowed(n::event_type::kArr))) {
+        continue;
+      }
+      for (auto& ride : to_rides) {
+        if (n::routing::matches(tt,
+                                n::routing::location_match_mode::kEquivalent,
+                                ride.stop_, stop.get_location_idx()) &&
+            ride.time_at_stop_ == stop.time(n::event_type::kArr)) {
+          auto const cur_odm_duration = duration(ride);
+          std::println("odm_duration: {}", cur_odm_duration);
+          if (cur_odm_duration <= min_odm_duration) {
+            min_stop_idx = stop.stop_idx_;
+            min_odm_duration = cur_odm_duration;
+            shorter_ride = ride;
+          }
+          break;
+        }
+      }
+    }
+    if (shorter_ride) {
+      std::println("Found a shorter ODM last leg: [{}, {}, {}]", min_stop_idx,
+                   tt.locations_.get(shorter_ride->stop_).name_,
+                   min_odm_duration);
+      auto& odm_offset = std::get<n::routing::offset>(odm_leg.uses_);
+      auto& pt_run_enter_exit =
+          std::get<n::routing::journey::run_enter_exit>(pt_leg.uses_);
+      pt_run_enter_exit.stop_range_.to_ = pt_run_enter_exit.r_.stop_range_.to_ =
+          min_stop_idx + 1U;
+      pt_leg.to_ = odm_leg.from_ = odm_offset.target_ = shorter_ride->stop_;
+      pt_leg.arr_time_ = odm_leg.dep_time_ = shorter_ride->time_at_stop_;
+      odm_offset.duration_ = min_odm_duration;
+      j.dest_time_ = odm_leg.arr_time_ = shorter_ride->time_at_start_;
+    }
+  };
+
+  for (auto& j : odm_journeys) {
+    if (j.legs_.empty()) {
+      fmt::println("shorten_odm: journey without legs");
+      continue;
+    }
+    shorten_first_leg(j);
+    shorten_last_leg(j);
+  }
+}
+
+}  // namespace motis::odm


### PR DESCRIPTION
Attempts to shorten the ODM first/last mile by scanning the stop sequence of the connected public transit leg for a stop with shorter ODM offset.

Currently, can lead to journeys from different subqueries be shortened to the same journey resulting in duplicates.  

TODO:
- [x] deduplicate ODM journeys