### PR TITLE
Update adr version

### DIFF
--- a/include/motis/hashes.h
+++ b/include/motis/hashes.h
@@ -14,7 +14,7 @@ constexpr auto const osr_version = []() {
   return meta_entry_t{"osr_bin_ver", 23U};
 };
 constexpr auto const adr_version = []() {
-  return meta_entry_t{"adr_bin_ver", 7U};
+  return meta_entry_t{"adr_bin_ver", 8U};
 };
 constexpr auto const n_version = []() {
   return meta_entry_t{"nigiri_bin_ver", 20U};


### PR DESCRIPTION
Updates  `adr_bin_ver`, as upgrading from `v2.2.0` will raise an error otherwise.