### PR TITLE
add option to fetch other stops on each run when querying stoptimes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1379,6 +1379,17 @@ paths:
             If set to `true`, only stations that are phyiscally in the radius are considered.
             If set to `false`, additionally to the stations in the radius, equivalences with the same name and children are considered.
 
+        - name: fetchStops
+          in: query
+          schema:
+            type: boolean
+          required: false
+          description: |
+            Experimental. Expect unannounced breaking changes (without version bumps).
+
+            Optional. Default is `false`. If set to `true`, the following stops are returned
+            for departures and the previous stops are returned for arrivals.
+
         - name: pageCursor
           in: query
           required: false
@@ -2155,6 +2166,22 @@ components:
           type: string
         displayName:
           type: string
+        previousStops:
+          type: array
+          description: |
+            Experimental. Expect unannounced breaking changes (without version bumps).
+
+            Stops on the trips before this stop. Returned only if `fetchStop` and `arriveBy` are `true`.
+          items:
+            $ref: "#/components/schemas/Place"
+        nextStops:
+          type: array
+          description: |
+            Experimental. Expect unannounced breaking changes (without version bumps).
+
+            Stops on the trips after this stop. Returned only if `fetchStop` is `true` and `arriveBy` is `false`.
+          items:
+            $ref: "#/components/schemas/Place"
         pickupDropoffType:
           description: Type of pickup (for departures) or dropoff (for arrivals), may be disallowed either due to schedule, skipped stops or cancellations
           $ref: '#/components/schemas/PickupDropoffType'


### PR DESCRIPTION
A while ago, I proposed in the Matrix channel to add an option to extend the stop times endpoint such that other stops are also returned for each found trip, eliminating the need for separate calls to the trip endpoint.

The purpose was to build a replacement for direkt.bahn.guru, which is already online at direct-trains.eu. Now, I got finally around to prepare the changes into a PR.

* The API was modeled after hafas-client. Consequently, only the subsequent/previous stops are returned when looking up departures/arrivals. Also, the keys in the JSON response differ.
* It would also be possible to return all stops on the trip (and make the response more similar to the trip endpoint). I did not choose this option because I figured that this way would be more useful in most situations as you don't need to look for the requested stop in the response.
* Interlined legs are joined.
* I marked the new API as experimental in case we need to change it