### PR TITLE
translation: label REGIONAL_FAST without regional

### DIFF
--- a/ui/src/lib/i18n/cz.ts
+++ b/ui/src/lib/i18n/cz.ts
@@ -83,7 +83,7 @@ const translations: Translations = {
 	HIGHSPEED_RAIL: 'Vysokorychlostní železnice',
 	LONG_DISTANCE: 'Dálková železnice',
 	NIGHT_RAIL: 'Noční vlaky',
-	REGIONAL_FAST_RAIL: 'Zrychlená regionální železnice',
+	REGIONAL_FAST_RAIL: 'Zrychlená železnice',
 	REGIONAL_RAIL: 'Regionální železnice',
 	OTHER: 'Jiné',
 	routingSegments: {

--- a/ui/src/lib/i18n/de.ts
+++ b/ui/src/lib/i18n/de.ts
@@ -82,7 +82,7 @@ const translations: Translations = {
 	HIGHSPEED_RAIL: 'Hochgeschwindigkeitszug',
 	LONG_DISTANCE: 'Intercityzug',
 	NIGHT_RAIL: 'Nachtzug',
-	REGIONAL_FAST_RAIL: 'Regionalexpresszug',
+	REGIONAL_FAST_RAIL: 'Schnellzug',
 	REGIONAL_RAIL: 'Regionalzug',
 	OTHER: 'Andere',
 	routingSegments: {

--- a/ui/src/lib/i18n/en.ts
+++ b/ui/src/lib/i18n/en.ts
@@ -81,7 +81,7 @@ const translations: Translations = {
 	HIGHSPEED_RAIL: 'High Speed Rail',
 	LONG_DISTANCE: 'Intercity Rail',
 	NIGHT_RAIL: 'Night Rail',
-	REGIONAL_FAST_RAIL: 'Regional Fast Rail',
+	REGIONAL_FAST_RAIL: 'Fast Rail',
 	REGIONAL_RAIL: 'Regional Rail',
 	OTHER: 'Other',
 	RENTAL_BICYCLE: 'Shared bike',

--- a/ui/src/lib/i18n/fr.ts
+++ b/ui/src/lib/i18n/fr.ts
@@ -81,7 +81,7 @@ const translations: Translations = {
 	HIGHSPEED_RAIL: 'Train à grande vitesse',
 	LONG_DISTANCE: 'Train intercité',
 	NIGHT_RAIL: 'Train de nuit',
-	REGIONAL_FAST_RAIL: 'Train express régional',
+	REGIONAL_FAST_RAIL: 'Train express',
 	REGIONAL_RAIL: 'Train régional',
 	OTHER: 'Autres',
 	routingSegments: {

--- a/ui/src/lib/i18n/pl.ts
+++ b/ui/src/lib/i18n/pl.ts
@@ -83,7 +83,7 @@ const translations: Translations = {
 	HIGHSPEED_RAIL: 'Kolej dużych prędkości',
 	LONG_DISTANCE: 'Kolej dalekobieżna',
 	NIGHT_RAIL: 'Nocne pociągi',
-	REGIONAL_FAST_RAIL: 'Przyspieszona kolej regionalna',
+	REGIONAL_FAST_RAIL: 'Pociąg pospieszny',
 	REGIONAL_RAIL: 'Kolej regionalna',
 	OTHER: 'Inne',
 	routingSegments: {


### PR DESCRIPTION
as the term regional may confuse one into thinking the train can be used with a ticket of regional public transport. In Germany there was special confusion, as for those routes I checked, the class of RegionalExpress trains in the data is labeled with REGIONAL_RAIL (IMHO correctly), and REGIONAL_FAST_RAIL was translated with RegionalExpress. I avoided to use the term InterRegio, as in Switzerland those are REGIONAL_RAIL, but the German railway company uses the term "InterRegio / fast train" for the lowest class of non-regional long distance. AFAIK German railway uses the "fast train" classification only for foreign trains.

The definition in openapi.yaml matches with
https://en.wikipedia.org/wiki/Express_train and a few of the other languages linked for that article. And I have not seen the term further differentiated with something like regional, only with a specific line.

I'm told REGIONAL_FAST_RAIL is also used as a fallback where there is no data and that the structure of the data is
not expressive enough to capture the ticket price structure, but as it is a few test routings on https://transitous.org/ revealed no conflicting usage of REGIONAL_FAST_RAIL. (Whether or not some of these should be a "faster" classification, does not pose any problem here.)

Whether it is because the origin on the data already fits this classification system and/or the fall back is selected well, but overall I think omitting regional is more likely to lead people to select the route options they intent.