### PR TITLE
refactor(ui): drop routes toggle workaround, add e2e tests and aria-label

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -88,7 +88,6 @@
 	let colorMode = $state<'rt' | 'route' | 'mode' | 'none'>(isSmallScreen ? 'none' : 'rt');
 	let showMap = $state(!isSmallScreen);
 	let showRoutes = $state(false);
-	let routesOverlaySession = $state(0);
 	let lastOneToAllQuery: OneToAllData | undefined = undefined;
 	let lastPlanQuery: PlanData | undefined = undefined;
 	let serverConfig: ServerConfig | undefined = $state();
@@ -99,11 +98,6 @@
 			colorMode = 'none';
 		}
 	});
-
-	const toggleRoutesOverlay = () => {
-		++routesOverlaySession;
-		showRoutes = !showRoutes;
-	};
 
 	let theme: 'light' | 'dark' =
 		(hasDark ? 'dark' : hasLight ? 'light' : undefined) ??
@@ -860,7 +854,10 @@
 				<Button
 					size="icon"
 					variant={showRoutes ? 'default' : 'outline'}
-					onclick={toggleRoutesOverlay}
+					aria-label="Toggle routes overlay"
+					onclick={() => {
+						showRoutes = !showRoutes;
+					}}
 				>
 					<Waypoints class="w-5 h-5" />
 				</Button>
@@ -938,14 +935,12 @@
 					</Button>
 				</Control>
 				{#if showRoutes}
-					{#key routesOverlaySession}
-						<Routes
-							{map}
-							{bounds}
-							{zoom}
-							shapesDebugEnabled={serverConfig?.shapesDebugEnabled === true}
-						/>
-					{/key}
+					<Routes
+						{map}
+						{bounds}
+						{zoom}
+						shapesDebugEnabled={serverConfig?.shapesDebugEnabled === true}
+					/>
 				{/if}
 				<Rentals {map} {bounds} {zoom} {theme} debug={hasDebug} />
 			{/if}

--- a/ui/tests/routes-overlay.spec.ts
+++ b/ui/tests/routes-overlay.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const setupRoutesOverlayMocks = async (page: Page) => {
+	let routesRequests = 0;
+
+	await page.route('**/api/v1/map/initial', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				lat: 48.137154,
+				lon: 11.576124,
+				zoom: 12,
+				serverConfig: {
+					shapesDebugEnabled: false,
+					maxOneToAllTravelTimeLimit: 120,
+					maxPrePostTransitTimeLimit: 7200,
+					maxDirectTimeLimit: 7200
+				}
+			})
+		});
+	});
+
+	await page.route('**/api/experimental/map/routes**', async (route) => {
+		routesRequests += 1;
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				routes: [],
+				polylines: [],
+				stops: [],
+				zoomFiltered: false
+			})
+		});
+	});
+
+	await page.route('**/api/v1/rentals**', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				providerGroups: [],
+				providers: [],
+				stations: [],
+				vehicles: [],
+				zones: []
+			})
+		});
+	});
+
+	return {
+		getRoutesRequests: () => routesRequests
+	};
+};
+
+// The routes overlay toggle is only rendered when the UI is opened in
+// debug mode (`?debug`), so all tests below navigate with that flag.
+test.describe('routes overlay toggle', () => {
+	test('requests routes data when enabled', async ({ page }) => {
+		const { getRoutesRequests } = await setupRoutesOverlayMocks(page);
+
+		await page.goto('/?debug');
+
+		const routesButton = page.getByRole('button', { name: 'Toggle routes overlay' });
+		await expect(routesButton).toBeVisible();
+		await routesButton.click();
+
+		await expect.poll(() => getRoutesRequests()).toBeGreaterThan(0);
+	});
+
+	test('re-enabling routes overlay triggers a fresh fetch', async ({ page }) => {
+		const { getRoutesRequests } = await setupRoutesOverlayMocks(page);
+
+		await page.goto('/?debug');
+
+		const routesButton = page.getByRole('button', { name: 'Toggle routes overlay' });
+		await expect(routesButton).toBeVisible();
+
+		// First enable: triggers the initial fetch.
+		await routesButton.click();
+		await expect.poll(() => getRoutesRequests()).toBeGreaterThanOrEqual(1);
+
+		// Disable, then re-enable: the overlay should re-mount and fetch again.
+		await routesButton.click();
+		await routesButton.click();
+
+		await expect.poll(() => getRoutesRequests()).toBeGreaterThanOrEqual(2);
+	});
+});


### PR DESCRIPTION
While looking at the routes overlay code I noticed the toggle button was using a session counter + `{#key}` to force `Routes.svelte` to remount on every toggle. The intent was to clear the internal `loadedBounds` cache so a re-enabled overlay always fetches fresh data.

But the surrounding `{#if showRoutes}` already destroys and recreates the component when the condition changes - cache and all. The `{#key}` never had any additional effect.

For users nothing changes. But the code is cleaner without the workaround, and the two new Playwright tests make sure it actually behaves as expected (fetch on enable, fresh fetch on re-enable). I also did a quick local smoke test against local backend, and it looked good.

I also snuck in an `aria-label` on the icon-only button - it had no accessible name before.