### PR TITLE
Reorganise transit modes in OpenAPI doc

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2391,7 +2391,7 @@ components:
 
         # Transit modes
 
-          - `TRANSIT`: translates to `RAIL,TRAM,BUS,FERRY,AIRPLANE,COACH,CABLE_CAR,FUNICULAR,AREAL_LIFT,OTHER`
+          - `TRANSIT`: translates to `TRAM,FERRY,AIRPLANE,BUS,COACH,RAIL,FUNICULAR,AERIAL_LIFT,OTHER`
           - `TRAM`: trams
           - `SUBWAY`: subway trains (Paris Metro, London Underground, but also NYC Subway, Hamburger Hochbahn, and other non-underground services)
           - `FERRY`: ferries
@@ -2438,12 +2438,12 @@ components:
         - NIGHT_RAIL
         - REGIONAL_FAST_RAIL
         - REGIONAL_RAIL
-        - CABLE_CAR
         - FUNICULAR
         - AERIAL_LIFT
         - OTHER
         - AREAL_LIFT
         - METRO
+        - CABLE_CAR
 
     Match:
       description: GeoCoding match


### PR DESCRIPTION
This PR improves the OpenAPI doc about the transit modes:

- Remove `CABLE_CAR` in the `TRANSIT` description as it is deprecated and as it falls back to `FUNICULAR`. Rename `AREAL_LIFT` to `AERIAL_LIFT` (the former is deprecated). Finally reorganize the list to be more coherent with the mode list.
- In the enum list, put `CABLE_CAR` at the bottom to be more consistent with the description (all deprecated modes at the bottom).