### PR TITLE
Handle trip_ids containing spaces in shape analysis

### DIFF
--- a/exe/main.cc
+++ b/exe/main.cc
@@ -259,7 +259,9 @@ int main(int ac, char** av) {
         auto const ids = utl::to_vec(
             vm["trip-id"].as<std::vector<std::string> >(),
             [](auto const& trip_id) {
-              auto const decoded = boost::urls::decode_view{trip_id};
+              // Set space_as_plus = true
+              auto const opts = boost::urls::encoding_opts{true};
+              auto const decoded = boost::urls::decode_view{trip_id, opts};
               return std::string{decoded.begin(), decoded.end()};
             });
 


### PR DESCRIPTION
Fixes an issue, if a `trip_id` contains spaces.
As the web UI encodes spaces as `+`, the analyzer needs to decode these correctly.
**Example**: `20250905_15%3A53_au-Translink-SEQ_33394889-SBL+25_26-39719`