### PR TITLE
Update default value for 'timetable.preprocess_max_matching_distance'

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -67,7 +67,7 @@ timetable:                          # if not set, no timetable will be loaded
   incremental_rt_update: false      # false = real-time updates are applied to a clean slate, true = no data will be dropped
   max_footpath_length: 15           # maximum footpath length when transitively connecting stops or for routing footpaths if `osr_footpath` is set to true
   max_matching_distance: 25.0       # maximum distance from geolocation to next OSM ways that will be found
-  preprocess_max_matching_distance: 0.0 # max. distance for preprocessing matches from nigiri locations (stops) to OSM ways to speed up querying (set to 0 (default) to disable)
+  preprocess_max_matching_distance: 250.0 # max. distance for preprocessing matches from nigiri locations (stops) to OSM ways to speed up querying (set to 0 (default) to disable)
   datasets:                         # map of tag -> dataset
     ch:                             # the tag will be used as prefix for stop IDs and trip IDs with `_` as divider, so `_` cannot be part of the dataset tag
       path: ch_opentransportdataswiss.gtfs.zip

--- a/include/motis/config.h
+++ b/include/motis/config.h
@@ -105,7 +105,7 @@ struct config {
     bool extend_missing_footpaths_{false};
     std::uint16_t max_footpath_length_{15};
     double max_matching_distance_{25.0};
-    double preprocess_max_matching_distance_{0.0};
+    double preprocess_max_matching_distance_{250.0};
     std::optional<std::string> default_timezone_{};
     std::map<std::string, dataset> datasets_{};
     std::optional<std::filesystem::path> assistance_times_{};

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -57,7 +57,7 @@ timetable:
   extend_missing_footpaths: false
   max_footpath_length: 15
   max_matching_distance: 25.000000
-  preprocess_max_matching_distance: 0.000000
+  preprocess_max_matching_distance: 250.000000
   datasets:
     de:
       path: delfi.gtfs.zip


### PR DESCRIPTION
Set a non trivial default value for `timetable.preprocess_max_matching_distance`, allowing the server to compute matches for stop locations during import by default. Previously no matches were precomputed. The default is now 250 meters.