### PR TITLE
Support for HTTP CONNECT Proxies

### DIFF
--- a/include/motis/config.h
+++ b/include/motis/config.h
@@ -209,6 +209,7 @@ struct config {
     unsigned http_timeout_{30};
     unsigned cache_size_{50};
     std::optional<std::string> proxy_{};
+    std::optional<bool> use_connect_{false};
     std::optional<ttl> ttl_{};
   };
   std::optional<gbfs> gbfs_{};

--- a/include/motis/http_req.h
+++ b/include/motis/http_req.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <boost/beast/core/stream_traits.hpp>
 #include <chrono>
 #include <map>
+#include <print>
 #include <string>
 
 #include "boost/asio/awaitable.hpp"
@@ -49,6 +51,7 @@ boost::asio::awaitable<void> http_CONNECT(Stream& stream,
   if (!proxy) {
     co_return;
   }
+  std::println("making a connect request");
   auto const target = std::string(url.host()) + ":" +
                       (url.has_port() ? std::string(url.port()) : "443");
 
@@ -56,11 +59,11 @@ boost::asio::awaitable<void> http_CONNECT(Stream& stream,
   req.set(http::field::host, target);
   beast::flat_buffer buf;
 
-  co_await http::async_write(stream.next_layer(), req);
+  co_await http::async_write(beast::get_lowest_layer(stream), req);
 
   http::response_parser<http::empty_body> res;
   res.skip(true);
-  co_await http::async_read_header(stream.next_layer(), buf, res);
+  co_await http::async_read_header(beast::get_lowest_layer(stream), buf, res);
 
   if (res.get().result() != http::status::ok) {
     throw utl::fail("CONNECT failed: target={}, status={}", target,

--- a/include/motis/http_req.h
+++ b/include/motis/http_req.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <boost/beast/core/stream_traits.hpp>
 #include <chrono>
 #include <map>
 #include <string>

--- a/include/motis/http_req.h
+++ b/include/motis/http_req.h
@@ -3,7 +3,6 @@
 #include <boost/beast/core/stream_traits.hpp>
 #include <chrono>
 #include <map>
-#include <print>
 #include <string>
 
 #include "boost/asio/awaitable.hpp"
@@ -51,7 +50,6 @@ boost::asio::awaitable<void> http_CONNECT(Stream& stream,
   if (!proxy) {
     co_return;
   }
-  std::println("making a connect request");
   auto const target = std::string(url.host()) + ":" +
                       (url.has_port() ? std::string(url.port()) : "443");
 

--- a/include/motis/http_req.h
+++ b/include/motis/http_req.h
@@ -5,19 +5,25 @@
 #include <string>
 
 #include "boost/asio/awaitable.hpp"
+#include "boost/beast/core/flat_buffer.hpp"
 #include "boost/beast/http/dynamic_body.hpp"
-#include "boost/beast/http/message.hpp"
+#include "boost/beast/http/empty_body.hpp"
+#include "boost/beast/http/read.hpp"
+#include "boost/beast/http/write.hpp"
 #include "boost/url/url.hpp"
+
+#include "utl/verify.h"
 
 namespace motis {
 
+namespace beast = boost::beast;
+namespace http = beast::http;
+
+using http_response = http::response<boost::beast::http::dynamic_body>;
+
 constexpr auto const kBodySizeLimit = 512U * 1024U * 1024U;  // 512 M
 
-using http_response =
-    boost::beast::http::response<boost::beast::http::dynamic_body>;
-
 struct proxy {
-  bool use_tls_;
   std::string host_, port_;
 };
 
@@ -33,6 +39,30 @@ boost::asio::awaitable<http_response> http_POST(
     std::string const& body,
     std::chrono::seconds timeout,
     std::optional<proxy> const& = std::nullopt);
+
+template <typename Stream>
+boost::asio::awaitable<void> http_CONNECT(Stream& stream,
+                                          boost::urls::url const& url,
+                                          std::optional<proxy> const& proxy) {
+  if (!proxy) co_return;
+  auto const target = std::string(url.host()) + ":" +
+                      (url.has_port() ? std::string(url.port()) : "443");
+
+  http::request<http::empty_body> req{http::verb::connect, target, 11};
+  req.set(http::field::host, target);
+  beast::flat_buffer buf;
+
+  co_await http::async_write(stream.next_layer(), req);
+
+  http::response_parser<http::empty_body> res;
+  res.skip(true);
+  co_await http::async_read_header(stream.next_layer(), buf, res);
+
+  if (res.get().result() != http::status::ok) {
+    throw utl::fail("CONNECT failed: target={}, status={}", target,
+                    res.get().result_int());
+  }
+}
 
 std::string get_http_body(http_response const&);
 

--- a/include/motis/http_req.h
+++ b/include/motis/http_req.h
@@ -24,6 +24,8 @@ using http_response = http::response<boost::beast::http::dynamic_body>;
 constexpr auto const kBodySizeLimit = 512U * 1024U * 1024U;  // 512 M
 
 struct proxy {
+  bool use_tls_;
+  bool use_connect_;
   std::string host_, port_;
 };
 
@@ -44,7 +46,9 @@ template <typename Stream>
 boost::asio::awaitable<void> http_CONNECT(Stream& stream,
                                           boost::urls::url const& url,
                                           std::optional<proxy> const& proxy) {
-  if (!proxy) co_return;
+  if (!proxy) {
+    co_return;
+  }
   auto const target = std::string(url.host()) + ":" +
                       (url.has_port() ? std::string(url.port()) : "443");
 

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -165,12 +165,13 @@ struct gbfs_update {
         d_{d},
         prev_d_{prev_d},
         timeout_{c.http_timeout_},
-        proxy_{c.proxy_.transform([](std::string const& u) {
+        proxy_{c.proxy_.transform([&](std::string const& u) {
           auto const url = boost::urls::url{u};
 
           auto p = proxy{};
           p.use_tls_ = url.scheme_id() == boost::urls::scheme::https;
           p.host_ = url.host();
+          p.use_connect_ = c.use_connect_.value_or(false);
           p.port_ = url.has_port() ? url.port() : (p.use_tls_ ? "443" : "80");
           return p;
         })} {}

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -169,8 +169,9 @@ struct gbfs_update {
           auto const url = boost::urls::url{u};
 
           auto p = proxy{};
+          p.use_tls_ = url.scheme_id() == boost::urls::scheme::https;
           p.host_ = url.host();
-          p.port_ = url.has_port() ? url.port() : "80";
+          p.port_ = url.has_port() ? url.port() : (p.use_tls_ ? "443" : "80");
           return p;
         })} {}
 

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -169,9 +169,8 @@ struct gbfs_update {
           auto const url = boost::urls::url{u};
 
           auto p = proxy{};
-          p.use_tls_ = url.scheme_id() == boost::urls::scheme::https;
           p.host_ = url.host();
-          p.port_ = url.has_port() ? url.port() : (p.use_tls_ ? "443" : "80");
+          p.port_ = url.has_port() ? url.port() : "80";
           return p;
         })} {}
 

--- a/src/http_req.cc
+++ b/src/http_req.cc
@@ -52,7 +52,6 @@ asio::awaitable<http_response> req_no_tls(
   stream.expires_after(timeout);
 
   co_await stream.async_connect(results);
-
   co_return co_await req(std::move(stream), url, headers, body);
 }
 

--- a/src/http_req.cc
+++ b/src/http_req.cc
@@ -71,10 +71,10 @@ asio::awaitable<http_response> req_tls(
   auto resolver = asio::ip::tcp::resolver{executor};
   auto stream = ssl::stream<beast::tcp_stream>{executor, ssl_ctx};
 
-  auto const host = proxy ? proxy->host_ : url.host();
-  auto const port =
-      proxy ? proxy->port_ : std::string{url.has_port() ? url.port() : "443"};
+  auto const target_port = std::string{url.has_port() ? url.port() : "443"};
+  auto const target_host = url.host();
 
+<<<<<<< HEAD
   if (!SSL_set_tlsext_host_name(stream.native_handle(),
                                 const_cast<char*>(host.c_str()))) {
     throw boost::system::system_error{
@@ -83,10 +83,23 @@ asio::awaitable<http_response> req_tls(
 
   auto const results = co_await resolver.async_resolve(
       host, port, asio::cancel_after(timeout, asio::use_awaitable));
+=======
+  auto const results = co_await resolver.async_resolve(
+      proxy ? proxy->host_ : target_host, proxy ? proxy->port_ : target_port);
+>>>>>>> c147bfbc (implement connect + bug fixes)
 
   stream.next_layer().expires_after(timeout);
 
   co_await beast::get_lowest_layer(stream).async_connect(results);
+
+  co_await http_CONNECT(stream, url, proxy);
+
+  if (!SSL_set_tlsext_host_name(stream.native_handle(),
+                                const_cast<char*>(target_host.c_str()))) {
+    throw boost::system::system_error{
+        {static_cast<int>(::ERR_get_error()), asio::error::get_ssl_category()}};
+  }
+
   co_await stream.async_handshake(ssl::stream_base::client);
   co_return co_await req(std::move(stream), url, headers, body);
 }
@@ -134,9 +147,7 @@ asio::awaitable<http::response<http::dynamic_body>> http_GET(
   auto n_redirects = 0U;
   auto next_url = url;
   while (n_redirects < 3U) {
-    auto const use_tls =
-        proxy.has_value() ? proxy->use_tls_
-                          : next_url.scheme_id() == boost::urls::scheme::https;
+    auto const use_tls = next_url.scheme_id() == boost::urls::scheme::https;
     auto const res = co_await (
         use_tls ? req_tls(next_url, headers, std::nullopt, timeout, proxy)
                 : req_no_tls(next_url, headers, std::nullopt, timeout, proxy));
@@ -162,9 +173,7 @@ asio::awaitable<http::response<http::dynamic_body>> http_POST(
   auto n_redirects = 0U;
   auto next_url = url;
   while (n_redirects < 3U) {
-    auto const use_tls =
-        proxy.has_value() ? proxy->use_tls_
-                          : next_url.scheme_id() == boost::urls::scheme::https;
+    auto const use_tls = next_url.scheme_id() == boost::urls::scheme::https;
     auto const res = co_await (
         use_tls ? req_tls(next_url, headers, body, timeout, proxy)
                 : req_no_tls(next_url, headers, body, timeout, proxy));

--- a/src/http_req.cc
+++ b/src/http_req.cc
@@ -52,6 +52,11 @@ asio::awaitable<http_response> req_no_tls(
   stream.expires_after(timeout);
 
   co_await stream.async_connect(results);
+
+  if (proxy && proxy->use_connect_) {
+    co_await http_CONNECT(stream, url, proxy);
+  }
+
   co_return co_await req(std::move(stream), url, headers, body);
 }
 
@@ -74,25 +79,17 @@ asio::awaitable<http_response> req_tls(
   auto const target_port = std::string{url.has_port() ? url.port() : "443"};
   auto const target_host = url.host();
 
-<<<<<<< HEAD
-  if (!SSL_set_tlsext_host_name(stream.native_handle(),
-                                const_cast<char*>(host.c_str()))) {
-    throw boost::system::system_error{
-        {static_cast<int>(::ERR_get_error()), asio::error::get_ssl_category()}};
-  }
-
   auto const results = co_await resolver.async_resolve(
-      host, port, asio::cancel_after(timeout, asio::use_awaitable));
-=======
-  auto const results = co_await resolver.async_resolve(
-      proxy ? proxy->host_ : target_host, proxy ? proxy->port_ : target_port);
->>>>>>> c147bfbc (implement connect + bug fixes)
+      proxy ? proxy->host_ : target_host, proxy ? proxy->port_ : target_port,
+      asio::cancel_after(timeout, asio::use_awaitable));
 
   stream.next_layer().expires_after(timeout);
 
   co_await beast::get_lowest_layer(stream).async_connect(results);
 
-  co_await http_CONNECT(stream, url, proxy);
+  if (proxy && proxy->use_connect_) {
+    co_await http_CONNECT(stream, url, proxy);
+  }
 
   if (!SSL_set_tlsext_host_name(stream.native_handle(),
                                 const_cast<char*>(target_host.c_str()))) {
@@ -147,7 +144,9 @@ asio::awaitable<http::response<http::dynamic_body>> http_GET(
   auto n_redirects = 0U;
   auto next_url = url;
   while (n_redirects < 3U) {
-    auto const use_tls = next_url.scheme_id() == boost::urls::scheme::https;
+    auto const use_tls =
+        proxy ? proxy->use_tls_
+              : next_url.scheme_id() == boost::urls::scheme::https;
     auto const res = co_await (
         use_tls ? req_tls(next_url, headers, std::nullopt, timeout, proxy)
                 : req_no_tls(next_url, headers, std::nullopt, timeout, proxy));
@@ -173,7 +172,9 @@ asio::awaitable<http::response<http::dynamic_body>> http_POST(
   auto n_redirects = 0U;
   auto next_url = url;
   while (n_redirects < 3U) {
-    auto const use_tls = next_url.scheme_id() == boost::urls::scheme::https;
+    auto const use_tls =
+        proxy ? proxy->use_tls_
+              : next_url.scheme_id() == boost::urls::scheme::https;
     auto const res = co_await (
         use_tls ? req_tls(next_url, headers, body, timeout, proxy)
                 : req_no_tls(next_url, headers, body, timeout, proxy));

--- a/src/http_req.cc
+++ b/src/http_req.cc
@@ -53,10 +53,6 @@ asio::awaitable<http_response> req_no_tls(
 
   co_await stream.async_connect(results);
 
-  if (proxy && proxy->use_connect_) {
-    co_await http_CONNECT(stream, url, proxy);
-  }
-
   co_return co_await req(std::move(stream), url, headers, body);
 }
 
@@ -144,9 +140,7 @@ asio::awaitable<http::response<http::dynamic_body>> http_GET(
   auto n_redirects = 0U;
   auto next_url = url;
   while (n_redirects < 3U) {
-    auto const use_tls =
-        proxy ? proxy->use_tls_
-              : next_url.scheme_id() == boost::urls::scheme::https;
+    auto const use_tls = next_url.scheme_id() == boost::urls::scheme::https;
     auto const res = co_await (
         use_tls ? req_tls(next_url, headers, std::nullopt, timeout, proxy)
                 : req_no_tls(next_url, headers, std::nullopt, timeout, proxy));
@@ -172,9 +166,7 @@ asio::awaitable<http::response<http::dynamic_body>> http_POST(
   auto n_redirects = 0U;
   auto next_url = url;
   while (n_redirects < 3U) {
-    auto const use_tls =
-        proxy ? proxy->use_tls_
-              : next_url.scheme_id() == boost::urls::scheme::https;
+    auto const use_tls = next_url.scheme_id() == boost::urls::scheme::https;
     auto const res = co_await (
         use_tls ? req_tls(next_url, headers, body, timeout, proxy)
                 : req_no_tls(next_url, headers, body, timeout, proxy));


### PR DESCRIPTION
- fixes https://github.com/motis-project/motis/issues/263
- fixes bug where using tls was always determined by the proxy scheme rather than target scheme.
- fixes same issue with choosing the SNI.

