### PR TITLE
Support for timetable attribution link

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,7 +38,8 @@ server:
   host: 0.0.0.0                     # host (default = 0.0.0.0)
   port: 8080                        # port (default = 8080)
   web_folder: ui                    # folder with static files to serve
-  n_threads: 24                     # default (if not set): number of hardware threads 
+  n_threads: 24                     # default (if not set): number of hardware threads
+  data_attribution_link: https://creativecommons.org/licenses/by/4.0/ # link to data sources or license exposed in HTTP headers and UI
 osm: netherlands-latest.osm.pbf     # required by tiles, street routing, geocoding and reverse-geocoding
 tiles:                              # tiles won't be available if this key is missing
   profile: tiles-profiles/full.lua  # currently `background.lua` (less details) and `full.lua` (more details) are available

--- a/include/motis/config.h
+++ b/include/motis/config.h
@@ -37,6 +37,7 @@ struct config {
     std::string port_{"8080"};
     std::string web_folder_{"ui"};
     unsigned n_threads_{std::thread::hardware_concurrency()};
+    std::optional<std::string> data_attribution_link_{};
   };
   std::optional<server> server_{};
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -62,9 +62,9 @@ int server(data d, config const& c, std::string_view const motis_version) {
   auto s = net::web_server{ioc};
   auto r = runner{server_config.n_threads_, 1024U};
   auto qr = net::query_router{net::fiber_exec{ioc, r.ch_}};
-  qr.add_header("Server", std::format("MOTIS {}", motis_version));
+  qr.add_header("Server", fmt::format("MOTIS {}", motis_version));
   if (c.server_->data_attribution_link_) {
-    qr.add_header("Link", std::format("<{}>; rel=\"license\"",
+    qr.add_header("Link", fmt::format("<{}>; rel=\"license\"",
                                       *c.server_->data_attribution_link_));
   }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -63,6 +63,10 @@ int server(data d, config const& c, std::string_view const motis_version) {
   auto r = runner{server_config.n_threads_, 1024U};
   auto qr = net::query_router{net::fiber_exec{ioc, r.ch_}};
   qr.add_header("Server", std::format("MOTIS {}", motis_version));
+  if (c.server_->data_attribution_link_) {
+    qr.add_header("Link", std::format("<{}>; rel=\"license\"",
+                                      *c.server_->data_attribution_link_));
+  }
 
   POST<ep::matches>(qr, "/api/matches", d);
   POST<ep::elevators>(qr, "/api/elevators", d);

--- a/ui/src/lib/i18n/de.ts
+++ b/ui/src/lib/i18n/de.ts
@@ -48,6 +48,7 @@ const translations: Translations = {
 	bikeRental: 'Sharing-Fahrzeuge berücksichtigen',
 	bikeCarriage: 'Fahrradmitnahme',
 	unreliableOptions: 'Je nach Datenverfügbarkeit können diese Optionen unzuverlässig sein.',
+	timetableSources: 'Fahrplandatenquellen',
 	WALK: 'Zu Fuß',
 	BIKE: 'Fahrrad',
 	RENTAL: 'Sharing',

--- a/ui/src/lib/i18n/en.ts
+++ b/ui/src/lib/i18n/en.ts
@@ -47,6 +47,7 @@ const translations: Translations = {
 	bikeRental: 'Allow usage of sharing vehicles',
 	bikeCarriage: 'Bike carriage',
 	unreliableOptions: 'Depending on data availability, these options may be unreliable.',
+	timetableSources: 'Timetable sources',
 	WALK: 'Walking',
 	BIKE: 'Bike',
 	RENTAL: 'Sharing',

--- a/ui/src/lib/i18n/fr.ts
+++ b/ui/src/lib/i18n/fr.ts
@@ -47,6 +47,7 @@ const translations: Translations = {
 	bikeRental: 'Utiliser véhicules partagés',
 	bikeCarriage: 'Transport vélo',
 	unreliableOptions: 'Selon la disponibilité des données, ces options peuvent ne pas être fiables.',
+	timetableSources: 'Sources des horaires',
 	WALK: 'À pied',
 	BIKE: 'Vélo',
 	RENTAL: 'Loué',

--- a/ui/src/lib/i18n/pl.ts
+++ b/ui/src/lib/i18n/pl.ts
@@ -47,6 +47,7 @@ const translations: Translations = {
 	bikeRental: 'Allow usage of sharing vehicles',
 	bikeCarriage: 'Bike carriage',
 	unreliableOptions: 'Depending on data availability, these options may be unreliable.',
+	timetableSources: 'Timetable sources',
 	WALK: 'Walking',
 	BIKE: 'Bike',
 	RENTAL: 'Sharing',

--- a/ui/src/lib/i18n/translation.ts
+++ b/ui/src/lib/i18n/translation.ts
@@ -42,6 +42,7 @@ export type Translations = {
 	bikeRental: string;
 	bikeCarriage: string;
 	unreliableOptions: string;
+	timetableSources: string;
 	WALK: string;
 	BIKE: string;
 	RENTAL: string;

--- a/ui/src/lib/map/Map.svelte
+++ b/ui/src/lib/map/Map.svelte
@@ -18,7 +18,7 @@
 	}: {
 		map?: maplibregl.Map;
 		style: maplibregl.StyleSpecification | undefined;
-		attribution: string;
+		attribution: string | undefined | false;
 		transformRequest?: maplibregl.RequestTransformFunction;
 		center: maplibregl.LngLatLike;
 		bounds?: maplibregl.LngLatBoundsLike | undefined;
@@ -48,7 +48,10 @@
 				center,
 				style,
 				transformRequest,
-				attributionControl: { customAttribution: attribution }
+				attributionControl:
+					attribution === false || attribution === undefined
+						? attribution
+						: { customAttribution: attribution }
 			});
 
 			tmp.addImage(

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -41,7 +41,7 @@
 	const hasDebug = urlParams && urlParams.has('debug');
 	const hasDark = urlParams && urlParams.has('dark');
 	const isSmallScreen = browser && window.innerWidth < 768;
-	let dataLicenseLink: string | undefined = $state(undefined);
+	let dataAttributionLink: string | undefined = $state(undefined);
 	let showMap = $state(!isSmallScreen);
 
 	let theme: 'light' | 'dark' =
@@ -62,7 +62,9 @@
 	onMount(async () => {
 		initial().then((d) => {
 			if (d.response.headers.has('Link')) {
-				dataLicenseLink = d.response.headers.get('Link')!.replace(/^<(.*)>; rel="license"$/, '$1');
+				dataAttributionLink = d.response.headers
+					.get('Link')!
+					.replace(/^<(.*)>; rel="license"$/, '$1');
 			}
 			const r = d.data;
 			if (r) {
@@ -454,8 +456,8 @@
 		<div class="maplibregl-ctrl maplibregl-ctrl-attrib">
 			<div class="maplibregl-ctrl-attrib-inner">
 				&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>
-				{#if dataLicenseLink}
-					| <a href={dataLicenseLink} target="_blank">{t.timetableSources}</a>
+				{#if dataAttributionLink}
+					| <a href={dataAttributionLink} target="_blank">{t.timetableSources}</a>
 				{/if}
 			</div>
 		</div>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -41,6 +41,7 @@
 	const hasDebug = urlParams && urlParams.has('debug');
 	const hasDark = urlParams && urlParams.has('dark');
 	const isSmallScreen = browser && window.innerWidth < 768;
+	let dataLicenseLink: string | undefined = $state(undefined);
 	let showMap = $state(!isSmallScreen);
 
 	let theme: 'light' | 'dark' =
@@ -60,6 +61,9 @@
 
 	onMount(async () => {
 		initial().then((d) => {
+			if (d.response.headers.has('Link')) {
+				dataLicenseLink = d.response.headers.get('Link')!.replace(/^<(.*)>; rel="license"$/, '$1');
+			}
 			const r = d.data;
 			if (r) {
 				center = [r.lon, r.lat];
@@ -321,7 +325,7 @@
 	{center}
 	class={cn('h-dvh overflow-clip', theme)}
 	style={showMap ? getStyle(theme, level) : undefined}
-	attribution={"&copy; <a href='http://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap</a>"}
+	attribution={false}
 >
 	{#if hasDebug}
 		<Control position="top-right">
@@ -443,6 +447,17 @@
 					</Card>
 				</Control>
 			{/if}
+		</div>
+	</div>
+
+	<div class="maplibregl-ctrl-bottom-right">
+		<div class="maplibregl-ctrl maplibregl-ctrl-attrib">
+			<div class="maplibregl-ctrl-attrib-inner">
+				&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>
+				{#if dataLicenseLink}
+					| <a href={dataLicenseLink} target="_blank">{t.timetableSources}</a>
+				{/if}
+			</div>
 		</div>
 	</div>
 


### PR DESCRIPTION
To finally properly attribute timetable sources...

Link header is somewhat of a standard according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link and https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#license. Alternative would be a custom header.

Sends header on all API requests and exposes it in the UI regardless if map is shown or not.