### PR TITLE
ui: fix API request types, remove unused query fields

### DIFF
--- a/ui/src/lib/tripsWorker.ts
+++ b/ui/src/lib/tripsWorker.ts
@@ -1,12 +1,6 @@
 /// <reference lib="webworker" />trips
 import polyline from '@mapbox/polyline';
-import {
-	client,
-	trips,
-	type Mode,
-	type TripsData,
-	type TripSegment
-} from '@motis-project/motis-client';
+import { client, trips, type Mode, type TripSegment } from '@motis-project/motis-client';
 import type { Trip, TransferData, MetaData } from './types';
 import type { QuerySerializerOptions } from '@hey-api/client-fetch';
 import { getDelayColor, hexToRgb } from './Color';
@@ -55,7 +49,7 @@ let status: number;
 const tripsMap = new Map<string, Trip>();
 const metaDataMap = new Map<string, MetaData>();
 let metadata: MetaData[] = [];
-const fetchData = async (query: TripsData) => {
+const fetchData = async (query: Parameters<typeof trips>[0]) => {
 	const { data, response } = await trips(query);
 	status = response.status;
 	if (!data) return;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -20,7 +20,6 @@
 		oneToAll,
 		plan,
 		type ElevationCosts,
-		type OneToAllData,
 		type PlanResponse,
 		type Itinerary,
 		type Mode,
@@ -88,7 +87,7 @@
 	let colorMode = $state<'rt' | 'route' | 'mode' | 'none'>(isSmallScreen ? 'none' : 'rt');
 	let showMap = $state(!isSmallScreen);
 	let showRoutes = $state(false);
-	let lastOneToAllQuery: OneToAllData | undefined = undefined;
+	let lastOneToAllQuery: Parameters<typeof oneToAll>[0] | undefined = undefined;
 	let lastPlanQuery: PlanData | undefined = undefined;
 	let serverConfig: ServerConfig | undefined = $state();
 	let dataLoaded: boolean = $state(false);
@@ -420,11 +419,9 @@
 						maxPreTransitTime,
 						maxPostTransitTime,
 						elevationCosts,
-						maxMatchingDistance: pedestrianProfile == 'WHEELCHAIR' ? 8 : 250,
-						ignorePreTransitRentalReturnConstraints,
-						ignorePostTransitRentalReturnConstraints
+						maxMatchingDistance: pedestrianProfile == 'WHEELCHAIR' ? 8 : 250
 					}
-				} as OneToAllData)
+				} satisfies Parameters<typeof oneToAll>[0])
 			: undefined
 	);
 


### PR DESCRIPTION
Adjusted the types for trips/oneToAll requests to match the actual function parameters (using `Parameters<typeof ...>[0])`. Removed `ignorePreTransitRentalReturnConstraints` and `ignorePostTransitRentalReturnConstraints` from oneToAll queries, since they aren’t supported by the current API.

**before:**

```bash
/motis/ui$ pnpm run check
...
Error: Argument of type '{ query: any; }' is not assignable to parameter of type 'TripsData'.
...
Error: Conversion of type '{ query: { one: string; maxTravelTime: number; time: string; transitModes: Mode[]; maxTransfers: number; arriveBy: boolean; useRoutedTransfers: boolean; pedestrianProfile: PedestrianProfile; ... 9 more ...; ignorePostTransitRentalReturnConstraints: boolean; }; }' to type 'OneToAllData' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
...
svelte-check found 2 errors and 6 warnings in 6 files
[ELIFECYCLE] Command failed with exit code 1.
```

**after:**

```bash
/motis/ui$ pnpm run check
...
svelte-check found 0 errors and 6 warnings in 4 files
```

Bottom line: This only fixes type errors and does not change any runtime behavior.