### PR TITLE
Add elevation data for routing path and steps

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2036,6 +2036,8 @@ components:
         - exit
         - stayOn
         - area
+        - elevationUp
+        - elevationDown
       properties:
         relativeDirection:
           $ref: '#/components/schemas/Direction'
@@ -2072,6 +2074,12 @@ components:
             This step is on an open area, such as a plaza or train platform,
             and thus the directions should say something like "cross"
           type: boolean
+        elevationUp:
+          type: integer
+          description: The maximum numbers of meters routed uphill
+        elevationDown:
+          type: integer
+          description: The maximum numbers of meters routed downhill
 
     RentalFormFactor:
       type: string
@@ -2385,6 +2393,8 @@ components:
         - startTime
         - endTime
         - transfers
+        - elevationUp
+        - elevationDown
         - legs
       properties:
         duration:
@@ -2401,6 +2411,12 @@ components:
         transfers:
           type: integer
           description: The number of transfers this trip has.
+        elevationUp:
+          type: integer
+          description: The maximum numbers of meters routed uphill
+        elevationDown:
+          type: integer
+          description: The maximum numbers of meters routed downhill
         legs:
           description: Journey legs
           type: array

--- a/src/street_routing.cc
+++ b/src/street_routing.cc
@@ -103,7 +103,9 @@ std::vector<api::StepInstruction> get_step_instructions(
                            : std::string{w.strings_[way_name].view()},
         .exit_ = {},  // TODO
         .stayOn_ = false,  // TODO
-        .area_ = false  // TODO
+        .area_ = false,  // TODO
+        .elevationUp_ = to_idx(s.elevation_.up_),
+        .elevationDown_ = to_idx(s.elevation_.down_),
     });
   }
 
@@ -362,7 +364,9 @@ api::Itinerary route(osr::ways const& w,
       .startTime_ = start_time,
       .endTime_ =
           end_time ? *end_time : start_time + std::chrono::seconds{path->cost_},
-      .transfers_ = 0};
+      .transfers_ = 0,
+      .elevationUp_ = to_idx(path->elevation_.up_),
+      .elevationDown_ = to_idx(path->elevation_.down_)};
 
   auto t = std::chrono::time_point_cast<std::chrono::seconds>(start_time);
   auto pred_place = from;


### PR DESCRIPTION
As requested by https://github.com/motis-project/motis/pull/827#issuecomment-2824074797

This will extend itineraries to contain the the maximum elevation up and down.
The response will contain the total elevation, as well as elevation per step. If no elevation data is available, these fields will be `0`.
As itineraries are only available for One-to-One queries, the feature will not support One-to-Many and One-to-All.