### PR TITLE
Fix detailedTransfers query parameter required value in OpenAPI doc

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -266,7 +266,7 @@ paths:
 
         - name: detailedTransfers
           in: query
-          required: true
+          required: false
           description: |
             - true: Compute transfer polylines and step instructions.
             - false: Only return basic information (start time, end time, duration) for transfers.


### PR DESCRIPTION
In the OpenAPI documentation, for the `/api/v5/plan` request, the boolean `detailedTransfers` query parameter is marked as required. Yet the doc specifies there is a default value set to `true`, and if we do not specify that query parameter, MOTIS does not complain (see for instance https://api.transitous.org/api/v5/plan?fromPlace=48.8534951%2C2.3483915&toPlace=45.7578137%2C4.8320114).

This PR fixes this and sets `detailedTransfers` as not required.