### PR TITLE
Add RIDE_SHARING in TRANSIT desc in OpenAPI doc

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3185,7 +3185,7 @@ components:
 
         # Transit modes
 
-          - `TRANSIT`: translates to `TRAM,FERRY,AIRPLANE,BUS,COACH,RAIL,ODM,FUNICULAR,AERIAL_LIFT,OTHER`
+          - `TRANSIT`: translates to `TRAM,FERRY,AIRPLANE,BUS,COACH,RAIL,ODM,RIDE_SHARING,FUNICULAR,AERIAL_LIFT,OTHER`
           - `TRAM`: trams
           - `SUBWAY`: subway trains (Paris Metro, London Underground, but also NYC Subway, Hamburger Hochbahn, and other non-underground services)
           - `FERRY`: ferries
@@ -3200,6 +3200,7 @@ components:
           - `REGIONAL_RAIL`: regional train
           - `SUBURBAN`: suburban trains (e.g. S-Bahn, RER, Elizabeth Line, ...)
           - `ODM`: demand responsive transport
+          - `RIDE_SHARING`: ride sharing
           - `FUNICULAR`: Funicular. Any rail system designed for steep inclines.
           - `AERIAL_LIFT`: Aerial lift, suspended cable car (e.g., gondola lift, aerial tramway). Cable transport where cabins, cars, gondolas or open chairs are suspended by means of one or more cables.
           - `AREAL_LIFT`: deprecated


### PR DESCRIPTION
PR #1307 added `RIDE_SHARING` as a transit mode. This PR adds this mode in the `TRANSIT` list in the OpenAPI doc.