### PR TITLE
Fix unhandled railviz timers

### DIFF
--- a/ui/src/lib/RailViz.svelte
+++ b/ui/src/lib/RailViz.svelte
@@ -242,7 +242,7 @@
 	let overlay = $state.raw<MapboxOverlay>();
 	const updateRailviz = async () => {
 		await updateRailvizLayer();
-		clearTimeout(timer);  // Ensure previous timer is cleared
+		clearTimeout(timer); // Ensure previous timer is cleared
 		timer = setTimeout(() => {
 			console.log('updateRailviz: timer');
 			updateRailviz();

--- a/ui/src/lib/RailViz.svelte
+++ b/ui/src/lib/RailViz.svelte
@@ -241,8 +241,8 @@
 	let timer: number | undefined;
 	let overlay = $state.raw<MapboxOverlay>();
 	const updateRailviz = async () => {
-		clearTimeout(timer);
 		await updateRailvizLayer();
+		clearTimeout(timer);  // Ensure previous timer is cleared
 		timer = setTimeout(() => {
 			console.log('updateRailviz: timer');
 			updateRailviz();


### PR DESCRIPTION
I noticed an unreasonable high memory usage, when working on the the web interface with Firefox for some time.
After some research, it seems to me, that this code can and will start multiple timers, while only the latest one will be cleared properly.

https://github.com/motis-project/motis/blob/a639f7021fd9715a0a31eec3444e68b2375f592c/ui/src/lib/RailViz.svelte#L243-L250

Moving `clearTimeout()` right before `setTimeout()` should ensure, that there is never more than one timer running.