### PR TITLE
add mime-type to tile glyphs

### DIFF
--- a/src/endpoints/tiles.cc
+++ b/src/endpoints/tiles.cc
@@ -36,6 +36,8 @@ net::reply tiles::operator()(net::route_request const& req, bool) const {
                                                req.version()};
       res.body() =
           std::string_view{reinterpret_cast<char const*>(mem.ptr_), mem.size_};
+      res.insert(boost::beast::http::field::content_type,
+                 "application/x-protobuf");
       res.keep_alive(req.keep_alive());
       return res;
     } catch (std::out_of_range const&) {


### PR DESCRIPTION
A very minor change, but as `application/x-protobuf` is in the default list of mime types that Caddy compresses by default (and probably also in other webservers' configs) this increases the chance that the files get sent compressed in people's hosted MOTIS instances and cause less bandwidth. 