### PR TITLE
Change server url to Transitous

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,7 +12,7 @@ externalDocs:
   description: Find out more about MOTIS
   url: https://github.com/motis-project/motis
 servers:
-  - url: https://europe.motis-project.de
+  - url: https://api.transitous.org
 paths:
   /api/v1/plan:
     get:


### PR DESCRIPTION
The file previously pointed to https://europe.motis-project.de/, a now dead website. It now uses the Transitous API, running motis.