### PR TITLE
Don't omit walk for direct connections when using rental mode

### DIFF
--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -437,8 +437,6 @@ std::pair<std::vector<api::Itinerary>, n::duration_t> routing::route_direct(
   if (!w_ || !l_) {
     return {};
   }
-  auto const omit_walk = gbfs_rd.has_data() &&
-                         utl::find(modes, api::ModeEnum::RENTAL) != end(modes);
   auto fastest_direct = kInfinityDuration;
   auto cache = street_routing_cache_t{};
   auto itineraries = std::vector<api::Itinerary>{};
@@ -474,7 +472,7 @@ std::pair<std::vector<api::Itinerary>, n::duration_t> routing::route_direct(
     } else if (m == api::ModeEnum::CAR || m == api::ModeEnum::BIKE ||
                m == api::ModeEnum::CAR_PARKING ||
                m == api::ModeEnum::CAR_DROPOFF ||
-               (!omit_walk && m == api::ModeEnum::WALK)) {
+               m == api::ModeEnum::BUS_ROUTE || m == api::ModeEnum::WALK) {
       route_with_profile(default_output{
           *w_, to_profile(m, pedestrian_profile, elevation_costs)});
     } else if (m == api::ModeEnum::RENTAL && gbfs_rd.has_data()) {

--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -471,8 +471,7 @@ std::pair<std::vector<api::Itinerary>, n::duration_t> routing::route_direct(
       }
     } else if (m == api::ModeEnum::CAR || m == api::ModeEnum::BIKE ||
                m == api::ModeEnum::CAR_PARKING ||
-               m == api::ModeEnum::CAR_DROPOFF ||
-               m == api::ModeEnum::BUS_ROUTE || m == api::ModeEnum::WALK) {
+               m == api::ModeEnum::CAR_DROPOFF || m == api::ModeEnum::WALK) {
       route_with_profile(default_output{
           *w_, to_profile(m, pedestrian_profile, elevation_costs)});
     } else if (m == api::ModeEnum::RENTAL && gbfs_rd.has_data()) {

--- a/test/routing_test.cc
+++ b/test/routing_test.cc
@@ -504,6 +504,8 @@ TEST(motis, routing) {
     (from=- [track=-, scheduled_track=-, level=0], to=- [track=-, scheduled_track=-, level=0], start=2019-05-01 01:25, mode="WALK", trip="-", end=2019-05-01 01:26),
     (from=- [track=-, scheduled_track=-, level=0], to=- [track=-, scheduled_track=-, level=0], start=2019-05-01 01:26, mode="RENTAL", trip="-", end=2019-05-01 01:27),
     (from=- [track=-, scheduled_track=-, level=0], to=- [track=-, scheduled_track=-, level=0], start=2019-05-01 01:27, mode="WALK", trip="-", end=2019-05-01 01:36)
+]date=2019-05-01, start=01:25, end=01:36, duration=00:11, transfers=0, legs=[
+    (from=- [track=-, scheduled_track=-, level=0], to=- [track=-, scheduled_track=-, level=0], start=2019-05-01 01:25, mode="WALK", trip="-", end=2019-05-01 01:36)
 ])",
         to_str(res.direct_));
   }


### PR DESCRIPTION
If mode `WALK` is included in `directModes`, it is now always used to calculate a direct route by walking, even if the `RENTAL` mode is also included. Previously, walking routes were only found if a direct connection using rental vehicles couldn't be found for at least one rental provider in that case.