### PR TITLE
fix(ui): stop sending Access-Control-Allow-Origin in Debug requests

### DIFF
--- a/ui/src/lib/Debug.svelte
+++ b/ui/src/lib/Debug.svelte
@@ -27,25 +27,14 @@
 	const post = async (path: string, req: unknown) => {
 		const response = await fetch(`${baseUrl}${path}`, {
 			method: 'POST',
-			mode: 'cors',
-			headers: {
-				'Access-Control-Allow-Origin': '*',
-				'Content-Type': 'application/json'
-			},
+			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(req)
 		});
 		return await response.json();
 	};
 
 	const get = async (path: string) => {
-		const response = await fetch(`${baseUrl}${path}`, {
-			method: 'GET',
-			mode: 'cors',
-			headers: {
-				'Access-Control-Allow-Origin': '*',
-				'Content-Type': 'application/json'
-			}
-		});
+		const response = await fetch(`${baseUrl}${path}`);
 		return await response.json();
 	};
 


### PR DESCRIPTION
While looking into `429` responses using the Debug mode I noticed that the fetch helpers were sending `Access-Control-Allow-Origin: *` as a request header. That is a response header - browsers ignore the value but still treat the request as non-simple and fire a CORS preflight. On top of that, the GET helper set `Content-Type: application/json` without a body, which is another preflight trigger on its own.

- GETs are now plain `fetch(url)` calls - no unnecessary preflights.
- POSTs keep `Content-Type: application/json` (needed) but drop the invalid header.

Won't fix every `429`, but removes one self-inflicted source of extra requests.
