### PR TITLE
Add parameter to set polygon resolution

### DIFF
--- a/ui/src/lib/defaults.ts
+++ b/ui/src/lib/defaults.ts
@@ -37,6 +37,7 @@ export const defaultQuery = {
 	additionalTransferTime: 0,
 	transferTimeFactor: 1,
 	numItineraries: 5,
+	circleResolution: undefined,
 	maxItineraries: undefined,
 	passengers: 1,
 	luggage: 0,

--- a/ui/src/lib/map/Isochrones.svelte
+++ b/ui/src/lib/map/Isochrones.svelte
@@ -24,6 +24,7 @@
 		streetModes,
 		wheelchair,
 		maxAllTime,
+		circleResolution,
 		active,
 		options = $bindable()
 	}: {
@@ -33,6 +34,7 @@
 		streetModes: PrePostDirectMode[];
 		wheelchair: boolean;
 		maxAllTime: number;
+		circleResolution: number | undefined;
 		active: boolean;
 		options: IsochronesOptions;
 	} = $props();
@@ -192,7 +194,8 @@
 				index: ++dataIndex,
 				data: $state.snapshot(isochronesData),
 				kilometersPerSecond: $state.snapshot(kilometersPerSecond),
-				maxSeconds: $state.snapshot(maxAllTime)
+				maxSeconds: $state.snapshot(maxAllTime),
+				circleResolution
 			});
 
 			lastData = isochronesData;

--- a/ui/src/lib/map/IsochronesShapeWorker.ts
+++ b/ui/src/lib/map/IsochronesShapeWorker.ts
@@ -27,6 +27,7 @@ let highestComputedLevel: DisplayLevel = 'NONE';
 let maxLevel: DisplayLevel = 'NONE';
 let working = false;
 let maxDistance = (_: IsochronesPos) => 0;
+let circleResolution: number = 64; // default 'steps' for @turf/circle
 
 self.onmessage = async function (event) {
 	const method = event.data.method;
@@ -36,6 +37,9 @@ self.onmessage = async function (event) {
 		const kilometersPerSecond = event.data.kilometersPerSecond;
 		const maxSeconds = event.data.maxSeconds;
 		maxDistance = getMaxDistanceFunction(kilometersPerSecond, maxSeconds);
+		if (event.data.circleResolution && event.data.circleResolution > 2) {
+			circleResolution = event.data.circleResolution;
+		}
 	} else if (method == 'set-max-level') {
 		maxLevel = event.data.level;
 		createShapes();
@@ -184,7 +188,7 @@ async function createCircles() {
 	}
 	const promises = rects.map(async (rect: RectType) => {
 		const c = circle([rect.data.lng, rect.data.lat], rect.distance, {
-			// steps: 64,
+			steps: circleResolution,
 			units: 'kilometers'
 		});
 		// bbox extent in [minX, minY, maxX, maxY] order

--- a/ui/src/lib/map/IsochronesWorker.ts
+++ b/ui/src/lib/map/IsochronesWorker.ts
@@ -28,6 +28,7 @@ self.onmessage = async function (event) {
 		const isochronesData = event.data.data;
 		const kilometersPerSecond: number = event.data.kilometersPerSecond;
 		const maxSeconds: number = event.data.maxSeconds;
+		const circleResolution: number = event.data.circleResolution;
 		dataIndex = index;
 		rects = undefined;
 		circles = undefined;
@@ -37,7 +38,8 @@ self.onmessage = async function (event) {
 			index: dataIndex,
 			data: isochronesData,
 			kilometersPerSecond,
-			maxSeconds
+			maxSeconds,
+			circleResolution
 		});
 	} else if (method == 'set-max-display-level') {
 		if (shapeWorker !== undefined) {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -254,6 +254,9 @@
 		status: 'DONE',
 		error: undefined
 	});
+	const isochronesCircleResolution = urlParams?.get('isochronesCircleResolution')
+		? parseIntOr(urlParams.get('isochronesCircleResolution'), defaultQuery.circleResolution)
+		: defaultQuery.circleResolution;
 
 	const toPlaceString = (l: Location) => {
 		if (l.match?.type === 'STOP') {
@@ -406,7 +409,10 @@
 						maxTravelTime: q.maxTravelTime * 60,
 						isochronesColor,
 						isochronesOpacity,
-						isochronesDisplayLevel
+						isochronesDisplayLevel,
+						...(isochronesCircleResolution && isochronesCircleResolution > 2
+							? { isochronesCircleResolution }
+							: {})
 					},
 					{},
 					true
@@ -739,6 +745,7 @@
 			streetModes={arriveBy ? preTransitModes : postTransitModes}
 			wheelchair={pedestrianProfile === 'WHEELCHAIR'}
 			maxAllTime={arriveBy ? maxPreTransitTime : maxPostTransitTime}
+			circleResolution={isochronesCircleResolution}
 			active={activeTab == 'isochrones'}
 			bind:options={isochronesOptions}
 		/>


### PR DESCRIPTION
When using queries with large `maxTravelTime`, the browser may fail to compute the union of the reachable polygons (circles). This adds an option to create much simpler polygons, for that the computation is much faster.

For queries with a large `maxTravelTime`, users will most likely use a low zoom level. In that case, having less vertices per circle will hardly be noticeable.
I don't think, that this needs to be selectable in the UI, as users cannot select travel times larger than 4 hours there anyway.

Example usage with `isochronesCircleResolution=4`
<img width="1570" height="1437" alt="Isochrones example isochronesCircleResolution=4" src="https://github.com/user-attachments/assets/9b19df4c-7d79-4319-b071-b88cfad69009" />
