### PR TITLE
odm subqueries speedup

### DIFF
--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -636,6 +636,8 @@ api::plan_response meta_router::run() {
 
   auto const routing_start = std::chrono::steady_clock::now();
   auto sub_queries = qf.make_queries(blacklisted);
+  n::log(n::log_lvl::debug, "motis.odm",
+         "[prepare queries] {} queries prepared", sub_queries.size());
   auto const results = search_interval(sub_queries);
   utl::verify(!results.empty(), "odm: public transport result expected");
   auto const& pt_result = results.front();

--- a/src/odm/query_factory.cc
+++ b/src/odm/query_factory.cc
@@ -12,14 +12,22 @@ std::vector<n::routing::query> query_factory::make_queries(
   queries.push_back(
       make(start_walk_, td_start_walk_, dest_walk_, td_dest_walk_));
   if (with_odm) {
-    queries.push_back(
-        make(start_walk_, td_start_walk_, dest_walk_, odm_dest_short_));
-    queries.push_back(
-        make(start_walk_, td_start_walk_, dest_walk_, odm_dest_long_));
-    queries.push_back(
-        make(start_walk_, odm_start_short_, dest_walk_, td_dest_walk_));
-    queries.push_back(
-        make(start_walk_, odm_start_long_, dest_walk_, td_dest_walk_));
+    if (odm_dest_short_.size() > 0) {
+      queries.push_back(
+          make(start_walk_, td_start_walk_, dest_walk_, odm_dest_short_));
+    }
+    if (odm_dest_long_.size() > 0) {
+      queries.push_back(
+          make(start_walk_, td_start_walk_, dest_walk_, odm_dest_long_));
+    }
+    if (odm_start_short_.size() > 0) {
+      queries.push_back(
+          make(start_walk_, odm_start_short_, dest_walk_, td_dest_walk_));
+    }
+    if (odm_start_long_.size() > 0) {
+      queries.push_back(
+          make(start_walk_, odm_start_long_, dest_walk_, td_dest_walk_));
+    }
   }
   return queries;
 }


### PR DESCRIPTION
~~proposition: use actual threads instead of just concurrency for the 5 subqueries for ODM (yes it's cheating :). For the slow queries https://github.com/motis-project/prima/issues/374, the majority of time is spent in routing, which becomes thus five times faster due to that~~

not running subqueries where no ODM was found on one of the sides – low impact since everything is parallelized now