### PR TITLE
docs(openapi): accidenttally "advertising" a required parameter

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -574,7 +574,6 @@ paths:
                 required:
                   - requestParameters
                   - debugOutput
-                  - date
                   - from
                   - to
                   - direct


### PR DESCRIPTION
During integration of the API I noticed this bug in the docs.

The value is not produced via the api when I tested => just mistakenly included in the array