### PR TITLE
Add ODM mode in TRANSIT description in OpenAPI doc

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2391,7 +2391,7 @@ components:
 
         # Transit modes
 
-          - `TRANSIT`: translates to `TRAM,FERRY,AIRPLANE,BUS,COACH,RAIL,FUNICULAR,AERIAL_LIFT,OTHER`
+          - `TRANSIT`: translates to `TRAM,FERRY,AIRPLANE,BUS,COACH,RAIL,ODM,FUNICULAR,AERIAL_LIFT,OTHER`
           - `TRAM`: trams
           - `SUBWAY`: subway trains (Paris Metro, London Underground, but also NYC Subway, Hamburger Hochbahn, and other non-underground services)
           - `FERRY`: ferries
@@ -2399,15 +2399,15 @@ components:
           - `BUS`: short distance buses (does not include `COACH`)
           - `COACH`: long distance buses (does not include `BUS`)
           - `RAIL`: translates to `HIGHSPEED_RAIL,LONG_DISTANCE,NIGHT_RAIL,REGIONAL_RAIL,REGIONAL_FAST_RAIL,SUBURBAN,SUBWAY`
-          - `SUBURBAN`: suburban trains (e.g. S-Bahn, RER, Elizabeth Line, ...)
           - `HIGHSPEED_RAIL`: long distance high speed trains (e.g. TGV)
           - `LONG_DISTANCE`: long distance inter city trains
           - `NIGHT_RAIL`: long distance night trains
           - `REGIONAL_FAST_RAIL`: regional express routes that skip low traffic stops to be faster
           - `REGIONAL_RAIL`: regional train
+          - `SUBURBAN`: suburban trains (e.g. S-Bahn, RER, Elizabeth Line, ...)
+          - `ODM`: demand responsive transport
           - `FUNICULAR`: Funicular. Any rail system designed for steep inclines.
           - `AERIAL_LIFT`: Aerial lift, suspended cable car (e.g., gondola lift, aerial tramway). Cable transport where cabins, cars, gondolas or open chairs are suspended by means of one or more cables.
-          - `ODM`: demand responsive transport
           - `AREAL_LIFT`: deprecated
           - `METRO`: deprecated
           - `CABLE_CAR`: deprecated
@@ -2429,7 +2429,6 @@ components:
         - SUBWAY
         - FERRY
         - AIRPLANE
-        - SUBURBAN
         - BUS
         - COACH
         - RAIL
@@ -2438,6 +2437,7 @@ components:
         - NIGHT_RAIL
         - REGIONAL_FAST_RAIL
         - REGIONAL_RAIL
+        - SUBURBAN
         - FUNICULAR
         - AERIAL_LIFT
         - OTHER


### PR DESCRIPTION
The `ODM` transit mode was added in MOTIS a couple months ago. But it was not included in the `TRANSIT` translation description in the OpenAPI doc. This PR fixes that.

Also reorganise the transit mode description to be more coherent with the order of the mode list in `src/timetable/modes_to_clasz_mask.cc`.