### PR TITLE
Update MapLibre map font files

### DIFF
--- a/.pkg
+++ b/.pkg
@@ -41,7 +41,7 @@
 [tiles]
   url=git@github.com:motis-project/tiles.git
   branch=master
-  commit=b1741f3af8cf837fa3c199abe3c950b5e0370dab
+  commit=e92dd0ff1def189bd4083393db3769d9434ef25d
 [boost]
   url=git@github.com:motis-project/boost.git
   branch=boost-1.89.0

--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -294,7 +294,7 @@ export const getStyle = (
 				layout: {
 					'symbol-placement': 'point',
 					'text-field': ['get', 'name'],
-					'text-font': ['Noto Sans Display Regular'],
+					'text-font': ['Noto Sans Regular'],
 					'text-size': 12
 				},
 				paint: {
@@ -719,7 +719,7 @@ export const getStyle = (
 				layout: {
 					'symbol-placement': 'line',
 					'text-field': ['get', 'ref'],
-					'text-font': ['Noto Sans Display Regular'],
+					'text-font': ['Noto Sans Regular'],
 					'text-size': ['case', ['==', ['get', 'highway'], 'motorway'], 11, 10],
 					'text-justify': 'center',
 					'text-rotation-alignment': 'viewport',
@@ -743,7 +743,7 @@ export const getStyle = (
 				layout: {
 					'symbol-placement': 'line',
 					'text-field': ['get', 'name'],
-					'text-font': ['Noto Sans Display Regular'],
+					'text-font': ['Noto Sans Regular'],
 					'text-size': 9
 				},
 				paint: {
@@ -761,7 +761,7 @@ export const getStyle = (
 				layout: {
 					// "symbol-sort-key": ["get", "population"],
 					'text-field': ['get', 'name'],
-					'text-font': ['Noto Sans Display Regular'],
+					'text-font': ['Noto Sans Regular'],
 					'text-size': 12
 				},
 				paint: {
@@ -779,7 +779,7 @@ export const getStyle = (
 				layout: {
 					'symbol-sort-key': ['-', ['coalesce', ['get', 'population'], 0]],
 					'text-field': ['get', 'name'],
-					'text-font': ['Noto Sans Display Bold'],
+					'text-font': ['Noto Sans Bold'],
 					'text-size': ['interpolate', ['linear'], ['zoom'], 6, 12, 9, 16]
 				},
 				paint: {
@@ -803,7 +803,7 @@ export const getStyle = (
 				//     "source-layer": "tiles_debug_info",
 				//     "layout": {
 				//       "text-field": ["get", "tile_id"],
-				//       "text-font": ["Noto Sans Display Bold"],
+				//       "text-font": ["Noto Sans Bold"],
 				//       "text-size": 16,
 				//     },
 				//     "paint": {


### PR DESCRIPTION
This fixes several missing scripts for labels on the map.

Fixes #748