### PR TITLE
GBFS: Add config option to override provider name

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -160,13 +160,16 @@ gbfs:
   http_timeout: 10
 ```
 
-## Provider Groups + Colors
+## Provider Names, Groups + Colors
 
 GBFS providers (feeds) can be grouped into "provider groups". For example, a provider may operate in multiple locations and provide a feed per location.
 To groups these different feeds into a single provider group, specify the same group name for each feed in the configuration.
 
 Feeds that don't have an explicit group setting in the configuration, their group name is derived from the system name. Group names
 may not contain commas. The API supports both provider groups and individual providers.
+
+Provider names are loaded from the feed (`system_information.name`) by default. To override them, set `name`
+for a standalone feed or map `system_id` to name for an aggregated feed.
 
 Provider colors are loaded from the feed (`brand_assets.color`) if available, but can also be set in the configuration
 to override the values contained in the feed or to set colors for feeds that don't include color information.
@@ -178,6 +181,7 @@ gbfs:
   feeds:
     de-CallaBike:
       url: https://api.mobidata-bw.de/sharing/gbfs/v2/callabike/gbfs
+      name: Call a Bike # optional override
       color: "#db0016"
     de-VRNnextbike:
       url: https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_vn/gbfs.json
@@ -211,6 +215,9 @@ gbfs:
         source-nextbike-westbike: nextbike # "source-nextbike-westbike" is the system_id
         source-voi-muenster: VOI
         source-voi-duisburg-oberhausen: VOI
+      name: # optional provider name overrides
+        source-voi-muenster: VOI Münster
+        source-voi-duisburg-oberhausen: VOI Duisburg Oberhausen
       # colors can be specified for individual feeds using the same syntax,
       # but in this example they are defined for the groups below
       #color:

--- a/include/motis/config.h
+++ b/include/motis/config.h
@@ -179,6 +179,9 @@ struct config {
           group_{};
       std::optional<
           std::variant<std::string, std::map<std::string, std::string>>>
+          name_{};
+      std::optional<
+          std::variant<std::string, std::map<std::string, std::string>>>
           color_{};
       std::optional<ttl> ttl_{};
     };

--- a/include/motis/gbfs/data.h
+++ b/include/motis/gbfs/data.h
@@ -429,6 +429,7 @@ struct provider_feed {
   geofencing_restrictions default_restrictions_{};
   std::optional<return_constraint> default_return_constraint_{};
   std::optional<std::string> config_group_{};
+  std::optional<std::string> config_name_{};
   std::optional<std::string> config_color_{};
   std::shared_ptr<oauth_state> oauth_{};
   std::map<std::string, unsigned> default_ttl_{};

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -315,6 +315,7 @@ struct gbfs_update {
                   .default_return_constraint_ =
                       lookup_default_return_constraint("", id),
                   .config_group_ = lookup_group("", id),
+                  .config_name_ = lookup_name("", id),
                   .config_color_ = lookup_color("", id),
                   .oauth_ = std::move(oauth),
                   .default_ttl_ = default_ttl,
@@ -431,6 +432,9 @@ struct gbfs_update {
           load_system_information);
       if (!sys_info_updated && prev_provider != nullptr) {
         provider.sys_info_ = prev_provider->sys_info_;
+      }
+      if (pf.config_name_) {
+        provider.sys_info_.name_ = *pf.config_name_;
       }
 
       auto const vehicle_types_updated = co_await update(
@@ -807,6 +811,7 @@ struct gbfs_update {
             .default_return_constraint_ =
                 lookup_default_return_constraint(af.id_, combined_id),
             .config_group_ = lookup_group(af.id_, system_id),
+            .config_name_ = lookup_name(af.id_, system_id),
             .config_color_ = lookup_color(af.id_, system_id),
             .oauth_ = af.oauth_,
             .default_ttl_ = af.default_ttl_,
@@ -827,6 +832,7 @@ struct gbfs_update {
             .default_return_constraint_ =
                 lookup_default_return_constraint(af.id_, combined_id),
             .config_group_ = lookup_group(af.id_, system_id),
+            .config_name_ = lookup_name(af.id_, system_id),
             .config_color_ = lookup_color(af.id_, system_id),
             .oauth_ = af.oauth_,
             .default_ttl_ = af.default_ttl_,
@@ -1071,6 +1077,12 @@ struct gbfs_update {
                                           std::string const& system_id) {
     return lookup_mapping(af_id, system_id,
                           [](auto const& cfg) { return cfg.color_; });
+  }
+
+  std::optional<std::string> lookup_name(std::string const& af_id,
+                                         std::string const& system_id) {
+    return lookup_mapping(af_id, system_id,
+                          [](auto const& cfg) { return cfg.name_; });
   }
 
   config::gbfs const& c_;


### PR DESCRIPTION
Adds a new optional config option to override the provider name for both standalone and aggregated feeds.