### PR TITLE
UI: Accept empty URL array parameters

### DIFF
--- a/ui/src/lib/AdvancedOptions.svelte
+++ b/ui/src/lib/AdvancedOptions.svelte
@@ -235,7 +235,7 @@
 					class="flex items-center w-full overflow-hidden"
 					aria-label={t.routingSegments.firstMile}
 				>
-					{selectedPreTransitModesLabel}
+					<span>{selectedPreTransitModesLabel}</span>
 				</Select.Trigger>
 				<Select.Content sideOffset={10}>
 					{#each prePostDirectModes as mode, i (i + mode)}
@@ -280,7 +280,7 @@
 					class="flex items-center w-full overflow-hidden"
 					aria-label={t.routingSegments.lastMile}
 				>
-					{selectedPostTransitModesLabel}
+					<span>{selectedPostTransitModesLabel}</span>
 				</Select.Trigger>
 				<Select.Content sideOffset={10}>
 					{#each prePostDirectModes as mode, i (i + mode)}
@@ -325,7 +325,7 @@
 					class="flex items-center w-full overflow-hidden"
 					aria-label={t.routingSegments.direct}
 				>
-					{selectedDirectModesLabel}
+					<span>{selectedDirectModesLabel}</span>
 				</Select.Trigger>
 				<Select.Content sideOffset={10}>
 					{#each prePostDirectModes as mode, i (i + mode)}

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -14,7 +14,7 @@ const urlParams = browser ? new URLSearchParams(window.location.search) : undefi
 export const getUrlArray = (key: string, defaultValue?: string[]): string[] => {
 	if (urlParams) {
 		const value = urlParams.get(key);
-		if (value) {
+		if (value != null) {
 			return value.split(',').filter((m) => m.length);
 		}
 	}


### PR DESCRIPTION
Fix for URLs such as `?transitModes=&preTransitModes=&postTransitModes=` etc.