### PR TITLE
Remove rail_old layer from map style

### DIFF
--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -576,16 +576,6 @@ export const getStyle = (theme: 'light' | 'dark', level: number): StyleSpecifica
 				}
 			},
 			{
-				id: 'rail_old',
-				type: 'line',
-				source: 'osm',
-				'source-layer': 'rail',
-				filter: ['==', 'rail', 'old'],
-				paint: {
-					'line-color': c.rail
-				}
-			},
-			{
 				id: 'rail_detail',
 				type: 'line',
 				source: 'osm',


### PR DESCRIPTION
This pull request removes the `rail_old` layer from the map style, as rendering abandoned or disused rail just like normal rail isn't really fitting.

See https://github.com/motis-project/tiles/pull/10