### PR TITLE
Fix zoom resetting when using Firefox

### DIFF
--- a/ui/src/lib/map/Map.svelte
+++ b/ui/src/lib/map/Map.svelte
@@ -82,7 +82,16 @@
 				currentZoom = zoom;
 			});
 
-			tmp.on('moveend', async () => {
+			// Same as for 'zoomend'
+			tmp.on('dragend', async () => {
+				zoom = tmp.getZoom();
+				currentZoom = zoom;
+				bounds = tmp.getBounds();
+				center = tmp.getCenter();
+			});
+
+			// Same as for 'dragend'
+			tmp.on('zoomend', async () => {
 				zoom = tmp.getZoom();
 				currentZoom = zoom;
 				bounds = tmp.getBounds();

--- a/ui/src/lib/map/Map.svelte
+++ b/ui/src/lib/map/Map.svelte
@@ -82,12 +82,14 @@
 				currentZoom = zoom;
 			});
 
-			tmp.on('moveend', () => untrack(async () => {
-				zoom = tmp.getZoom();
-				currentZoom = zoom;
-				bounds = tmp.getBounds();
-				center = tmp.getCenter();
-			}));
+			tmp.on('moveend', () =>
+				untrack(async () => {
+					zoom = tmp.getZoom();
+					currentZoom = zoom;
+					bounds = tmp.getBounds();
+					center = tmp.getCenter();
+				})
+			);
 		} catch (e) {
 			console.log(e);
 		}

--- a/ui/src/lib/map/Map.svelte
+++ b/ui/src/lib/map/Map.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import maplibregl from 'maplibre-gl';
-	import { setContext, type Snippet } from 'svelte';
+	import { setContext, untrack, type Snippet } from 'svelte';
 	import 'maplibre-gl/dist/maplibre-gl.css';
 	import { createShield } from './shield';
 
@@ -82,21 +82,12 @@
 				currentZoom = zoom;
 			});
 
-			// Same as for 'zoomend'
-			tmp.on('dragend', async () => {
+			tmp.on('moveend', () => untrack(async () => {
 				zoom = tmp.getZoom();
 				currentZoom = zoom;
 				bounds = tmp.getBounds();
 				center = tmp.getCenter();
-			});
-
-			// Same as for 'dragend'
-			tmp.on('zoomend', async () => {
-				zoom = tmp.getZoom();
-				currentZoom = zoom;
-				bounds = tmp.getBounds();
-				center = tmp.getCenter();
-			});
+			}));
 		} catch (e) {
 			console.log(e);
 		}


### PR DESCRIPTION
This fixes an issue, that caused Firefox to reset the zoom, while a trip is selected. This behavior makes it therefore difficult to check details, without deselecting first. Furthermore, it could log an error to the console:
`Uncaught (in promise) Error: https://svelte.dev/e/effect_update_depth_exceeded`
As I didn't noticed this behavior on Chrome based browsers, nothing should change there.