### PR TITLE
Add translated quickstart documentation

### DIFF
--- a/docs/quickstart.de.md
+++ b/docs/quickstart.de.md
@@ -1,0 +1,30 @@
+# Schnellstart
+
+1. Den [aktuellen Release](https://github.com/motis-project/motis/releases) herunterladen
+
+1. OpenStreetMap-Daten im `.osm.pbf`-Format herunterladen
+
+1. Eine oder mehrere _timetable_s herunterladen
+
+1. Die Konfiguration erstellen:
+```sh
+motis config <osm-data> <timetable>...
+```
+
+1. Die Daten importieren:
+```sh
+motis import
+```
+
+1. Den Server starten:
+```sh
+motis server
+```
+
+1. Der Server ist verfügbar unter http://localhost:8080
+
+Weitere Informationen und Optionen sind dokumentiert unter:
+* [dev-setup-server](dev-setup-server.md)
+* [elevation-setup](elevation-setup.md)
+
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,29 @@
+# Quickstart
+
+1. Download the [latest release](https://github.com/motis-project/motis/releases)
+
+1. Download a OpenStreetMap dataset, stored in `.osm.pbf` format
+
+1. Download one or multiple timetable datasets
+
+1. Create the configuration:
+```sh
+motis config <osm-data> <timetable>...
+```
+
+1. Import the data:
+```sh
+motis import
+```
+
+1. Start the server:
+```sh
+motis server
+```
+
+1. Access the server at http://localhost:8080
+
+For more details and options see also:
+* [dev-setup-server](dev-setup-server.md)
+* [elevation-setup](elevation-setup.md)
+


### PR DESCRIPTION
Add an explicit quickstart guide, that can be used by non developers.
As the documentation is to be read by operators, the file has been translated as well.