### PR TITLE
GBFS: Use same headers for feeds listed in aggregate feeds

### DIFF
--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -638,6 +638,7 @@ struct gbfs_update {
             .id_ = combined_id,
             .url_ =
                 static_cast<std::string>(latest_version.at("url").as_string()),
+            .headers_ = af.headers_,
             .default_restrictions_ =
                 lookup_default_restrictions(af.id_, combined_id)});
       }
@@ -650,6 +651,7 @@ struct gbfs_update {
         feeds.emplace_back(provider_feed{
             .id_ = combined_id,
             .url_ = static_cast<std::string>(system.at("url").as_string()),
+            .headers_ = af.headers_,
             .default_restrictions_ =
                 lookup_default_restrictions(af.id_, combined_id)});
       }


### PR DESCRIPTION
The headers listed in the config file are now not only used to fetch the aggregate feed, but also for all the providers listed in the aggregate feed.

This is required for the [sharedmobility.ch GBFS 2.3 endpoint](https://github.com/SFOE/sharedmobility/blob/main/Access%20the%20data.md) for example.