### PR TITLE
Fix no longer showing MOTIS version for initial endpoint

### DIFF
--- a/include/motis/data.h
+++ b/include/motis/data.h
@@ -66,22 +66,22 @@ struct data {
   void load_tiles();
   void load_auser_updater(std::string_view, config::timetable::dataset const&);
 
+  void init_initial(std::string_view motis_version);
   void init_rtt(date::sys_days = std::chrono::time_point_cast<date::days>(
                     std::chrono::system_clock::now()));
 
   auto cista_members() {
     // !!! Remember to add all new members !!!
-    return std::tie(config_, motis_version_, initial_response_, t_, adr_ext_,
-                    f_, tz_, r_, tc_, w_, pl_, l_, elevations_, tt_, tbd_,
-                    tags_, location_rtree_, elevator_nodes_,
-                    elevator_osm_mapping_, shapes_, railviz_static_, matches_,
-                    way_matches_, rt_, gbfs_, odm_bounds_, ride_sharing_bounds_,
-                    flex_areas_, metrics_, auser_);
+    return std::tie(config_, initial_response_, t_, adr_ext_, f_, tz_, r_, tc_,
+                    w_, pl_, l_, elevations_, tt_, tbd_, tags_, location_rtree_,
+                    elevator_nodes_, elevator_osm_mapping_, shapes_,
+                    railviz_static_, matches_, way_matches_, rt_, gbfs_,
+                    odm_bounds_, ride_sharing_bounds_, flex_areas_, metrics_,
+                    auser_);
   }
 
   std::filesystem::path path_;
   config config_;
-  std::string_view motis_version_;
 
   api::initial_response initial_response_;
   cista::wrapped<adr::typeahead> t_;

--- a/include/motis/endpoints/initial.h
+++ b/include/motis/endpoints/initial.h
@@ -7,7 +7,8 @@
 
 namespace motis::ep {
 
-api::initial_response get_initial_response(data const&);
+api::initial_response get_initial_response(data const&,
+                                           std::string_view motis_version);
 
 struct initial {
   api::initial_response operator()(boost::urls::url_view const&) const;

--- a/include/motis/motis_instance.h
+++ b/include/motis/motis_instance.h
@@ -81,7 +81,7 @@ struct motis_instance {
                  std::string_view motis_version)
       : qr_{std::forward<Executor>(exec)} {
     qr_.add_header("Server", fmt::format("MOTIS {}", motis_version));
-    d.motis_version_ = motis_version;
+    d.init_initial(motis_version);
     if (c.server_.value_or(config::server{}).data_attribution_link_) {
       qr_.add_header("Link", fmt::format("<{}>; rel=\"license\"",
                                          *c.server_->data_attribution_link_));

--- a/src/data.cc
+++ b/src/data.cc
@@ -239,8 +239,6 @@ data::data(std::filesystem::path p, config const& c)
   throw_if_failed("elevators", elevators);
   throw_if_failed("tiles", tiles);
 
-  initial_response_ = ep::get_initial_response(*this);
-
   utl_verify(
       shapes_ == nullptr || tt_ == nullptr ||
           (tt_->n_routes() == shapes_->route_bboxes_.size() &&
@@ -286,6 +284,10 @@ void data::load_flex_areas() {
   utl::verify(tt_ && w_ && l_, "flex areas requires tt={}, w={}, l={}",
               tt_ != nullptr, w_ != nullptr, l_ != nullptr);
   flex_areas_ = std::make_unique<flex::flex_areas>(*tt_, *w_, *l_);
+}
+
+void data::init_initial(std::string_view motis_version) {
+  initial_response_ = ep::get_initial_response(*this, motis_version);
 }
 
 void data::init_rtt(date::sys_days const d) {

--- a/src/endpoints/initial.cc
+++ b/src/endpoints/initial.cc
@@ -15,7 +15,8 @@ namespace n = nigiri;
 
 namespace motis::ep {
 
-api::initial_response get_initial_response(data const& d) {
+api::initial_response get_initial_response(data const& d,
+                                           std::string_view motis_version) {
   auto const get_quantiles = [](std::vector<double>&& coords) {
     utl::erase_if(coords, [](auto const c) { return c == 0.; });
     if (coords.empty()) {
@@ -65,7 +66,7 @@ api::initial_response get_initial_response(data const& d) {
       .lon_ = center.lng_,
       .zoom_ = static_cast<double>(zoom),
       .serverConfig_ = api::ServerConfig{
-          .motisVersion_ = std::string{d.motis_version_},
+          .motisVersion_ = std::string{motis_version},
           .hasElevation_ = d.config_.get_street_routing()
                                .transform([](config::street_routing const& x) {
                                  return x.elevation_data_dir_.has_value();

--- a/test/endpoints/initial_test.cc
+++ b/test/endpoints/initial_test.cc
@@ -1,0 +1,19 @@
+#include "gtest/gtest.h"
+
+#include "utl/init_from.h"
+
+#include "motis/endpoints/initial.h"
+
+#include "../test_case.h"
+
+TEST(initial, motis_version) {
+  // Pick any test case, preferably the smallest
+  auto [d, _config] = get_test_case<test_case::FFM_one_to_many>();
+  auto const version = "v1.2.3-test";
+  d.init_initial(version);  // Must be invoked by motis_instance()
+  auto const ep = utl::init_from<motis::ep::initial>(d).value();
+
+  auto const res = ep("");
+
+  EXPECT_EQ(version, res.serverConfig_.motisVersion_);
+}

--- a/test/endpoints/initial_test.cc
+++ b/test/endpoints/initial_test.cc
@@ -6,7 +6,7 @@
 
 #include "../test_case.h"
 
-TEST(initial, motis_version) {
+TEST(initial, server_config) {
   // Pick any test case, preferably the smallest
   auto [d, _config] = get_test_case<test_case::FFM_one_to_many>();
   auto const version = "v1.2.3-test";
@@ -15,23 +15,14 @@ TEST(initial, motis_version) {
 
   auto const res = ep("");
 
-  EXPECT_EQ(version, res.serverConfig_.motisVersion_);
-}
-
-TEST(initial, server_config) {
-  auto [d, _config] = get_test_case<test_case::FFM_one_to_many>();
-  d.init_initial("initial-test");
-  auto const ep = utl::init_from<motis::ep::initial>(d).value();
-
-  auto const res = ep("");
-
   auto const& config = res.serverConfig_;
-  EXPECT_TRUE(config.hasRoutedTransfers_);
-  EXPECT_TRUE(config.hasStreetRouting_);
-  EXPECT_FALSE(config.hasElevation_);
-  EXPECT_FALSE(config.shapesDebugEnabled_);
+  EXPECT_EQ(version, config.motisVersion_);
   EXPECT_EQ(128.0, config.maxOneToManySize_);
   EXPECT_EQ(90.0, config.maxOneToAllTravelTimeLimit_);
   EXPECT_EQ(3600.0, config.maxPrePostTransitTimeLimit_);
   EXPECT_EQ(21600.0, config.maxDirectTimeLimit_);
+  EXPECT_TRUE(config.hasRoutedTransfers_);
+  EXPECT_TRUE(config.hasStreetRouting_);
+  EXPECT_FALSE(config.hasElevation_);
+  EXPECT_FALSE(config.shapesDebugEnabled_);
 }

--- a/test/endpoints/initial_test.cc
+++ b/test/endpoints/initial_test.cc
@@ -17,3 +17,21 @@ TEST(initial, motis_version) {
 
   EXPECT_EQ(version, res.serverConfig_.motisVersion_);
 }
+
+TEST(initial, server_config) {
+  auto [d, _config] = get_test_case<test_case::FFM_one_to_many>();
+  d.init_initial("initial-test");
+  auto const ep = utl::init_from<motis::ep::initial>(d).value();
+
+  auto const res = ep("");
+
+  auto const& config = res.serverConfig_;
+  EXPECT_TRUE(config.hasRoutedTransfers_);
+  EXPECT_TRUE(config.hasStreetRouting_);
+  EXPECT_FALSE(config.hasElevation_);
+  EXPECT_FALSE(config.shapesDebugEnabled_);
+  EXPECT_EQ(128.0, config.maxOneToManySize_);
+  EXPECT_EQ(90.0, config.maxOneToAllTravelTimeLimit_);
+  EXPECT_EQ(3600.0, config.maxPrePostTransitTimeLimit_);
+  EXPECT_EQ(21600.0, config.maxDirectTimeLimit_);
+}


### PR DESCRIPTION
I noticed, that a recent change caused the `/api/v1/map/initial` endpoint to no longer show the actual MOTIS version. Instead an empty string is returned. (I think, this was caused by this refactoring: ebdc9f0e34c9ec66446195759cb8f16133554c2b)
This patch should fix the behavior. I also added some tests for the endpoint, as I couldn't find any. I don't like the explicit call of `init_initial()` in the test though, but I can't think of a better solution. And it doesn't seem unreasonable to do so.