### PR TITLE
Add one-to-many POST request in OpenAPI doc

### DIFF
--- a/include/motis/endpoints/one_to_many.h
+++ b/include/motis/endpoints/one_to_many.h
@@ -15,7 +15,7 @@
 namespace motis::ep {
 
 template <typename Params>
-api::oneToManyGet_response one_to_many_handle_request(
+api::oneToMany_response one_to_many_handle_request(
     Params const& query,
     osr::ways const& w_,
     osr::lookup const& l_,
@@ -50,7 +50,7 @@ api::oneToManyGet_response one_to_many_handle_request(
 }
 
 struct one_to_many {
-  api::oneToManyGet_response operator()(boost::urls::url_view const&) const;
+  api::oneToMany_response operator()(boost::urls::url_view const&) const;
 
   osr::ways const& w_;
   osr::lookup const& l_;

--- a/include/motis/osr/parameters.h
+++ b/include/motis/osr/parameters.h
@@ -21,7 +21,7 @@ osr_parameters get_osr_parameters(api::plan_params const&);
 
 osr_parameters get_osr_parameters(api::oneToAll_params const&);
 
-osr_parameters get_osr_parameters(api::oneToManyGet_params const&);
+osr_parameters get_osr_parameters(api::oneToMany_params const&);
 
 osr_parameters get_osr_parameters(api::OneToManyParams const&);
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -932,7 +932,7 @@ paths:
       summary: |
         Street routing from one to many places or many to one.
         The order in the response array corresponds to the order of coordinates of the \`many\` parameter in the query.
-      operationId: oneToManyGet
+      operationId: oneToMany
       parameters:
         - name: one
           in: query

--- a/src/endpoints/one_to_many.cc
+++ b/src/endpoints/one_to_many.cc
@@ -2,9 +2,9 @@
 
 namespace motis::ep {
 
-api::oneToManyGet_response one_to_many::operator()(
+api::oneToMany_response one_to_many::operator()(
     boost::urls::url_view const& url) const {
-  auto const query = api::oneToManyGet_params{url.params()};
+  auto const query = api::oneToMany_params{url.params()};
   return one_to_many_handle_request(query, w_, l_, elevations_);
 }
 

--- a/src/osr/parameters.cc
+++ b/src/osr/parameters.cc
@@ -104,7 +104,7 @@ osr_parameters get_osr_parameters(api::oneToAll_params const& params) {
   return to_osr_parameters(params);
 }
 
-osr_parameters get_osr_parameters(api::oneToManyGet_params const& params) {
+osr_parameters get_osr_parameters(api::oneToMany_params const& params) {
   return to_osr_parameters(params);
 }
 


### PR DESCRIPTION
#1164 introduced a POST endpoint for `/api/v1/one-to-many`. That PR updated the OpenAPI doc to specify the expected body, but forgot to document the POST request itself.

This PR completes the OpenAPI doc by adding the missing POST request, and also adds in the code a `Post` suffix to the relevant one-to-many POST code so to comply with OpenAPI specs (unique `operationId`).