### PR TITLE
ui: use proper baseUrl for tripsWorker

### DIFF
--- a/ui/src/lib/RailViz.svelte
+++ b/ui/src/lib/RailViz.svelte
@@ -11,6 +11,7 @@
 	import type { MetaData } from './types';
 	import Control from './map/Control.svelte';
 	import { SvelteMap } from 'svelte/reactivity';
+	import { client } from '@motis-project/motis-client';
 	let {
 		map,
 		bounds,
@@ -195,9 +196,8 @@
 	const metaDataMap = new SvelteMap<number, MetaData>();
 
 	onMount(() => {
-		const origin = new URL(window.location.href).searchParams.get('motis');
 		worker = new Worker(new URL('tripsWorker.ts', import.meta.url), { type: 'module' });
-		worker.postMessage({ type: 'init', origin });
+		worker.postMessage({ type: 'init', baseUrl: client.getConfig().baseUrl });
 		worker.onmessage = (e) => {
 			if (e.data.type == 'fetch-complete') {
 				metaDataMap.clear();

--- a/ui/src/lib/tripsWorker.ts
+++ b/ui/src/lib/tripsWorker.ts
@@ -283,7 +283,7 @@ self.onmessage = async (e) => {
 	switch (e.data.type) {
 		case 'init': {
 			const querySerializer = { array: { explode: false } } as QuerySerializerOptions;
-			client.setConfig({ baseUrl: e.data.origin, querySerializer });
+			client.setConfig({ baseUrl: e.data.baseUrl, querySerializer });
 			break;
 		}
 		case 'fetch':


### PR DESCRIPTION
This pull request fixes the baseUrl for tripsWorker being wrong when hosting MOTIS UI on a non root path.