### PR TITLE
Fix type error in OpenAPI file

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -821,7 +821,7 @@ paths:
           schema:
             type: boolean
       responses:
-        200:
+        '200':
           description: |
             A list of durations.
             If no path was found, the object is empty.
@@ -1088,7 +1088,7 @@ paths:
             minimum: 0
 
       responses:
-        200:
+        '200':
           description: |
             The starting position and a list of all reachable stops
             If no paths are found, the reachable list is empty.
@@ -1121,7 +1121,7 @@ paths:
           schema:
             $ref: '#/components/schemas/LocationType'
       responses:
-        200:
+        '200':
           description: A list of guesses to resolve the coordinates to a location
           content:
             application/json:
@@ -1184,7 +1184,7 @@ paths:
             default: 1
 
       responses:
-        200:
+        '200':
           description: A list of guesses to resolve the text to a location
           content:
             application/json:
@@ -1214,7 +1214,7 @@ paths:
             type: boolean
             default: false
       responses:
-        200:
+        '200':
           description: the requested trip as itinerary
           content:
             application/json:
@@ -1338,7 +1338,7 @@ paths:
             type: boolean
             default: false
       responses:
-        200:
+        '200':
           description: A list of departures/arrivals
           content:
             application/json:


### PR DESCRIPTION
Error reported by `openapi-python-client`:
`Input should be a valid string [type=string_type, input_value=200, input_type=int]`