### PR TITLE
fix(batch): handle CRLF line endings in queries.txt

### DIFF
--- a/exe/batch.cc
+++ b/exe/batch.cc
@@ -150,8 +150,8 @@ int batch(int ac, char** av) {
   auto queries = std::vector<std::string_view>{};
   auto f = cista::mmap{queries_path.generic_string().c_str(),
                        cista::mmap::protection::READ};
-  utl::for_each_token(utl::cstr{f.view()}, '\n',
-                      [&](utl::cstr s) { queries.push_back(s.view()); });
+  utl::for_each_line(utl::cstr{f.view()},
+                     [&](utl::cstr s) { queries.push_back(s.view()); });
 
   auto const c = config::read(data_path / "config.yml");
   utl::verify(c.timetable_.has_value(), "timetable required");


### PR DESCRIPTION
On windows, when using `batch` and `generate` there is a bug because of end of line encoding...

```
 ..\..\..\bin\motis\motis.exe generate --data .\data-back\ -n 100
date range: [2026-02-22 00:00:00, 2026-03-08 00:00:00], tt=[2026-02-22 00:00, 2027-02-23 00:00[
station-to-station
from and to pairings by lower bounds rank
generating 100 queries: [███████████████████████████████████████████████████████ ] 100%
```

```
 ..\..\..\bin\motis\motis.exe batch --data .\data-back\
ERROR IN QUERY 0: leftover [boost.url.grammar:4]ERROR IN QUERY 3: leftover [boost.url.grammar:4]
ERROR IN QUERY 6: leftover [boost.url.grammar:4]
ERROR IN QUERY 4: leftover [boost.url.grammar:4]
ERROR IN QUERY 1ERROR IN QUERY 16: ERROR IN QUERY 18: leftover [boost.url.grammar:4]
ERROR IN QUERY 5ERROR IN QUERY 23: leftover [boost.url.grammar:4]ERROR IN QUERY 25ERROR IN QUERY 26: ERROR IN QUERY 28: ERROR IN QUERY 30: ERROR IN QUERY 32: leftover [boost.url.grammar:4]
ERROR IN QUERY 35: leftover [boost.url.grammar:4]
ERROR IN QUERY 11: leftover [boost.url.grammar:4]
ERROR IN QUERY 43: ERROR IN QUERY 46: ERROR IN QUERY 48ERROR IN QUERY 49: ERROR IN QUERY 51: ERROR IN QUERY 53: ERROR IN QUERY 55: ERROR IN QUERY 57: ERROR IN QUERY ERROR IN QUERY 60ERROR IN QUERY 61: leftover [boost.url.grammar:4]
ERROR IN QUERY 41ERROR IN QUERY 65: ERROR IN QUERY 67: leftover [boost.url.grammar:4]
ERROR IN QUERY 69: leftover [boost.url.grammar:4]
leftover [boost.url.grammar:4]
leftover [boost.url.grammar:4]
...
```

If I change manually the CRLF encoding to LF in the generated queries file, batch works.

This PR should solve this.