### PR TITLE
Prefer GTFS entrances for footpath generation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -68,6 +68,7 @@ timetable:                          # if not set, no timetable will be loaded
   max_footpath_length: 15           # maximum footpath length when transitively connecting stops or for routing footpaths if `osr_footpath` is set to true
   max_matching_distance: 25.0       # maximum distance from geolocation to next OSM ways that will be found
   preprocess_max_matching_distance: 0.0 # max. distance for preprocessing matches from nigiri locations (stops) to OSM ways to speed up querying (set to 0 (default) to disable)
+  prefer_gtfs_entrances: false      # Prefer station entrances defined in GTFS (stops.txt, location_type=2) over OSM for generating footpaths.
   datasets:                         # map of tag -> dataset
     ch:                             # the tag will be used as prefix for stop IDs and trip IDs with `_` as divider, so `_` cannot be part of the dataset tag
       path: ch_opentransportdataswiss.gtfs.zip

--- a/include/motis/config.h
+++ b/include/motis/config.h
@@ -99,6 +99,7 @@ struct config {
     bool incremental_rt_update_{false};
     bool use_osm_stop_coordinates_{false};
     bool extend_missing_footpaths_{false};
+    bool prefer_gtfs_entrances_{false};
     std::uint16_t max_footpath_length_{15};
     double max_matching_distance_{25.0};
     double preprocess_max_matching_distance_{0.0};

--- a/src/import.cc
+++ b/src/import.cc
@@ -405,6 +405,7 @@ data import(config const& c, fs::path const& data_path, bool const write) {
     auto& h = osr_footpath_settings_hash.second;
     h = cista::hash_combine(h, c.timetable_->use_osm_stop_coordinates_,
                             c.timetable_->extend_missing_footpaths_,
+                            c.timetable_->prefer_gtfs_entrances_,
                             c.timetable_->max_matching_distance_,
                             c.timetable_->max_footpath_length_);
   }


### PR DESCRIPTION
This PR adds a `prefer_gtfs_entrances` config option. When enabled, MOTIS will use station entrances from GTFS (location_type=2) for generating pedestrian footpaths, falling back to OSM only if GTFS entrances are not available for a station.

This improves intermodal routing accuracy in areas where GTFS entrance data is more reliable than OSM. To ensure good performance, the implementation routes from the single closest entrance to a neighboring station, avoiding a costly computation from all possible entrances.

Fixes #919 