### PR TITLE
ui: don't initialize state tracking vars from props

### DIFF
--- a/ui/src/lib/map/Layer.svelte
+++ b/ui/src/lib/map/Layer.svelte
@@ -141,12 +141,10 @@
 	let source: { id: string | null } = getContext('source'); // from GeoJSON component
 
 	let initialized = false;
-	/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-	// @ts-ignore
-	let currFilter = $state.snapshot(filter);
-	let currLayout = $state.snapshot(layout);
-	let currPaint = $state.snapshot(paint);
-	let currBefore = beforeLayerId;
+	let currFilter: maplibregl.FilterSpecification | undefined;
+	let currLayout: object | undefined;
+	let currPaint: object | undefined;
+	let currBefore: string | undefined;
 
 	let updateLayer = () => {
 		const map = ctx.map;
@@ -181,9 +179,9 @@
 				},
 				before
 			);
-			currFilter = $state.snapshot(filter);
-			currLayout = $state.snapshot(layout);
-			currPaint = $state.snapshot(paint);
+			currFilter = filter;
+			currLayout = layout;
+			currPaint = paint;
 			currBefore = beforeLayerId;
 			layer.id = id;
 			if (beforeLayerId && !before) {
@@ -194,7 +192,7 @@
 		}
 
 		if (currFilter != filter) {
-			currFilter = $state.snapshot(filter);
+			currFilter = filter;
 			map!.setFilter(id, filter);
 		}
 		if (currBefore !== beforeLayerId) {

--- a/ui/src/lib/map/rentals/ZoneLayer.svelte
+++ b/ui/src/lib/map/rentals/ZoneLayer.svelte
@@ -23,7 +23,7 @@
 	let layerInstance = $state<ZoneFillLayer | null>(null);
 	let pendingRetryHandler: ((event?: unknown) => void) | null = null;
 	let currentFeatures: RentalZoneFeature[] | null = null;
-	let lastOpacity = opacity;
+	let lastOpacity: number | undefined;
 
 	const ensureLayerInstance = () => {
 		if (!layerInstance) {


### PR DESCRIPTION
This PR simplifies tracking of the last applied map layer values.

In Layer and ZoneLayer, those tracking variables were set from props too early. That made the first comparison less reliable. They now start as undefined and are set during the first real update.

As part of that cleanup, the `@ts-ignore` and `$state.snapshot()` workarounds in `Layer` are not needed anymore and have been removed.

No user-facing behavior is intended to change. This is a small robustness cleanup for more predictable internal updates.

There may be a few more similar cleanup opportunities in this area. But I am still new here, so I wanted to keep PRs intentionally small and easy to review.