### PR TITLE
docs: specify that `length` for `EncodedPolyline` cannot be negative

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1624,7 +1624,6 @@ components:
           description: The number of points in the string
           type: integer
           minimum: 0
-          format: int64
 
     StepInstruction:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1623,6 +1623,8 @@ components:
         length:
           description: The number of points in the string
           type: integer
+          minimum: 0
+          format: int64
 
     StepInstruction:
       type: object


### PR DESCRIPTION
This is came up as otherwise some openapi-tooling generates signed integers.

The int64 comes from here:
https://github.com/motis-project/motis/blob/add29967c455b48ae8933f670261fd1049556924/src/journey_to_response.cc#L279-L280