### PR TITLE
Fix for very short ODM direct routes

### DIFF
--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -246,9 +246,11 @@ void meta_router::init_prima(n::interval<n::unixtime_t> const& search_intvl,
   }
 
   auto const max_offset_duration =
-      direct_duration ? std::min(*direct_duration - kODMOffsetMinImprovement,
-                                 kODMMaxDuration)
-                      : kODMMaxDuration;
+      direct_duration
+          ? std::min(std::max(*direct_duration, kODMOffsetMinImprovement) -
+                         kODMOffsetMinImprovement,
+                     kODMMaxDuration)
+          : kODMMaxDuration;
 
   if (odm_pre_transit_ && holds_alternative<osr::location>(from_)) {
     init_pt(p->from_rides_, r_, std::get<osr::location>(from_),

--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -18,6 +18,7 @@
 
 #include "utl/erase_duplicates.h"
 
+#include "nigiri/logging.h"
 #include "nigiri/routing/journey.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/query.h"
@@ -69,9 +70,9 @@ using td_offsets_t =
     n::hash_map<n::location_idx_t, std::vector<n::routing::td_offset>>;
 
 void print_time(auto const& start, std::string_view name) {
-  fmt::println("{} {}", name,
-               std::chrono::duration_cast<std::chrono::milliseconds>(
-                   std::chrono::steady_clock::now() - start));
+  n::log(n::log_lvl::debug, "motis.odm", "{} {}", name,
+         std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now() - start));
 }
 
 meta_router::meta_router(ep::routing const& r,
@@ -153,7 +154,8 @@ n::duration_t init_direct(std::vector<direct_ride>& direct_rides,
   auto const to_pos = geo::latlng{to_p.lat_, to_p.lon_};
   if (r.odm_bounds_ != nullptr && (!r.odm_bounds_->contains(from_pos) ||
                                    !r.odm_bounds_->contains(to_pos))) {
-    fmt::println("No direct connection, from: {}, to: {}", from_pos, to_pos);
+    n::log(n::log_lvl::debug, "motis.odm",
+           "No direct connection, from: {}, to: {}", from_pos, to_pos);
     return ep::kInfinityDuration;
   }
 
@@ -193,7 +195,7 @@ void init_pt(std::vector<n::routing::start>& rides,
              n::routing::location_match_mode location_match_mode,
              std::chrono::seconds const max) {
   if (r.odm_bounds_ != nullptr && !r.odm_bounds_->contains(l.pos_)) {
-    fmt::println("no PT connection: {}", l.pos_);
+    n::log(n::log_lvl::debug, "motis.odm", "no PT connection: {}", l.pos_);
     return;
   }
 
@@ -207,7 +209,8 @@ void init_pt(std::vector<n::routing::start>& rides,
         (r.odm_bounds_ != nullptr &&
          !r.odm_bounds_->contains(r.tt_->locations_.coordinates_[o.target_]));
     if (out_of_bounds) {
-      fmt::println("Bounds filtered: {}", n::location{*r.tt_, o.target_});
+      n::log(n::log_lvl::debug, "motis.odm", "Bounds filtered: {}",
+             n::location{*r.tt_, o.target_});
     }
     return out_of_bounds;
   });
@@ -427,8 +430,8 @@ void collect_odm_journeys(
       }
     }
   }
-  fmt::println("[routing] collected {} ODM-PT journeys",
-               p->odm_journeys_.size());
+  n::log(n::log_lvl::debug, "motis.odm",
+         "[routing] collected {} ODM-PT journeys", p->odm_journeys_.size());
 }
 
 void extract_rides() {
@@ -479,7 +482,8 @@ void meta_router::add_direct() const {
         .dest_ = to_l,
         .transfers_ = 0U});
   }
-  fmt::println("[whitelisting] added {} direct rides", p->direct_rides_.size());
+  n::log(n::log_lvl::debug, "motis.odm", "[whitelisting] added {} direct rides",
+         p->direct_rides_.size());
 }
 
 api::plan_response meta_router::run() {
@@ -527,7 +531,8 @@ api::plan_response meta_router::run() {
   auto ioc = boost::asio::io_context{};
   auto const bl_start = std::chrono::steady_clock::now();
   try {
-    fmt::println("[blacklisting] request for {} events", p->n_events());
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[blacklisting] request for {} events", p->n_events());
     boost::asio::co_spawn(
         ioc,
         [&]() -> boost::asio::awaitable<void> {
@@ -539,13 +544,14 @@ api::plan_response meta_router::run() {
         boost::asio::detached);
     ioc.run();
   } catch (std::exception const& e) {
-    fmt::println("[blacklisting] networking failed: {}", e.what());
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[blacklisting] networking failed: {}", e.what());
     blacklist_response = std::nullopt;
   }
   auto const blacklisted =
       blacklist_response && p->blacklist_update(*blacklist_response);
-  fmt::println("[blacklisting] ODM events after blacklisting: {}",
-               p->n_events());
+  n::log(n::log_lvl::debug, "motis.odm",
+         "[blacklisting] ODM events after blacklisting: {}", p->n_events());
   print_time(bl_start, "[blacklisting]");
 
   // prepare queries
@@ -615,7 +621,8 @@ api::plan_response meta_router::run() {
                odm_time(a.legs_.front()) == odm_time(b.legs_.front()) &&
                odm_time(a.legs_.back()) == odm_time(b.legs_.back());
       });
-  fmt::println("[routing] interval searched: {}", pt_result.interval_);
+  n::log(n::log_lvl::debug, "motis.odm", "[routing] interval searched: {}",
+         pt_result.interval_);
   print_time(routing_start, "[routing]");
 
   // whitelisting
@@ -625,7 +632,8 @@ api::plan_response meta_router::run() {
   if (blacklisted) {
     extract_rides();
     try {
-      fmt::println("[whitelisting] request for {} events", p->n_events());
+      n::log(n::log_lvl::debug, "motis.odm",
+             "[whitelisting] request for {} events", p->n_events());
       boost::asio::co_spawn(
           ioc2,
           [&]() -> boost::asio::awaitable<void> {
@@ -637,7 +645,8 @@ api::plan_response meta_router::run() {
           boost::asio::detached);
       ioc2.run();
     } catch (std::exception const& e) {
-      fmt::println("[whitelisting] networking failed: {}", e.what());
+      n::log(n::log_lvl::debug, "motis.odm",
+             "[whitelisting] networking failed: {}", e.what());
       whitelist_response = std::nullopt;
     }
   }
@@ -651,12 +660,14 @@ api::plan_response meta_router::run() {
     add_direct();
   } else {
     p->odm_journeys_.clear();
-    fmt::println("[whitelisting] failed, discarding ODM journeys");
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[whitelisting] failed, discarding ODM journeys");
   }
   print_time(wl_start, "[whitelisting]");
 
-  fmt::println("[mixing] {} PT journeys and {} ODM journeys",
-               pt_result.journeys_.size(), p->odm_journeys_.size());
+  n::log(n::log_lvl::debug, "motis.odm",
+         "[mixing] {} PT journeys and {} ODM journeys",
+         pt_result.journeys_.size(), p->odm_journeys_.size());
   kMixer.mix(pt_result.journeys_, p->odm_journeys_);
   print_time(mixing_start, "[mixing]");
 

--- a/src/odm/mixer.cc
+++ b/src/odm/mixer.cc
@@ -2,6 +2,7 @@
 
 #include "utl/overloaded.h"
 
+#include "nigiri/logging.h"
 #include "nigiri/special_stations.h"
 
 #include "motis/odm/odm.h"
@@ -103,10 +104,10 @@ bool mixer::cost_dominates(nr::journey const& a, nr::journey const& b) const {
   auto const alpha_term = cost_alpha_ * time_ratio * dist;
   auto const ret = dist < max_distance_ && cost_a + alpha_term < cost_b;
   if (kMixerTracing) {
-    fmt::println(
-        "{} cost-dominates {}, ratio: {}, dist: {}, {} + {} < {} --> {}",
-        label(a), label(b), time_ratio, dist, cost_a, alpha_term, cost_b,
-        ret ? "true" : "false");
+    n::log(n::log_lvl::debug, "motis.odm",
+           "{} cost-dominates {}, ratio: {}, dist: {}, {} + {} < {} --> {}",
+           label(a), label(b), time_ratio, dist, cost_a, alpha_term, cost_b,
+           ret ? "true" : "false");
   }
   return ret;
 }
@@ -154,8 +155,9 @@ void mixer::pareto_dominance(
     auto const odm_time_b = odm_time(b);
     auto const ret = a.dominates(b) && odm_time_a < odm_time_b;
     if (kMixerTracing) {
-      fmt::println("{} pareto-dominates {}, odm_time: {} < {} --> {}", label(a),
-                   label(b), odm_time_a, odm_time_b, ret ? "true" : "false");
+      n::log(n::log_lvl::debug, "motis.odm",
+             "{} pareto-dominates {}, odm_time: {} < {} --> {}", label(a),
+             label(b), odm_time_a, odm_time_b, ret ? "true" : "false");
     }
     return ret;
   };
@@ -181,8 +183,9 @@ void mixer::productivity_dominance(
     auto const prod_b = (cost_a + alpha_term) / odm_time_b;
     auto const ret = dist < max_distance_ && prod_a > prod_b;
     if (kMixerTracing) {
-      fmt::println("{} prod-dominates {}, dist: {}, {} > {} --> {}", label(a),
-                   label(b), dist, prod_a, prod_b, ret ? "true" : "false");
+      n::log(n::log_lvl::debug, "motis.odm",
+             "{} prod-dominates {}, dist: {}, {} > {} --> {}", label(a),
+             label(b), dist, prod_a, prod_b, ret ? "true" : "false");
     }
     return ret;
   };

--- a/src/odm/prima.cc
+++ b/src/odm/prima.cc
@@ -9,6 +9,7 @@
 #include "utl/zip.h"
 
 #include "nigiri/common/parse_time.h"
+#include "nigiri/logging.h"
 #include "nigiri/timetable.h"
 
 #include "motis/odm/odm.h"
@@ -169,7 +170,8 @@ bool prima::blacklist_update(std::string_view json) {
       with_errors |= update_pt_rides(from_rides_, prev_from_rides_,
                                      o.at("start").as_array());
     } else {
-      fmt::println(
+      n::log(
+          n::log_lvl::debug, "motis.odm",
           "[blacklisting] from_rides_.size() != n_pt_updates_from ({} != {})",
           from_rides_.size(), n_pt_updates_from);
       with_errors = true;
@@ -181,9 +183,9 @@ bool prima::blacklist_update(std::string_view json) {
       with_errors |=
           update_pt_rides(to_rides_, prev_to_rides_, o.at("target").as_array());
     } else {
-      fmt::println(
-          "[blacklisting] to_rides_.size() != n_pt_updates_to ({} != {})",
-          to_rides_.size(), n_pt_updates_to);
+      n::log(n::log_lvl::debug, "motis.odm",
+             "[blacklisting] to_rides_.size() != n_pt_updates_to ({} != {})",
+             to_rides_.size(), n_pt_updates_to);
       with_errors = true;
       to_rides_.clear();
     }
@@ -192,7 +194,8 @@ bool prima::blacklist_update(std::string_view json) {
       with_errors |= update_direct_rides(direct_rides_, prev_direct_rides_,
                                          o.at("direct").as_array());
     } else {
-      fmt::println(
+      n::log(
+          n::log_lvl::debug, "motis.odm",
           "[blacklisting] direct_rides_.size() != n_direct_updates ({} != {})",
           direct_rides_.size(), o.at("direct").as_array().size());
       with_errors = true;
@@ -200,12 +203,13 @@ bool prima::blacklist_update(std::string_view json) {
     }
 
   } catch (std::exception const&) {
-    fmt::println("[blacklisting] could not parse response: {}", json);
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[blacklisting] could not parse response: {}", json);
     return false;
   }
   if (with_errors) {
-    fmt::println("[blacklisting] parsed response with invalid values: {}",
-                 json);
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[blacklisting] parsed response with invalid values: {}", json);
   }
   return true;
 }
@@ -219,8 +223,9 @@ bool update_pt_rides(std::vector<nigiri::routing::start>& rides,
 
   auto const n_pt_udpates = n_pt_updates(update);
   if (prev_rides.size() != n_pt_udpates) {
-    fmt::println("[whitelisting] #rides != #updates ({} != {})",
-                 prev_rides.size(), n_pt_udpates);
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[whitelisting] #rides != #updates ({} != {})", prev_rides.size(),
+           n_pt_udpates);
     return true;
   }
 
@@ -256,8 +261,9 @@ bool update_pt_rides(std::vector<nigiri::routing::start>& rides,
 bool update_direct_rides(std::vector<direct_ride>& rides,
                          json::array const& update) {
   if (rides.size() != update.size()) {
-    fmt::println("[whitelisting] #rides != #updates ({} != {})", rides.size(),
-                 update.size());
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[whitelisting] #rides != #updates ({} != {})", rides.size(),
+           update.size());
     rides.clear();
     return true;
   }
@@ -284,11 +290,13 @@ bool prima::whitelist_update(std::string_view json) {
     with_errors |=
         update_direct_rides(direct_rides_, o.at("direct").as_array());
   } catch (std::exception const&) {
-    fmt::println("[whitelisting] could not parse response: {}", json);
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[whitelisting] could not parse response: {}", json);
     return false;
   }
   if (with_errors) {
-    fmt::println("[whitelisting] parsed response with errors: {}", json);
+    n::log(n::log_lvl::debug, "motis.odm",
+           "[whitelisting] parsed response with errors: {}", json);
   }
   return true;
 }

--- a/src/odm/shorten.cc
+++ b/src/odm/shorten.cc
@@ -1,6 +1,7 @@
 #include "motis/odm/odm.h"
 
 #include "nigiri/for_each_meta.h"
+#include "nigiri/logging.h"
 #include "nigiri/rt/frun.h"
 #include "nigiri/rt/rt_timetable.h"
 #include "nigiri/timetable.h"
@@ -73,7 +74,8 @@ void shorten(std::vector<nr::journey>& odm_journeys,
       auto const new_stop = tt.locations_.get(odm_leg.to_).name_;
       auto const new_pt_time = pt_leg.arr_time_ - pt_leg.dep_time_;
 
-      fmt::println(
+      n::log(
+          n::log_lvl::debug, "motis.odm",
           "Shortened ODM first leg: [ODM: {}, stop: {}, PT: {}] --> [ODM: {}, "
           "stop: {}, PT: {}] (ODM: -{}, PT: +{})",
           old_odm_time, old_stop, old_pt_time, new_odm_time, new_stop,
@@ -137,7 +139,8 @@ void shorten(std::vector<nr::journey>& odm_journeys,
       auto const new_stop = tt.locations_.get(odm_leg.from_).name_;
       auto const new_pt_time = pt_leg.arr_time_ - pt_leg.dep_time_;
 
-      fmt::println(
+      n::log(
+          n::log_lvl::debug, "motis.odm",
           "Shortened ODM last leg: [ODM: {}, stop: {}, PT: {}] --> [ODM: {}, "
           "stop: {}, PT: {}] (ODM: -{}, PT: +{})",
           old_odm_time, old_stop, old_pt_time, new_odm_time, new_stop,
@@ -148,7 +151,7 @@ void shorten(std::vector<nr::journey>& odm_journeys,
 
   for (auto& j : odm_journeys) {
     if (j.legs_.empty()) {
-      fmt::println("shorten: journey without legs");
+      n::log(n::log_lvl::debug, "motis.odm", "shorten: journey without legs");
       continue;
     }
     shorten_first_leg(j);


### PR DESCRIPTION
* Fix negative overflow when direct route is < `kODMOffsetMinImprovement`, leading to a 65476s max distance, leading to Dijkstra discovering the whole of Germany (and while doing that, permanently allocating 6 GB in every thread this runs on, since Dijkstra reset only clears cost vectors for reuse, but doesn't free)
* Using `n::log` for timestamp prefixing