### PR TITLE
Various edge cases

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1962,7 +1962,7 @@ components:
           description: Whether there is real-time data about this leg
           type: boolean
         polyline:
-          description: Google polyline encoded coordinate sequence (with precision 7) where the trip travels on this segment.
+          description: Google polyline encoded coordinate sequence (with precision 6) where the trip travels on this segment.
           type: string
 
     Direction:
@@ -1990,7 +1990,7 @@ components:
         - length
       properties:
         points:
-          description: The encoded points of the polyline using the Google polyline encoding with precision 7.
+          description: The encoded points of the polyline using the Google polyline encoding with precision 6.
           type: string
         length:
           description: The number of points in the string

--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -467,8 +467,9 @@ api::plan_response routing::operator()(boost::urls::url_view const& url) const {
   auto const rtt = rt->rtt_.get();
   auto const e = rt_->e_.get();
   auto gbfs_rd = gbfs::gbfs_routing_data{w_, l_, gbfs_};
-  if (blocked.get() == nullptr && w_ != nullptr) {
-    blocked.reset(new osr::bitvec<osr::node_idx_t>{w_->n_nodes()});
+  if (blocked.get() == nullptr) {
+    blocked.reset(
+        new osr::bitvec<osr::node_idx_t>{w_ != nullptr ? w_->n_nodes() : 0});
   }
 
   auto const query = api::plan_params{url.params()};

--- a/src/journey_to_response.cc
+++ b/src/journey_to_response.cc
@@ -368,7 +368,7 @@ api::Itinerary journey_to_response(
               fr.for_each_shape_point(
                   shapes, t.stop_range_,
                   [&](geo::latlng const& pos) { polyline.emplace_back(pos); });
-              leg.legGeometry_.points_ = geo::encode_polyline<7>(polyline);
+              leg.legGeometry_.points_ = geo::encode_polyline<6>(polyline);
               leg.legGeometry_.length_ =
                   static_cast<std::int64_t>(polyline.size());
 

--- a/src/polyline.cc
+++ b/src/polyline.cc
@@ -11,6 +11,6 @@ api::EncodedPolyline to_polyline(geo::polyline const& polyline) {
 }
 
 template api::EncodedPolyline to_polyline<5>(geo::polyline const&);
-template api::EncodedPolyline to_polyline<7>(geo::polyline const&);
+template api::EncodedPolyline to_polyline<6>(geo::polyline const&);
 
 }  // namespace motis

--- a/src/street_routing.cc
+++ b/src/street_routing.cc
@@ -95,7 +95,7 @@ std::vector<api::StepInstruction> get_step_instructions(
                        ? std::nullopt
                        : std::optional{static_cast<std::int64_t>(
                              to_idx(w.way_osm_idx_[s.way_]))},
-        .polyline_ = to_polyline<7>(s.polyline_),
+        .polyline_ = to_polyline<6>(s.polyline_),
         .streetName_ = way_name == osr::string_idx_t::invalid()
                            ? ""
                            : std::string{w.strings_[way_name].view()},
@@ -414,7 +414,7 @@ api::Itinerary route(osr::ways const& w,
             .startTime_ = pred_end_time,
             .endTime_ = is_last_leg && end_time ? *end_time : t,
             .distance_ = dist,
-            .legGeometry_ = to_polyline<7>(concat),
+            .legGeometry_ = to_polyline<6>(concat),
             .steps_ = get_step_instructions(w, get_location(from),
                                             get_location(to), range),
             .rental_ = is_rental ? std::optional{sharing_data->get_rental(

--- a/ui/src/lib/ConnectionDetail.svelte
+++ b/ui/src/lib/ConnectionDetail.svelte
@@ -17,7 +17,8 @@
 		itinerary: Itinerary;
 	} = $props();
 
-	const lastLeg = $derived(itinerary.legs.findLast((l) => l.duration !== 0));
+	const isRelevantLeg = (l: Leg) => l.duration !== 0 || l.routeShortName;
+	const lastLeg = $derived(itinerary.legs.findLast(isRelevantLeg));
 </script>
 
 {#snippet stopTimes(
@@ -165,7 +166,7 @@
 		{#if l.routeShortName}
 			<div class="w-full flex justify-between items-center space-x-1">
 				<Route {onClickTrip} {l} />
-				{#if pred && (pred.from.track || pred.duration !== 0) && (i != 1 || pred.routeShortName)}
+				{#if pred && (pred.from.track || isRelevantLeg(pred)) && (i != 1 || pred.routeShortName)}
 					<div class="border-t h-0 grow shrink"></div>
 					<div class="text-sm text-muted-foreground leading-none px-2 text-center">
 						{#if pred.from.track}
@@ -271,7 +272,7 @@
 					</details>
 				{/if}
 
-				{#if !isLast && !(isLastPred && next!.duration === 0)}
+				{#if !isLast && !(isLastPred && !next!.to.stopId)}
 					<div class="grid gap-y-6 grid-cols-[max-content_max-content_auto] items-center pb-3">
 						{@render stopTimes(
 							l.endTime!,
@@ -285,12 +286,12 @@
 					</div>
 				{/if}
 
-				{#if isLast || (isLastPred && next!.duration === 0)}
+				{#if isLast || (isLastPred && !isRelevantLeg(next!))}
 					<!-- fill visual gap -->
 					<div class="pb-2"></div>
 				{/if}
 			</div>
-		{:else if !(isLast && l.duration === 0) && ((i == 0 && l.duration !== 0) || !next || !next.routeShortName || l.mode != 'WALK' || (pred && (pred.mode == 'BIKE' || pred.mode == 'RENTAL')))}
+		{:else if !(isLast && !isRelevantLeg(l)) && ((i == 0 && isRelevantLeg(l)) || !next || !next.routeShortName || l.mode != 'WALK' || (pred && (pred.mode == 'BIKE' || pred.mode == 'RENTAL')))}
 			<Route {onClickTrip} {l} />
 			<div class="pt-4 pl-6 border-l-4 left-4 relative" style={routeBorderColor(l)}>
 				<div class="grid gap-y-6 grid-cols-[max-content_max-content_auto] items-center">

--- a/ui/src/lib/ItineraryGeoJSON.svelte
+++ b/ui/src/lib/ItineraryGeoJSON.svelte
@@ -6,7 +6,7 @@
 	import polyline from 'polyline';
 	import { colord } from 'colord';
 
-	const PRECISION = 7;
+	const PRECISION = 6;
 
 	function isIndividualTransport(m: Mode): boolean {
 		return m == 'WALK' || m == 'BIKE' || m == 'CAR';

--- a/ui/src/lib/openapi/schemas.gen.ts
+++ b/ui/src/lib/openapi/schemas.gen.ts
@@ -576,7 +576,7 @@ export const TripSegmentSchema = {
             type: 'boolean'
         },
         polyline: {
-            description: 'Google polyline encoded coordinate sequence (with precision 7) where the trip travels on this segment.',
+            description: 'Google polyline encoded coordinate sequence (with precision 6) where the trip travels on this segment.',
             type: 'string'
         }
     }
@@ -592,7 +592,7 @@ export const EncodedPolylineSchema = {
     required: ['points', 'length'],
     properties: {
         points: {
-            description: 'The encoded points of the polyline using the Google polyline encoding with precision 7.',
+            description: 'The encoded points of the polyline using the Google polyline encoding with precision 6.',
             type: 'string'
         },
         length: {

--- a/ui/src/lib/openapi/types.gen.ts
+++ b/ui/src/lib/openapi/types.gen.ts
@@ -485,7 +485,7 @@ export type TripSegment = {
      */
     realTime: boolean;
     /**
-     * Google polyline encoded coordinate sequence (with precision 7) where the trip travels on this segment.
+     * Google polyline encoded coordinate sequence (with precision 6) where the trip travels on this segment.
      */
     polyline: string;
 };
@@ -494,7 +494,7 @@ export type Direction = 'DEPART' | 'HARD_LEFT' | 'LEFT' | 'SLIGHTLY_LEFT' | 'CON
 
 export type EncodedPolyline = {
     /**
-     * The encoded points of the polyline using the Google polyline encoding with precision 7.
+     * The encoded points of the polyline using the Google polyline encoding with precision 6.
      */
     points: string;
     /**


### PR DESCRIPTION
* the conditions in ConnectionDetail are getting completely out of hand...
* For polyline string encoding, coordinates with |lon| > 107.3741824 and our chosen precision 7 yield a 32-bit int overflow ([due to the additional left shift](https://developers.google.com/maps/documentation/utilities/polylinealgorithm)). Maybe due to that reason, we use an int64 there, but I have not found any (JS) implementation that correctly decodes that. From my perspective this case is not really defined. The only decoder https://polylinedecoder.online/ I've found that allegedly supports precision 7 wasn't able to decode it either. So either we make a breaking change to the API and lower the precision to 6 (which is still about 10cm precision) which probably avoids many errors in client implementations, or we keep precision 7 and write our own JS decoder.