### PR TITLE
docs(setup): optimize local dev setup docs

### DIFF
--- a/docs/dev-setup-server.md
+++ b/docs/dev-setup-server.md
@@ -1,5 +1,7 @@
 # Setting up a server from a development build
 
+## Build and run MOTIS with bundled UI
+
 1. Build `motis`. Refer to the respective documentation if necessary:
    - [for Linux](linux-dev-setup.md)
    - [for Windows](windows-dev-setup.md)
@@ -12,23 +14,23 @@
     motis/ui$ pnpm install
     motis/ui$ pnpm -r build
     ```
-   
+
 3. Move the UI build into the build folder of `motis`:
     ```shell
     motis$ mv ui/build build/ui
     ```
-   
+
 4. Copy the tiles profiles to the `motis` build folder:
     ```shell
     motis$ cp -r deps/tiles/profile build/tiles-profiles
     ```
-   
+
 5. Download OpenStreetMap and timetable datasets and place them in the build folder of `motis`:
     ```shell
     motis/build$ wget https://github.com/motis-project/test-data/raw/aachen/aachen.osm.pbf
     motis/build$ wget https://opendata.avv.de/current_GTFS/AVV_GTFS_Masten_mit_SPNV.zip
     ```
-   
+
 6. Run `motis config` on the downloaded datasets to create a config file:
     ```shell
     motis/build$ ./motis config aachen.osm.pbf AVV_GTFS_Masten_mit_SPNV.zip
@@ -41,3 +43,22 @@
     ```
 
 8. Open `localhost:8080` in a browser to see if everything is working.
+
+## Run backend and UI dev server together
+
+Run backend from your development build and UI in watch mode:
+
+1. Start MOTIS backend:
+    ```shell
+    motis/build$ ./motis server
+    ```
+
+2. In a second terminal, start the UI dev server:
+    ```shell
+    motis/ui$ pnpm dev
+    ```
+
+3. Open the UI with an explicit backend target:
+    - `http://localhost:5173/?motis=http://localhost:8080`
+    - if Vite uses another port, adapt accordingly
+    - for UI-only changes you can also point to a live backend, e.g. `?motis=https://api.transitous.org`

--- a/docs/linux-dev-setup.md
+++ b/docs/linux-dev-setup.md
@@ -1,10 +1,12 @@
-> [!NOTE]  
+# Linux Development Setup
+
+> [!NOTE]
 > Due to developer capacity constraints we cannot support newer or older compilers.
 > We also cannot support other versions of dependencies.
 > In case of doubt you can check the full release build setup used in our CI [here](https://github.com/motis-project/docker-cpp-build/blob/master/Dockerfile).
 > To exactly reproduce the CI build, you need to use the according preset from our [CMakePresets.json](../CMakePresets.json).
 
-Requirements:
+## Requirements
 
 - A recent C++ compiler: Either [Clang](https://llvm.org/) 21 or GCC 13
 - CMake 3.17 (or newer): [cmake.org](https://cmake.org/download/) ([Ubuntu APT Repository](https://apt.kitware.com/))

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,14 +1,52 @@
+## UI Development
+
+### Setup (once)
+
+Install dependencies once before running build/dev commands:
+
+```bash
+pnpm install
+```
+
+### Build
+
 Build UI (the `-r` is important to also update the OpenAPI client):
 
 ```bash
 pnpm -r build
 ```
 
+### Run Dev Server
+
+Run UI development server:
+
+```bash
+pnpm dev
+```
+
+When developing UI against a local MOTIS backend, open the dev URL with a
+`motis` query parameter, for example:
+
+- `http://localhost:5173/?motis=http://localhost:8080`
+
+If Vite selected another port, replace `5173` with the port printed by
+`pnpm dev`.
+
+For UI-only changes you can also point to a live backend instead, e.g.
+`?motis=https://api.transitous.org`.
+
+Without this parameter, the UI uses the current origin as API base URL, which
+leads to 404s for `/api/...` and `/tiles/...` on the Vite server.
+
+### OpenAPI Client
+
 Generate OpenAPI client (when openapi.yaml has been changed, included in `pnpm -r build`):
 
 ```bash
 pnpm update-api
 ```
+
+### Publish to npmjs
 
 To publish a new version to npmjs:
 


### PR DESCRIPTION
I kept running into the same issues while trying to get the local dev setup running, and to be fair, part of that was me not reading the existing docs carefully enough. But even with that, I still spent too much time breaking my head over setup friction, so the goal of this PR is to refine the docs to make the path clearer and less error-prone.