### PR TITLE
ODM: ease domination of long overnight journeys

### DIFF
--- a/src/odm/mixer.cc
+++ b/src/odm/mixer.cc
@@ -38,7 +38,7 @@ std::int32_t distance(nr::journey const& a, nr::journey const& b) {
            x.arrival_time() < y.arrival_time();
   };
 
-  return overtakes(a, b) || overtakes(b, a)
+  return overtakes(a, b)
              ? 0
              : std::max(
                    std::chrono::abs(a.departure_time() - b.departure_time()),


### PR DESCRIPTION
Schleife - Klein-Priebus does not offer any direct ODMs in the evenings anymore, when travel times are slightly longer due to buffers for ride pooling, on staging: /routing?from=%7B%22type%22%3A%22PLACE%22%2C%22tokens%22%3A%5B%5B0%2C8%5D%5D%2C%22name%22%3A%22Schleife%22%2C%22id%22%3A%22node%2F240034042%22%2C%22lat%22%3A51.5446031%2C%22lon%22%3A14.5355952%2C%22zip%22%3A%2202959%22%2C%22tz%22%3A%22Europe%2FBerlin%22%2C%22areas%22%3A%5B%7B%22name%22%3A%22Deutschland%22%2C%22adminLevel%22%3A2%2C%22matched%22%3Afalse%2C%22unique%22%3Afalse%2C%22default%22%3Afalse%7D%2C%7B%22name%22%3A%22Sachsen%22%2C%22adminLevel%22%3A4%2C%22matched%22%3Afalse%2C%22unique%22%3Afalse%2C%22default%22%3Afalse%7D%2C%7B%22name%22%3A%22G%C3%B6rlitz%22%2C%22adminLevel%22%3A6%2C%22matched%22%3Afalse%2C%22unique%22%3Afalse%2C%22default%22%3Afalse%7D%2C%7B%22name%22%3A%22Schleife%22%2C%22adminLevel%22%3A7%2C%22matched%22%3Afalse%2C%22unique%22%3Afalse%2C%22default%22%3Afalse%7D%2C%7B%22name%22%3A%22Schleife%22%2C%22adminLevel%22%3A8%2C%22matched%22%3Afalse%2C%22unique%22%3Atrue%2C%22default%22%3Atrue%7D%5D%2C%22score%22%3A-6.770999908447266%7D&to=%7B%22type%22%3A%22PLACE%22%2C%22tokens%22%3A%5B%5B0%2C5%5D%2C%5B6%2C7%5D%5D%2C%22name%22%3A%22Klein+Priebus%22%2C%22id%22%3A%22node%2F316079873%22%2C%22lat%22%3A51.4539665%2C%22lon%22%3A14.9565612%2C%22zip%22%3A%2202957%22%2C%22tz%22%3A%22Europe%2FBerlin%22%2C%22areas%22%3A%5B%7B%22name%22%3A%22Deutschland%22%2C%22adminLevel%22%3A2%2C%22matched%22%3Afalse%2C%22unique%22%3Afalse%2C%22default%22%3Afalse%7D%2C%7B%22name%22%3A%22Sachsen%22%2C%22adminLevel%22%3A4%2C%22matched%22%3Afalse%2C%22unique%22%3Afalse%2C%22default%22%3Afalse%7D%2C%7B%22name%22%3A%22G%C3%B6rlitz%22%2C%22adminLevel%22%3A6%2C%22matched%22%3Afalse%2C%22unique%22%3Afalse%2C%22default%22%3Afalse%7D%2C%7B%22name%22%3A%22Krauschwitz%22%2C%22adminLevel%22%3A8%2C%22matched%22%3Afalse%2C%22unique%22%3Atrue%2C%22default%22%3Atrue%7D%5D%2C%22score%22%3A-8%7D&time=Wed+Sep+17+2025+14%3A49%3A00+GMT%2B0200+%28Central+European+Summer+Time%29&arriveBy=false

Cause: Long overnight journey dominates short ODM journey that it overtakes (distance=0).

Proposition to be discussed.