### PR TITLE
do not show dropoff/pickup on first/last stop, respectively

### DIFF
--- a/ui/src/lib/ConnectionDetail.svelte
+++ b/ui/src/lib/ConnectionDetail.svelte
@@ -211,7 +211,7 @@
 						l.from.name,
 						l.from.stopId,
 						l.from.pickupType,
-						l.from.dropoffType
+						'NORMAL'
 					)}
 				</div>
 				<div class="mt-2 flex items-center text-muted-foreground leading-none">
@@ -275,7 +275,7 @@
 							l.realTime!,
 							l.to.name,
 							l.to.stopId,
-							l.to.pickupType,
+							'NORMAL',
 							l.to.dropoffType
 						)}
 					</div>
@@ -297,7 +297,7 @@
 						l.from.name,
 						l.from.stopId,
 						l.from.pickupType,
-						l.from.dropoffType
+						'NORMAL'
 					)}
 				</div>
 				{@render streetLeg(l)}
@@ -309,7 +309,7 @@
 							l.realTime,
 							l.to.name,
 							l.to.stopId,
-							l.to.pickupType,
+							'NORMAL',
 							l.to.dropoffType
 						)}
 					</div>
@@ -331,7 +331,7 @@
 				lastLeg!.realTime,
 				lastLeg!.to.name,
 				lastLeg!.to.stopId,
-				lastLeg!.to.pickupType,
+				'NORMAL',
 				lastLeg!.to.dropoffType
 			)}
 		</div>


### PR DESCRIPTION
In some GTFS feeds, drop_off_type is set to "No dropoff available" for the first stop of routes (pickup_type respectively for last stop). Doesn't make sense to display "Exit not allowed" in the UI.

Alternative: Always set to in/out_allowed true in the backend, but actually IMO it would be more correct to always set it to false. 