### PR TITLE
Platform code matching

### DIFF
--- a/src/endpoints/matches.cc
+++ b/src/endpoints/matches.cc
@@ -54,7 +54,6 @@ json::value matches::operator()(json::value const& query) const {
                                }},
                osr::to_ref(pl_.platform_ref_[p][0]));
 
-
     matches.emplace_back(json::value{
         {"type", "Feature"},
         {"properties", platform_data},

--- a/src/match_platforms.cc
+++ b/src/match_platforms.cc
@@ -136,7 +136,6 @@ int compare_platform_code(Collection&& names, std::string_view platform_code) {
   return bonus;
 }
 
-
 struct center {
   template <typename T>
   void add(T const& polyline) {
@@ -242,8 +241,7 @@ osr::platform_idx_t get_match(n::timetable const& tt,
     auto const routes_bonus = get_routes_bonus(tt, l, pl.platform_names_[x]);
     auto const code_bonus = compare_platform_code(
         pl.platform_names_[x],
-        tt.get_default_translation(tt.locations_.platform_codes_[l])
-        );
+        tt.get_default_translation(tt.locations_.platform_codes_[l]));
 
     auto const score =
         dist - match_bonus - way_bonus - lvl_bonus - routes_bonus - code_bonus;


### PR DESCRIPTION
fixes #1238 

"fixes" might be a too strong word, as this replaces one vague heuristic with a slightly different one.
But in my tests in Vienna and Lower Austria this improves matching of platforms by quite a bit.

The `has_number_match(names, *get_track(ref))` score bonus felt too strong to me. In my case it seemed to be mostly looking at the end of IFOPT codes like `at:43:3952:0:2` and then applying a lot of weight to the nearby train platform `2` even though it explicitly has a `platform_code` of `E`. It feels far too easy for me for this bonus to match with random numbers (this also happens a bit with the `routes_bonus` if e.g. the city bus line `2` is also involved).

On top of this, I added a new bonus that looks for exact matches between the GTFS platform_code and the OSM platform names (so things like ref, local_ref and name). This works really well in most cases, but of course still has flaws. Especially in multi-layer metro stations (where there are many platform 1/2) and in simple train stations with bus stops next to it. But I think it should not cause completely wrong/confusing matches. And at least in complicated metro stations any heuristic will fail and there is likely an unambiguous `ref:IFOPT` that can be added in OSM instead. 

That said, this is impossible to test thoroughly and I just checked different areas inside Vienna and around Lower Austria. 