### PR TITLE
Keep std::clog thread-safe when redirected

### DIFF
--- a/include/motis/clog_redirect.h
+++ b/include/motis/clog_redirect.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <fstream>
+#include <memory>
+#include <mutex>
 #include <streambuf>
 
 namespace motis {
@@ -19,7 +21,10 @@ struct clog_redirect {
 
 private:
   std::ofstream sink_;
-  std::streambuf* backup_clog_;
+  std::unique_ptr<std::streambuf> sink_buf_;
+  std::streambuf* backup_clog_{};
+  bool active_{};
+  std::mutex mutex_;
 
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool enabled_;

--- a/src/clog_redirect.cc
+++ b/src/clog_redirect.cc
@@ -1,24 +1,63 @@
 #include "motis/clog_redirect.h"
 
 #include <iostream>
+#include <mutex>
 
 namespace motis {
 
-clog_redirect::clog_redirect(char const* log_file_path)
-    : backup_clog_{std::clog.rdbuf()} {
+namespace {
+
+struct synchronized_streambuf : std::streambuf {
+  synchronized_streambuf(std::streambuf* wrapped, std::mutex& mutex)
+      : wrapped_{wrapped}, mutex_{mutex} {}
+
+  int_type overflow(int_type ch) override {
+    auto const lock = std::lock_guard{mutex_};
+    if (traits_type::eq_int_type(ch, traits_type::eof())) {
+      return wrapped_->pubsync() == 0 ? traits_type::not_eof(ch)
+                                      : traits_type::eof();
+    }
+    return wrapped_->sputc(traits_type::to_char_type(ch));
+  }
+
+  std::streamsize xsputn(char const* s, std::streamsize count) override {
+    auto const lock = std::lock_guard{mutex_};
+    return wrapped_->sputn(s, count);
+  }
+
+  int sync() override {
+    auto const lock = std::lock_guard{mutex_};
+    return wrapped_->pubsync();
+  }
+
+private:
+  std::streambuf* wrapped_;
+  std::mutex& mutex_;
+};
+
+}  // namespace
+
+clog_redirect::clog_redirect(char const* log_file_path) {
   if (!enabled_) {
     return;
   }
 
   sink_.exceptions(std::ios_base::badbit | std::ios_base::failbit);
   sink_.open(log_file_path, std::ios_base::app);
-  std::clog.rdbuf(sink_.rdbuf());
+  sink_buf_ = std::make_unique<synchronized_streambuf>(sink_.rdbuf(), mutex_);
+
+  backup_clog_ = std::clog.rdbuf();
+  std::clog.rdbuf(sink_buf_.get());
+  active_ = true;
 }
 
 clog_redirect::~clog_redirect() {
-  if (enabled_) {
-    std::clog.rdbuf(backup_clog_);
+  if (!active_) {
+    return;
   }
+
+  auto const lock = std::lock_guard{mutex_};
+  std::clog.rdbuf(backup_clog_);
 }
 
 void clog_redirect::set_enabled(bool const enabled) { enabled_ = enabled; }


### PR DESCRIPTION
See #1338

(Assumes that only one `clog_redirect` is used at a time)