### PR TITLE
feat(api): add modes field to Place schema and map/stops endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2650,6 +2650,11 @@ components:
           description: Time that on-demand service ends
           type: string
           format: date-time
+        modes:
+          description: available transport modes for stops
+          type: array
+          items:
+            $ref: "#/components/schemas/Mode"
 
     ReachablePlace:
       description: Place reachable by One-to-All

--- a/src/place.cc
+++ b/src/place.cc
@@ -12,6 +12,7 @@
 
 #include "motis/parse_location.h"
 #include "motis/tag_lookup.h"
+#include "motis/timetable/clasz_to_mode.h"
 
 namespace n = nigiri;
 
@@ -134,6 +135,16 @@ api::Place to_place(n::timetable const* tt,
               auto const pos = tt->locations_.coordinates_[l];
               auto const p = tt->locations_.get_root_idx(l);
               auto const timezone = get_tz(*tt, ae, tz_map, p);
+              
+              auto modes = std::optional<std::vector<api::ModeEnum>>{};
+              if (ae != nullptr) {
+                try {
+                  auto const place_idx = ae->location_place_.at(p);
+                  modes = to_modes(ae->place_clasz_.at(place_idx), 5);
+                } catch (...) {
+                }
+              }
+              
               return {
                   .name_ = std::string{tt->translate(
                       lang, tt->locations_.names_.at(p))},
@@ -153,7 +164,8 @@ api::Place to_place(n::timetable const* tt,
                   .scheduledTrack_ = get_track(tt_l.scheduled_),
                   .track_ = get_track(tt_l.l_),
                   .description_ = get_description(tt_l.scheduled_),
-                  .vertexType_ = api::VertexTypeEnum::TRANSIT};
+                  .vertexType_ = api::VertexTypeEnum::TRANSIT,
+                  .modes_ = std::move(modes)};
             }
           }},
       l);

--- a/src/place.cc
+++ b/src/place.cc
@@ -135,16 +135,7 @@ api::Place to_place(n::timetable const* tt,
               auto const pos = tt->locations_.coordinates_[l];
               auto const p = tt->locations_.get_root_idx(l);
               auto const timezone = get_tz(*tt, ae, tz_map, p);
-              
-              auto modes = std::optional<std::vector<api::ModeEnum>>{};
-              if (ae != nullptr) {
-                try {
-                  auto const place_idx = ae->location_place_.at(p);
-                  modes = to_modes(ae->place_clasz_.at(place_idx), 5);
-                } catch (...) {
-                }
-              }
-              
+
               return {
                   .name_ = std::string{tt->translate(
                       lang, tt->locations_.names_.at(p))},
@@ -165,7 +156,12 @@ api::Place to_place(n::timetable const* tt,
                   .track_ = get_track(tt_l.l_),
                   .description_ = get_description(tt_l.scheduled_),
                   .vertexType_ = api::VertexTypeEnum::TRANSIT,
-                  .modes_ = std::move(modes)};
+                  .modes_ =
+                      ae != nullptr
+                          ? std::optional<std::vector<api::ModeEnum>>{to_modes(
+                                ae->place_clasz_.at(ae->location_place_.at(p)),
+                                5)}
+                          : std::nullopt};
             }
           }},
       l);


### PR DESCRIPTION
Adds the modes field to the Place schema, matching the existing modes field in the Match schema. This makes transport mode information available on all Place objects in routing/trip responses (legs, tripTo, intermediateStops) and the /api/v1/map/stops endpoint. The field is populated from pre-computed adr_ext place_clasz data.