### PR TITLE
Show all found journeys on the map

### DIFF
--- a/ui/src/lib/ItineraryGeoJSON.svelte
+++ b/ui/src/lib/ItineraryGeoJSON.svelte
@@ -68,12 +68,14 @@
 		itinerary,
 		id,
 		selected,
+		selectItinerary,
 		level,
 		theme
 	}: {
 		itinerary: Itinerary;
 		id?: string;
 		selected: boolean;
+		selectItinerary?: () => void;
 		level: number;
 		theme: 'light' | 'dark';
 	} = $props();
@@ -104,6 +106,11 @@
 			'line-cap': 'round'
 		}}
 		filter={['any', ['!has', 'level'], ['==', 'level', level]]}
+		onclick={selectItinerary
+			? (_) => {
+					selectItinerary();
+				}
+			: undefined}
 		paint={{
 			'line-color': selected ? ['get', 'color'] : theme == 'dark' ? '#777' : '#bbb',
 			'line-width': 7.5,

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -610,7 +610,16 @@
 			{#each routingResponses as r, rI (rI)}
 				{#await r then r}
 					{#each r.itineraries as it, i (i)}
-						<ItineraryGeoJson itinerary={it} id="{rI}-{i}" selected={false} {level} {theme} />
+						<ItineraryGeoJson
+							itinerary={it}
+							id="{rI}-{i}"
+							selected={false}
+							selectItinerary={() => {
+								pushState('', { selectedItinerary: it });
+							}}
+							{level}
+							{theme}
+						/>
 					{/each}
 				{/await}
 			{/each}


### PR DESCRIPTION
Dark theme: 
<img width="2620" height="1574" alt="grafik" src="https://github.com/user-attachments/assets/b4189326-fec4-4ec8-a008-319c65c2e5b9" />

Light theme:
<img width="2620" height="1572" alt="grafik" src="https://github.com/user-attachments/assets/e8c4f107-8a5b-4283-be39-08a112d97834" />

The patch still has one minor issue (that I know of): Multiple itineraries can be selected when clicking if they overlap on the map. Then, they have to be closed one-by-one.