### PR TITLE
take dur into account for odm td_offsets

### DIFF
--- a/include/motis/odm/td_offsets.h
+++ b/include/motis/odm/td_offsets.h
@@ -13,7 +13,9 @@ nigiri::routing::td_offsets_t get_td_offsets(
       rides, [](auto const& a, auto const& b) { return a.stop_ == b.stop_; },
       [&](auto&& from_it, auto&& to_it) {
         td_offsets.emplace(from_it->stop_,
-                           std::vector<nigiri::routing::td_offset>{});
+                           std::vector<nigiri::routing::td_offset>{
+                               {nigiri::unixtime_t{nigiri::i32_minutes{0U}},
+                                nigiri::footpath::kMaxDuration, mode}});
 
         for (auto const& r : nigiri::it_range{from_it, to_it}) {
           auto const tdo = nigiri::routing::td_offset{
@@ -34,9 +36,9 @@ nigiri::routing::td_offsets_t get_td_offsets(
           }
 
           if (i + 1 == end(td_offsets.at(r.stop_)) ||
-              (i + 1)->valid_from_ != tdo.valid_from_ + 1min) {
+              (i + 1)->valid_from_ > tdo.valid_from_ + tdo.duration_) {
             td_offsets.at(r.stop_).insert(
-                i + 1, {.valid_from_ = tdo.valid_from_ + 1min,
+                i + 1, {.valid_from_ = tdo.valid_from_ + tdo.duration_,
                         .duration_ = nigiri::footpath::kMaxDuration,
                         .transport_mode_id_ = mode});
           }

--- a/test/odm/td_offsets_test.cc
+++ b/test/odm/td_offsets_test.cc
@@ -31,18 +31,21 @@ TEST(odm, get_td_offsets_basic) {
   print(td_offsets);
 
   ASSERT_TRUE(td_offsets.contains(location_idx_t{1U}));
-  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 2U);
+  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 3U);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].valid_from_, unixtime_t{10h});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_, 1h);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_,
+            footpath::kMaxDuration);
+
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_, unixtime_t{10h});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_, 1h);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
             kOdmTransportModeId);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_,
-            unixtime_t{10h + 1min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].valid_from_,
+            unixtime_t{10h + 1h});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_,
             footpath::kMaxDuration);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].transport_mode_id_,
             kOdmTransportModeId);
 }
 
@@ -64,18 +67,21 @@ TEST(odm, get_td_offsets_extension) {
   print(td_offsets);
 
   ASSERT_TRUE(td_offsets.contains(location_idx_t{1U}));
-  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 2U);
+  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 3U);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].valid_from_, unixtime_t{10h});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_, 1h);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_,
+            footpath::kMaxDuration);
+
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_, unixtime_t{10h});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_, 1h);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
             kOdmTransportModeId);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_,
-            unixtime_t{10h + 3min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].valid_from_,
+            unixtime_t{10h + 1h + 2min});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_,
             footpath::kMaxDuration);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].transport_mode_id_,
             kOdmTransportModeId);
 }
 
@@ -97,18 +103,21 @@ TEST(odm, get_td_offsets_extension_reverse) {
   print(td_offsets);
 
   ASSERT_TRUE(td_offsets.contains(location_idx_t{1U}));
-  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 2U);
+  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 3U);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].valid_from_, unixtime_t{10h});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_, 1h);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_,
+            footpath::kMaxDuration);
+
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_, unixtime_t{10h});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_, 1h);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
             kOdmTransportModeId);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_,
-            unixtime_t{10h + 3min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].valid_from_,
+            unixtime_t{10h + 1h + 2min});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_,
             footpath::kMaxDuration);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].transport_mode_id_,
             kOdmTransportModeId);
 }
 
@@ -130,31 +139,35 @@ TEST(odm, get_td_offsets_extension_fill_gap) {
   print(td_offsets);
 
   ASSERT_TRUE(td_offsets.contains(location_idx_t{1U}));
-  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 2U);
+  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 3U);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].valid_from_, unixtime_t{10h});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_, 1h);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_,
+            footpath::kMaxDuration);
+
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_, unixtime_t{10h});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_, 1h);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
             kOdmTransportModeId);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_,
-            unixtime_t{10h + 3min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].valid_from_,
+            unixtime_t{10h + 1h + 2min});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_,
             footpath::kMaxDuration);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].transport_mode_id_,
             kOdmTransportModeId);
 }
 
 TEST(odm, get_td_offsets_intermittent) {
-  auto const rides = std::vector<start>{{.time_at_start_ = unixtime_t{10h},
-                                         .time_at_stop_ = unixtime_t{11h},
-                                         .stop_ = location_idx_t{1U}},
-                                        {.time_at_start_ = unixtime_t{11h},
-                                         .time_at_stop_ = unixtime_t{12h},
-                                         .stop_ = location_idx_t{1U}},
-                                        {.time_at_start_ = unixtime_t{12h},
-                                         .time_at_stop_ = unixtime_t{13h},
-                                         .stop_ = location_idx_t{1U}}};
+  auto const rides =
+      std::vector<start>{{.time_at_start_ = unixtime_t{10h},
+                          .time_at_stop_ = unixtime_t{11h},
+                          .stop_ = location_idx_t{1U}},
+                         {.time_at_start_ = unixtime_t{11h},
+                          .time_at_stop_ = unixtime_t{11h + 59min},
+                          .stop_ = location_idx_t{1U}},
+                         {.time_at_start_ = unixtime_t{12h},
+                          .time_at_stop_ = unixtime_t{13h},
+                          .stop_ = location_idx_t{1U}}};
 
   auto const td_offsets =
       motis::odm::get_td_offsets(rides, kOdmTransportModeId);
@@ -164,23 +177,20 @@ TEST(odm, get_td_offsets_intermittent) {
   ASSERT_TRUE(td_offsets.contains(location_idx_t{1U}));
   ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 6U);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].valid_from_, unixtime_t{10h});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_, 1h);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].transport_mode_id_,
-            kOdmTransportModeId);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_,
-            unixtime_t{10h + 1min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_,
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_,
             footpath::kMaxDuration);
+
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_, unixtime_t{10h});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_, 1h);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
             kOdmTransportModeId);
 
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].valid_from_, unixtime_t{11h});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_, 1h);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_, 59min);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].transport_mode_id_,
             kOdmTransportModeId);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[3].valid_from_,
-            unixtime_t{11h + 1min});
+            unixtime_t{11h + 59min});
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[3].duration_,
             footpath::kMaxDuration);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[3].transport_mode_id_,
@@ -191,7 +201,7 @@ TEST(odm, get_td_offsets_intermittent) {
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[4].transport_mode_id_,
             kOdmTransportModeId);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[5].valid_from_,
-            unixtime_t{12h + 1min});
+            unixtime_t{12h + 1h});
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[5].duration_,
             footpath::kMaxDuration);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[5].transport_mode_id_,
@@ -216,30 +226,33 @@ TEST(odm, get_td_offsets_long_short_long) {
   print(td_offsets);
 
   ASSERT_TRUE(td_offsets.contains(location_idx_t{1U}));
-  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 4U);
+  ASSERT_EQ(td_offsets.at(location_idx_t{1U}).size(), 5U);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].valid_from_, unixtime_t{10h});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_, 1h);
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].transport_mode_id_,
-            kOdmTransportModeId);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[0].duration_,
+            footpath::kMaxDuration);
 
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_,
-            unixtime_t{10h + 1min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_, 30min);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].valid_from_, unixtime_t{10h});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].duration_, 1h);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[1].transport_mode_id_,
             kOdmTransportModeId);
 
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].valid_from_,
-            unixtime_t{10h + 2min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_, 1h);
+            unixtime_t{10h + 1min});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].duration_, 30min);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[2].transport_mode_id_,
             kOdmTransportModeId);
 
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[3].valid_from_,
-            unixtime_t{10h + 3min});
-  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[3].duration_,
-            footpath::kMaxDuration);
+            unixtime_t{10h + 2min});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[3].duration_, 1h);
   EXPECT_EQ(td_offsets.at(location_idx_t{1U})[3].transport_mode_id_,
+            kOdmTransportModeId);
+
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[4].valid_from_,
+            unixtime_t{10h + 1h + 2min});
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[4].duration_,
+            footpath::kMaxDuration);
+  EXPECT_EQ(td_offsets.at(location_idx_t{1U})[4].transport_mode_id_,
             kOdmTransportModeId);
 }
 


### PR DESCRIPTION
For a ride share offer 
Niesky, Deutschland -> Weißwasser Bahnhof, Weißwasser/O.L.
16:19 - 17:16 we obtain this:
<img width="449" height="982" alt="image" src="https://github.com/user-attachments/assets/a5a2374c-50d6-4e62-a515-68fb4a9bffa0" />

(i.e. too early departure time and non-repaired bus stop time) – can be reproduced on many/all examples on staging.

[In other places](https://github.com/motis-project/motis/blob/2060bc7c52ca993c9f7d65fc26d8a133bccf75cb/src/flex/flex.cc#L350), the offset is reset to `kMaxDuration` only after the duration of the walk/ride and not after 1min. Not sure why, but this appears to fix the ride share legs again. Haven't yet completely fixed the tests because this might need more work and I wanted to discuss this first.
