### PR TITLE
Fix street routing cache for routes without GBFS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
           asset_content_type: application/x-
 
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: linux
     steps:
       - uses: actions/checkout@v4

--- a/src/street_routing.cc
+++ b/src/street_routing.cc
@@ -312,11 +312,15 @@ api::Itinerary route(osr::ways const& w,
     }
   };
 
+  auto const transport_mode =
+      profile == osr::search_profile::kBikeSharing
+          ? static_cast<transport_mode_t>(gbfs_rd.get_transport_mode(prod_ref))
+          : static_cast<transport_mode_t>(profile);
+
   auto const path = [&]() {
     auto p = get_path(
         w, l, e, sharing_data ? &sharing_data->sharing_data_ : nullptr,
-        get_location(from), get_location(to),
-        static_cast<transport_mode_t>(gbfs_rd.get_transport_mode(prod_ref)),
+        get_location(from), get_location(to), transport_mode,
         to_profile(mode, wheelchair), start_time, max_matching_distance,
         static_cast<osr::cost_t>(max.count()), cache, blocked_mem);
 


### PR DESCRIPTION
For modes other than RENTAL, the transport mode cache key was always set to the same value. This resulted in a bug where e.g. for routing requests with `directModes=WALK,CAR`, only the direct routes for WALK were calculated.
The transport mode cache key is now set to the osr profile if it isn't a sharing profile.