### PR TITLE
Fix data attribution link header not being set properly

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -67,7 +67,7 @@ int server(data d, config const& c, std::string_view const motis_version) {
   qr.add_header("Server", fmt::format("MOTIS {}", motis_version));
   if (server_config.data_attribution_link_) {
     qr.add_header("Link", fmt::format("<{}>; rel=\"license\"",
-                                      server_config.data_attribution_link_));
+                                      *server_config.data_attribution_link_));
   }
 
   POST<ep::matches>(qr, "/api/matches", d);


### PR DESCRIPTION
This pull request fixes the `Link: <https://example.com>; rel="license"` header not being set correctly.

It would previously render as `Link: <optional("https://example.com")>; rel="license"`.