### PR TITLE
Fix swapped pre and post transit time when arriveBy=true

### DIFF
--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -812,30 +812,33 @@ api::plan_response routing::operator()(boost::urls::url_view const& url) const {
         .start_match_mode_ = get_match_mode(start),
         .dest_match_mode_ = get_match_mode(dest),
         .use_start_footpaths_ = !is_intermodal(start),
-        .start_ = get_offsets(
-            rtt, start,
-            query.arriveBy_ ? osr::direction::kBackward
-                            : osr::direction::kForward,
-            start_modes, start_form_factors, start_propulsion_types,
-            start_rental_providers, start_rental_provider_groups,
-            start_ignore_return_constraints, osr_params,
-            query.pedestrianProfile_, query.elevationCosts_, pre_transit_time,
-            query.maxMatchingDistance_, gbfs_rd, prepare_stats),
-        .destination_ = get_offsets(
-            rtt, dest,
-            query.arriveBy_ ? osr::direction::kForward
-                            : osr::direction::kBackward,
-            dest_modes, dest_form_factors, dest_propulsion_types,
-            dest_rental_providers, dest_rental_provider_groups,
-            dest_ignore_return_constraints, osr_params,
-            query.pedestrianProfile_, query.elevationCosts_, post_transit_time,
-            query.maxMatchingDistance_, gbfs_rd, prepare_stats),
+        .start_ =
+            get_offsets(rtt, start,
+                        query.arriveBy_ ? osr::direction::kBackward
+                                        : osr::direction::kForward,
+                        start_modes, start_form_factors, start_propulsion_types,
+                        start_rental_providers, start_rental_provider_groups,
+                        start_ignore_return_constraints, osr_params,
+                        query.pedestrianProfile_, query.elevationCosts_,
+                        query.arriveBy_ ? post_transit_time : pre_transit_time,
+                        query.maxMatchingDistance_, gbfs_rd, prepare_stats),
+        .destination_ =
+            get_offsets(rtt, dest,
+                        query.arriveBy_ ? osr::direction::kForward
+                                        : osr::direction::kBackward,
+                        dest_modes, dest_form_factors, dest_propulsion_types,
+                        dest_rental_providers, dest_rental_provider_groups,
+                        dest_ignore_return_constraints, osr_params,
+                        query.pedestrianProfile_, query.elevationCosts_,
+                        query.arriveBy_ ? pre_transit_time : post_transit_time,
+                        query.maxMatchingDistance_, gbfs_rd, prepare_stats),
         .td_start_ = get_td_offsets(
             rtt, e, start,
             query.arriveBy_ ? osr::direction::kBackward
                             : osr::direction::kForward,
             start_modes, osr_params, query.pedestrianProfile_,
-            query.elevationCosts_, query.maxMatchingDistance_, pre_transit_time,
+            query.elevationCosts_, query.maxMatchingDistance_,
+            query.arriveBy_ ? post_transit_time : pre_transit_time,
             start_time.start_time_, prepare_stats),
         .td_dest_ = get_td_offsets(
             rtt, e, dest,
@@ -843,7 +846,8 @@ api::plan_response routing::operator()(boost::urls::url_view const& url) const {
                             : osr::direction::kBackward,
             dest_modes, osr_params, query.pedestrianProfile_,
             query.elevationCosts_, query.maxMatchingDistance_,
-            post_transit_time, start_time.start_time_, prepare_stats),
+            query.arriveBy_ ? pre_transit_time : post_transit_time,
+            start_time.start_time_, prepare_stats),
         .max_transfers_ = static_cast<std::uint8_t>(max_transfers),
         .max_travel_time_ = query.maxTravelTime_
                                 .and_then([](std::int64_t const dur) {

--- a/src/odm/meta_router.cc
+++ b/src/odm/meta_router.cc
@@ -345,7 +345,8 @@ api::plan_response meta_router::run() {
           start_modes_, start_form_factors_, start_propulsion_types_,
           start_rental_providers_, start_rental_provider_groups_,
           start_ignore_rental_return_constraints_, params,
-          query_.pedestrianProfile_, query_.elevationCosts_, pre_transit_time,
+          query_.pedestrianProfile_, query_.elevationCosts_,
+          query_.arriveBy_ ? post_transit_time : pre_transit_time,
           query_.maxMatchingDistance_, gbfs_rd_, prepare_stats),
       .dest_walk_ = r_.get_offsets(
           rtt_, dest_,
@@ -354,22 +355,25 @@ api::plan_response meta_router::run() {
           dest_modes_, dest_form_factors_, dest_propulsion_types_,
           dest_rental_providers_, dest_rental_provider_groups_,
           dest_ignore_rental_return_constraints_, params,
-          query_.pedestrianProfile_, query_.elevationCosts_, post_transit_time,
+          query_.pedestrianProfile_, query_.elevationCosts_,
+          query_.arriveBy_ ? pre_transit_time : post_transit_time,
           query_.maxMatchingDistance_, gbfs_rd_, prepare_stats),
-      .td_start_walk_ =
-          r_.get_td_offsets(rtt_, e_, start_,
-                            query_.arriveBy_ ? osr::direction::kBackward
-                                             : osr::direction::kForward,
-                            start_modes_, params, query_.pedestrianProfile_,
-                            query_.elevationCosts_, query_.maxMatchingDistance_,
-                            pre_transit_time, context_intvl, prepare_stats),
-      .td_dest_walk_ =
-          r_.get_td_offsets(rtt_, e_, dest_,
-                            query_.arriveBy_ ? osr::direction::kForward
-                                             : osr::direction::kBackward,
-                            dest_modes_, params, query_.pedestrianProfile_,
-                            query_.elevationCosts_, query_.maxMatchingDistance_,
-                            post_transit_time, context_intvl, prepare_stats),
+      .td_start_walk_ = r_.get_td_offsets(
+          rtt_, e_, start_,
+          query_.arriveBy_ ? osr::direction::kBackward
+                           : osr::direction::kForward,
+          start_modes_, params, query_.pedestrianProfile_,
+          query_.elevationCosts_, query_.maxMatchingDistance_,
+          query_.arriveBy_ ? post_transit_time : pre_transit_time,
+          context_intvl, prepare_stats),
+      .td_dest_walk_ = r_.get_td_offsets(
+          rtt_, e_, dest_,
+          query_.arriveBy_ ? osr::direction::kForward
+                           : osr::direction::kBackward,
+          dest_modes_, params, query_.pedestrianProfile_,
+          query_.elevationCosts_, query_.maxMatchingDistance_,
+          query_.arriveBy_ ? pre_transit_time : post_transit_time,
+          context_intvl, prepare_stats),
       .start_taxi_short_ =
           query_.arriveBy_ ? last_mile_taxi_short : first_mile_taxi_short,
       .start_taxi_long_ =


### PR DESCRIPTION
Fixes an issue, where `maxPreTransitTime` and `maxPostTransitTime` were swapped, when `arriveBy=true`.