### PR TITLE
Don't display cable cars as aerial lifts in the UI

### DIFF
--- a/ui/src/lib/modeStyle.ts
+++ b/ui/src/lib/modeStyle.ts
@@ -80,6 +80,8 @@ export const getModeStyle = (l: LegLike): [string, string, string] => {
 			return ['funicular', '#795548', 'white'];
 
 		case 'CABLE_CAR':
+			return ['tram', '#795548', 'white'];
+
 		case 'AREAL_LIFT':
 			return ['aerial_lift', '#795548', 'white'];
 	}


### PR DESCRIPTION
Cable cars in GTFS terms refer to "street-level rail cars where the cable runs beneath the vehicle", such as the cable cars in San Francisco.

DELFI classifies funiculars as route type 5 (cable car), so this fixes those showing up as aerial lifts.