### PR TITLE
feat(one-to-many): optional distance in one-to-many

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -997,7 +997,7 @@ paths:
             false = one to many
           schema:
             type: boolean
-        - name: distance
+        - name: withDistance
           in: query
           required: false
           description: |
@@ -3855,7 +3855,7 @@ components:
             true = many to one
             false = one to many
           type: boolean
-        distance:
+        withDistance:
           description: |
             Optional. Default is `false`.
             If true, the response includes the distance in meters


### PR DESCRIPTION
Adding distance arg and distance output to one-to-many.


I tested a build of this locally on my mac and also on a linux machine, this worked very well.

---

Ideally, I would actually suggest a much bigger revamp of this api endpoint.

While I was working on it, I noticed that it is the only one that asks for seconds, rather than minutes. Also, I would like to add optional debug output to it, but this would be a breaking change requiring new v2 endpoint, as the format of the output would fundamentally change to a different form of json. But that's out of scope for this PR.

