### PR TITLE
normalize overlapping time-dependent offsets

### DIFF
--- a/include/motis/flex/flex.h
+++ b/include/motis/flex/flex.h
@@ -17,16 +17,6 @@ using flex_routings_t =
     hash_map<std::pair<nigiri::flex_stop_seq_idx_t, nigiri::stop_idx_t>,
              std::vector<mode_id>>;
 
-struct flex_td_candidate {
-  nigiri::unixtime_t valid_from_;
-  nigiri::unixtime_t valid_to_;
-  nigiri::duration_t duration_;
-  nigiri::transport_mode_id_t transport_mode_id_;
-};
-
-std::vector<nigiri::routing::td_offset> normalize_flex_td_offsets(
-    std::vector<flex_td_candidate>);
-
 osr::sharing_data prepare_sharing_data(nigiri::timetable const&,
                                        osr::ways const&,
                                        osr::lookup const&,

--- a/include/motis/flex/flex.h
+++ b/include/motis/flex/flex.h
@@ -17,6 +17,16 @@ using flex_routings_t =
     hash_map<std::pair<nigiri::flex_stop_seq_idx_t, nigiri::stop_idx_t>,
              std::vector<mode_id>>;
 
+struct flex_td_candidate {
+  nigiri::unixtime_t valid_from_;
+  nigiri::unixtime_t valid_to_;
+  nigiri::duration_t duration_;
+  nigiri::transport_mode_id_t transport_mode_id_;
+};
+
+std::vector<nigiri::routing::td_offset> normalize_flex_td_offsets(
+    std::vector<flex_td_candidate>);
+
 osr::sharing_data prepare_sharing_data(nigiri::timetable const&,
                                        osr::ways const&,
                                        osr::lookup const&,

--- a/include/motis/td_offsets.h
+++ b/include/motis/td_offsets.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <vector>
+
+#include "nigiri/routing/query.h"
+
+namespace motis {
+
+void normalize_td_offsets(std::vector<nigiri::routing::td_offset>&);
+
+}  // namespace motis

--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -55,6 +55,7 @@
 #include "motis/parse_location.h"
 #include "motis/server.h"
 #include "motis/tag_lookup.h"
+#include "motis/td_offsets.h"
 #include "motis/timetable/modes_to_clasz_mask.h"
 #include "motis/timetable/time_conv.h"
 #include "motis/update_rtt_td_footpaths.h"
@@ -138,15 +139,19 @@ n::routing::td_offsets_t get_td_offsets(
           return a.target_ == b.target_;
         },
         [&](auto&& from, auto&& to) {
-          ret.emplace(from->target_,
-                      utl::to_vec(from, to, [&](n::td_footpath const fp) {
-                        return n::routing::td_offset{
-                            .valid_from_ = fp.valid_from_,
-                            .duration_ = fp.duration_,
-                            .transport_mode_id_ =
-                                static_cast<n::transport_mode_id_t>(profile)};
-                      }));
+          auto& offsets = ret[from->target_];
+          for (auto it = from; it != to; ++it) {
+            offsets.push_back(n::routing::td_offset{
+                .valid_from_ = it->valid_from_,
+                .duration_ = it->duration_,
+                .transport_mode_id_ =
+                    static_cast<n::transport_mode_id_t>(profile)});
+          }
         });
+  }
+
+  for (auto& [l, location_offsets] : ret) {
+    normalize_td_offsets(location_offsets);
   }
 
   return ret;

--- a/src/flex/flex.cc
+++ b/src/flex/flex.cc
@@ -1,11 +1,9 @@
 #include "motis/flex/flex.h"
 
-#include <algorithm>
 #include <optional>
 #include <ranges>
 
 #include "utl/concat.h"
-#include "utl/erase_if.h"
 
 #include "osr/lookup.h"
 #include "osr/routing/parameters.h"
@@ -24,69 +22,6 @@
 namespace n = nigiri;
 
 namespace motis::flex {
-
-std::vector<n::routing::td_offset> normalize_flex_td_offsets(
-    std::vector<flex_td_candidate> candidates) {
-  utl::erase_if(candidates, [](flex_td_candidate const& c) {
-    return c.valid_to_ <= c.valid_from_ ||
-           c.duration_ >= n::footpath::kMaxDuration;
-  });
-
-  if (candidates.empty()) {
-    return {};
-  }
-
-  auto breakpoints = std::vector<n::unixtime_t>{};
-  breakpoints.reserve(candidates.size() * 2U);
-  for (auto const& c : candidates) {
-    breakpoints.emplace_back(c.valid_from_);
-    breakpoints.emplace_back(c.valid_to_);
-  }
-  utl::sort(breakpoints);
-  breakpoints.erase(std::unique(begin(breakpoints), end(breakpoints)),
-                    end(breakpoints));
-
-  auto ret = std::vector<n::routing::td_offset>{};
-  auto const inactive_mode = n::transport_mode_id_t{0U};
-  auto const is_same_state = [](n::routing::td_offset const& a,
-                                n::routing::td_offset const& b) {
-    if (a.duration_ == n::footpath::kMaxDuration &&
-        b.duration_ == n::footpath::kMaxDuration) {
-      return true;
-    }
-    return a.duration_ == b.duration_ &&
-           a.transport_mode_id_ == b.transport_mode_id_;
-  };
-  auto const append_state = [&](n::routing::td_offset const& state) {
-    if (!ret.empty() && is_same_state(ret.back(), state)) {
-      return;
-    }
-    ret.emplace_back(state);
-  };
-
-  auto const zero = n::unixtime_t{n::i32_minutes{0U}};
-  if (breakpoints.front() > zero) {
-    append_state({zero, n::footpath::kMaxDuration, inactive_mode});
-  }
-
-  for (auto const t : breakpoints) {
-    auto best = std::optional<flex_td_candidate>{};
-    for (auto const& c : candidates) {
-      if (c.valid_from_ <= t && t < c.valid_to_ &&
-          (!best.has_value() || c.duration_ < best->duration_)) {
-        best = c;
-      }
-    }
-
-    append_state(best.has_value()
-                     ? n::routing::td_offset{t, best->duration_,
-                                             best->transport_mode_id_}
-                     : n::routing::td_offset{t, n::footpath::kMaxDuration,
-                                             inactive_mode});
-  }
-
-  return ret;
-}
 
 osr::sharing_data prepare_sharing_data(n::timetable const& tt,
                                        osr::ways const& w,
@@ -366,9 +301,6 @@ void add_flex_td_offsets(osr::ways const& w,
   stats.emplace(fmt::format("prepare_{}_FLEX_lookup", to_str(dir)),
                 UTL_GET_TIMING_MS(flex_lookup_timer));
 
-  auto candidates =
-      hash_map<n::location_idx_t, std::vector<flex_td_candidate>>{};
-
   for (auto const& [stop_seq, transports] : routings) {
     UTL_START_TIMING(routing_timer);
 
@@ -419,9 +351,13 @@ void add_flex_td_offsets(osr::ways const& w,
                                              ? iv_at_to_stop << duration
                                              : iv_at_to_stop >> duration;
 
-            candidates[l].emplace_back(flex_td_candidate{iv_at_from_stop.from_,
-                                                         iv_at_from_stop.to_,
-                                                         duration, id.to_id()});
+            if (iv_at_from_stop.from_ < iv_at_from_stop.to_ &&
+                duration < n::footpath::kMaxDuration) {
+              auto& offsets = ret[l];
+              offsets.emplace_back(iv_at_from_stop.from_, duration, id.to_id());
+              offsets.emplace_back(iv_at_from_stop.to_,
+                                   n::footpath::kMaxDuration, id.to_id());
+            }
           }
         }
       }
@@ -439,23 +375,6 @@ void add_flex_td_offsets(osr::ways const& w,
                                               tt.flex_area_name_[a]);
                                         }})),
         UTL_GET_TIMING_MS(routing_timer));
-  }
-
-  for (auto& [l, flex_candidates] : candidates) {
-    auto flex_offsets = normalize_flex_td_offsets(std::move(flex_candidates));
-    if (flex_offsets.empty()) {
-      continue;
-    }
-
-    auto& offsets = ret[l];
-    offsets.insert(end(offsets), begin(flex_offsets), end(flex_offsets));
-  }
-
-  for (auto& [_, offsets] : ret) {
-    utl::sort(offsets, [](n::routing::td_offset const& a,
-                          n::routing::td_offset const& b) {
-      return a.valid_from_ < b.valid_from_;
-    });
   }
 }
 

--- a/src/flex/flex.cc
+++ b/src/flex/flex.cc
@@ -1,8 +1,11 @@
 #include "motis/flex/flex.h"
 
+#include <algorithm>
+#include <optional>
 #include <ranges>
 
 #include "utl/concat.h"
+#include "utl/erase_if.h"
 
 #include "osr/lookup.h"
 #include "osr/routing/parameters.h"
@@ -21,6 +24,69 @@
 namespace n = nigiri;
 
 namespace motis::flex {
+
+std::vector<n::routing::td_offset> normalize_flex_td_offsets(
+    std::vector<flex_td_candidate> candidates) {
+  utl::erase_if(candidates, [](flex_td_candidate const& c) {
+    return c.valid_to_ <= c.valid_from_ ||
+           c.duration_ >= n::footpath::kMaxDuration;
+  });
+
+  if (candidates.empty()) {
+    return {};
+  }
+
+  auto breakpoints = std::vector<n::unixtime_t>{};
+  breakpoints.reserve(candidates.size() * 2U);
+  for (auto const& c : candidates) {
+    breakpoints.emplace_back(c.valid_from_);
+    breakpoints.emplace_back(c.valid_to_);
+  }
+  utl::sort(breakpoints);
+  breakpoints.erase(std::unique(begin(breakpoints), end(breakpoints)),
+                    end(breakpoints));
+
+  auto ret = std::vector<n::routing::td_offset>{};
+  auto const inactive_mode = n::transport_mode_id_t{0U};
+  auto const is_same_state = [](n::routing::td_offset const& a,
+                                n::routing::td_offset const& b) {
+    if (a.duration_ == n::footpath::kMaxDuration &&
+        b.duration_ == n::footpath::kMaxDuration) {
+      return true;
+    }
+    return a.duration_ == b.duration_ &&
+           a.transport_mode_id_ == b.transport_mode_id_;
+  };
+  auto const append_state = [&](n::routing::td_offset const& state) {
+    if (!ret.empty() && is_same_state(ret.back(), state)) {
+      return;
+    }
+    ret.emplace_back(state);
+  };
+
+  auto const zero = n::unixtime_t{n::i32_minutes{0U}};
+  if (breakpoints.front() > zero) {
+    append_state({zero, n::footpath::kMaxDuration, inactive_mode});
+  }
+
+  for (auto const t : breakpoints) {
+    auto best = std::optional<flex_td_candidate>{};
+    for (auto const& c : candidates) {
+      if (c.valid_from_ <= t && t < c.valid_to_ &&
+          (!best.has_value() || c.duration_ < best->duration_)) {
+        best = c;
+      }
+    }
+
+    append_state(best.has_value()
+                     ? n::routing::td_offset{t, best->duration_,
+                                             best->transport_mode_id_}
+                     : n::routing::td_offset{t, n::footpath::kMaxDuration,
+                                             inactive_mode});
+  }
+
+  return ret;
+}
 
 osr::sharing_data prepare_sharing_data(n::timetable const& tt,
                                        osr::ways const& w,
@@ -300,6 +366,9 @@ void add_flex_td_offsets(osr::ways const& w,
   stats.emplace(fmt::format("prepare_{}_FLEX_lookup", to_str(dir)),
                 UTL_GET_TIMING_MS(flex_lookup_timer));
 
+  auto candidates =
+      hash_map<n::location_idx_t, std::vector<flex_td_candidate>>{};
+
   for (auto const& [stop_seq, transports] : routings) {
     UTL_START_TIMING(routing_timer);
 
@@ -350,14 +419,9 @@ void add_flex_td_offsets(osr::ways const& w,
                                              ? iv_at_to_stop << duration
                                              : iv_at_to_stop >> duration;
 
-            auto& offsets = ret[l];
-            if (offsets.empty()) {
-              offsets.emplace_back(n::unixtime_t{n::i32_minutes{0U}},
-                                   n::footpath::kMaxDuration, id.to_id());
-            }
-            offsets.emplace_back(iv_at_from_stop.from_, duration, id.to_id());
-            offsets.emplace_back(iv_at_from_stop.to_, n::footpath::kMaxDuration,
-                                 id.to_id());
+            candidates[l].emplace_back(flex_td_candidate{iv_at_from_stop.from_,
+                                                         iv_at_from_stop.to_,
+                                                         duration, id.to_id()});
           }
         }
       }
@@ -375,6 +439,16 @@ void add_flex_td_offsets(osr::ways const& w,
                                               tt.flex_area_name_[a]);
                                         }})),
         UTL_GET_TIMING_MS(routing_timer));
+  }
+
+  for (auto& [l, flex_candidates] : candidates) {
+    auto flex_offsets = normalize_flex_td_offsets(std::move(flex_candidates));
+    if (flex_offsets.empty()) {
+      continue;
+    }
+
+    auto& offsets = ret[l];
+    offsets.insert(end(offsets), begin(flex_offsets), end(flex_offsets));
   }
 
   for (auto& [_, offsets] : ret) {

--- a/src/td_offsets.cc
+++ b/src/td_offsets.cc
@@ -1,0 +1,113 @@
+#include "motis/td_offsets.h"
+
+#include <algorithm>
+#include <optional>
+
+#include "nigiri/footpath.h"
+
+#include "motis/types.h"
+
+namespace n = nigiri;
+
+namespace motis {
+
+bool is_same_td_state(n::routing::td_offset const& a,
+                      n::routing::td_offset const& b) {
+  return a.duration_ == b.duration_ &&
+         a.transport_mode_id_ == b.transport_mode_id_;
+}
+
+void normalize_td_offsets(std::vector<n::routing::td_offset>& offsets) {
+  if (offsets.empty()) {
+    return;
+  }
+
+  // (1) lower envelope: sweep all breakpoints, keeping the fastest active
+  // offer per point in time.
+  std::sort(begin(offsets), end(offsets),
+            [](n::routing::td_offset const& a, n::routing::td_offset const& b) {
+              return a.valid_from_ < b.valid_from_;
+            });
+
+  auto active = hash_map<n::transport_mode_id_t, n::duration_t>{};
+  auto envelope = std::vector<n::routing::td_offset>{};
+  for (auto it = begin(offsets); it != end(offsets);) {
+    auto const t = it->valid_from_;
+    for (; it != end(offsets) && it->valid_from_ == t; ++it) {
+      if (it->duration_ >= n::footpath::kMaxDuration) {
+        active.erase(it->transport_mode_id_);
+      } else {
+        active[it->transport_mode_id_] = it->duration_;
+      }
+    }
+
+    auto best = n::routing::td_offset{.valid_from_ = t,
+                                      .duration_ = n::footpath::kMaxDuration,
+                                      .transport_mode_id_ = 0U};
+    for (auto const& [mode, duration] : active) {
+      if (duration < best.duration_ ||
+          (duration == best.duration_ && mode < best.transport_mode_id_)) {
+        best.duration_ = duration;
+        best.transport_mode_id_ = mode;
+      }
+    }
+
+    if (envelope.empty() || !is_same_td_state(envelope.back(), best)) {
+      envelope.push_back(best);
+    }
+  }
+
+  // (2) FIFO repair: walking backwards, `best_arr` is the earliest arrival
+  // reachable by departing at or after the current position. An active
+  // window [vf, duration] is cut at `best_arr - duration`: departing later
+  // than that should wait for the faster offer instead.
+  auto fixed = std::vector<n::routing::td_offset>{};
+  fixed.reserve(envelope.size());
+  auto best_arr = std::optional<n::unixtime_t>{};
+  for (auto i = envelope.size(); i-- != 0U;) {
+    auto const& e = envelope[i];
+    if (e.duration_ >= n::footpath::kMaxDuration) {
+      fixed.push_back(e);
+      continue;
+    }
+
+    auto const next_from = i + 1U < envelope.size()
+                               ? envelope[i + 1U].valid_from_
+                               : n::unixtime_t::max();
+    if (best_arr.has_value() && *best_arr - e.duration_ <= e.valid_from_) {
+      // whole window dominated by waiting for a later, faster offer
+      fixed.push_back({.valid_from_ = e.valid_from_,
+                       .duration_ = n::footpath::kMaxDuration,
+                       .transport_mode_id_ = 0U});
+      continue;
+    }
+
+    if (best_arr.has_value() && *best_arr - e.duration_ < next_from) {
+      // tail of the window dominated -> end the offer early
+      fixed.push_back({.valid_from_ = *best_arr - e.duration_,
+                       .duration_ = n::footpath::kMaxDuration,
+                       .transport_mode_id_ = 0U});
+    }
+    fixed.push_back(e);
+    best_arr = e.valid_from_ + e.duration_;
+  }
+  std::reverse(begin(fixed), end(fixed));
+
+  // Re-emit, starting with a dead window from the beginning of time so the
+  // result is a complete step function, and dropping adjacent duplicates
+  // introduced by the repair.
+  offsets.clear();
+  auto const zero = n::unixtime_t{n::i32_minutes{0}};
+  if (fixed.front().valid_from_ > zero) {
+    offsets.push_back({.valid_from_ = zero,
+                       .duration_ = n::footpath::kMaxDuration,
+                       .transport_mode_id_ = 0U});
+  }
+  for (auto const& e : fixed) {
+    if (offsets.empty() || !is_same_td_state(offsets.back(), e)) {
+      offsets.push_back(e);
+    }
+  }
+}
+
+}  // namespace motis

--- a/test/flex_mode_id_test.cc
+++ b/test/flex_mode_id_test.cc
@@ -1,25 +1,10 @@
 #include "gtest/gtest.h"
 
-#include "motis/flex/flex.h"
 #include "motis/flex/mode_id.h"
 
 namespace n = nigiri;
 
 using namespace motis::flex;
-
-namespace {
-
-n::unixtime_t t(int const minutes) {
-  return n::unixtime_t{n::i32_minutes{minutes}};
-}
-
-n::transport_mode_id_t flex_id(n::flex_transport_idx_t::value_t const transport,
-                               n::stop_idx_t const stop,
-                               osr::direction const dir) {
-  return mode_id{n::flex_transport_idx_t{transport}, stop, dir}.to_id();
-}
-
-}  // namespace
 
 TEST(motis, flex_mode_id_zero) {
   auto const t = n::flex_transport_idx_t{0U};
@@ -45,86 +30,4 @@ TEST(motis, flex_mode_id) {
   EXPECT_EQ(stop, id1.get_stop());
   EXPECT_EQ(dir, id1.get_dir());
   EXPECT_EQ(t, id1.get_flex_transport());
-}
-
-TEST(motis, flex_td_offsets_keep_shortest_same_window) {
-  auto const slow = flex_id(1U, 0U, osr::direction::kBackward);
-  auto const fast = flex_id(2U, 0U, osr::direction::kBackward);
-
-  auto const offsets = normalize_flex_td_offsets({
-      {t(100), t(200), n::duration_t{30}, slow},
-      {t(100), t(200), n::duration_t{10}, fast},
-  });
-
-  ASSERT_EQ(3U, offsets.size());
-  EXPECT_EQ(t(0), offsets[0].valid_from_);
-  EXPECT_EQ(n::footpath::kMaxDuration, offsets[0].duration_);
-  EXPECT_EQ(t(100), offsets[1].valid_from_);
-  EXPECT_EQ(n::duration_t{10}, offsets[1].duration_);
-  EXPECT_EQ(fast, offsets[1].transport_mode_id_);
-  EXPECT_EQ(t(200), offsets[2].valid_from_);
-  EXPECT_EQ(n::footpath::kMaxDuration, offsets[2].duration_);
-}
-
-TEST(motis, flex_td_offsets_preserve_first_on_equal_duration) {
-  auto const first = flex_id(1U, 0U, osr::direction::kBackward);
-  auto const second = flex_id(2U, 0U, osr::direction::kBackward);
-
-  auto const offsets = normalize_flex_td_offsets({
-      {t(100), t(200), n::duration_t{10}, first},
-      {t(100), t(200), n::duration_t{10}, second},
-  });
-
-  ASSERT_EQ(3U, offsets.size());
-  EXPECT_EQ(first, offsets[1].transport_mode_id_);
-}
-
-TEST(motis, flex_td_offsets_split_overlapping_windows) {
-  auto const long_id = flex_id(1U, 0U, osr::direction::kBackward);
-  auto const short_id = flex_id(2U, 0U, osr::direction::kBackward);
-
-  auto const offsets = normalize_flex_td_offsets({
-      {t(100), t(220), n::duration_t{30}, long_id},
-      {t(150), t(180), n::duration_t{10}, short_id},
-  });
-
-  ASSERT_EQ(5U, offsets.size());
-  EXPECT_EQ(t(100), offsets[1].valid_from_);
-  EXPECT_EQ(long_id, offsets[1].transport_mode_id_);
-  EXPECT_EQ(t(150), offsets[2].valid_from_);
-  EXPECT_EQ(short_id, offsets[2].transport_mode_id_);
-  EXPECT_EQ(t(180), offsets[3].valid_from_);
-  EXPECT_EQ(long_id, offsets[3].transport_mode_id_);
-  EXPECT_EQ(t(220), offsets[4].valid_from_);
-  EXPECT_EQ(n::footpath::kMaxDuration, offsets[4].duration_);
-}
-
-TEST(motis, flex_td_offsets_keep_inactive_gaps) {
-  auto const first = flex_id(1U, 0U, osr::direction::kBackward);
-  auto const second = flex_id(2U, 0U, osr::direction::kBackward);
-
-  auto const offsets = normalize_flex_td_offsets({
-      {t(100), t(120), n::duration_t{10}, first},
-      {t(150), t(170), n::duration_t{8}, second},
-  });
-
-  ASSERT_EQ(5U, offsets.size());
-  EXPECT_EQ(t(120), offsets[2].valid_from_);
-  EXPECT_EQ(n::footpath::kMaxDuration, offsets[2].duration_);
-  EXPECT_EQ(t(150), offsets[3].valid_from_);
-  EXPECT_EQ(second, offsets[3].transport_mode_id_);
-}
-
-TEST(motis, flex_td_offsets_preserve_mode_id_direction) {
-  auto const backward = flex_id(42U, 3U, osr::direction::kBackward);
-
-  auto const offsets = normalize_flex_td_offsets({
-      {t(100), t(200), n::duration_t{10}, backward},
-  });
-
-  ASSERT_EQ(3U, offsets.size());
-  auto const restored = mode_id{offsets[1].transport_mode_id_};
-  EXPECT_EQ(osr::direction::kBackward, restored.get_dir());
-  EXPECT_EQ(n::flex_transport_idx_t{42U}, restored.get_flex_transport());
-  EXPECT_EQ(static_cast<n::stop_idx_t>(3U), restored.get_stop());
 }

--- a/test/flex_mode_id_test.cc
+++ b/test/flex_mode_id_test.cc
@@ -1,11 +1,28 @@
 #include "gtest/gtest.h"
 
+#include "motis/flex/flex.h"
 #include "motis/flex/mode_id.h"
+
+namespace n = nigiri;
 
 using namespace motis::flex;
 
+namespace {
+
+n::unixtime_t t(int const minutes) {
+  return n::unixtime_t{n::i32_minutes{minutes}};
+}
+
+n::transport_mode_id_t flex_id(n::flex_transport_idx_t::value_t const transport,
+                               n::stop_idx_t const stop,
+                               osr::direction const dir) {
+  return mode_id{n::flex_transport_idx_t{transport}, stop, dir}.to_id();
+}
+
+}  // namespace
+
 TEST(motis, flex_mode_id_zero) {
-  auto const t = nigiri::flex_transport_idx_t{0U};
+  auto const t = n::flex_transport_idx_t{0U};
   auto const stop = 0U;
   auto const dir = osr::direction::kForward;
   auto const id = mode_id{t, stop, dir}.to_id();
@@ -18,7 +35,7 @@ TEST(motis, flex_mode_id_zero) {
 }
 
 TEST(motis, flex_mode_id) {
-  auto const t = nigiri::flex_transport_idx_t{44444U};
+  auto const t = n::flex_transport_idx_t{44444U};
   auto const stop = 15;
   auto const dir = osr::direction::kBackward;
   auto const id = mode_id{t, stop, dir}.to_id();
@@ -28,4 +45,86 @@ TEST(motis, flex_mode_id) {
   EXPECT_EQ(stop, id1.get_stop());
   EXPECT_EQ(dir, id1.get_dir());
   EXPECT_EQ(t, id1.get_flex_transport());
+}
+
+TEST(motis, flex_td_offsets_keep_shortest_same_window) {
+  auto const slow = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const fast = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto const offsets = normalize_flex_td_offsets({
+      {t(100), t(200), n::duration_t{30}, slow},
+      {t(100), t(200), n::duration_t{10}, fast},
+  });
+
+  ASSERT_EQ(3U, offsets.size());
+  EXPECT_EQ(t(0), offsets[0].valid_from_);
+  EXPECT_EQ(n::footpath::kMaxDuration, offsets[0].duration_);
+  EXPECT_EQ(t(100), offsets[1].valid_from_);
+  EXPECT_EQ(n::duration_t{10}, offsets[1].duration_);
+  EXPECT_EQ(fast, offsets[1].transport_mode_id_);
+  EXPECT_EQ(t(200), offsets[2].valid_from_);
+  EXPECT_EQ(n::footpath::kMaxDuration, offsets[2].duration_);
+}
+
+TEST(motis, flex_td_offsets_preserve_first_on_equal_duration) {
+  auto const first = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const second = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto const offsets = normalize_flex_td_offsets({
+      {t(100), t(200), n::duration_t{10}, first},
+      {t(100), t(200), n::duration_t{10}, second},
+  });
+
+  ASSERT_EQ(3U, offsets.size());
+  EXPECT_EQ(first, offsets[1].transport_mode_id_);
+}
+
+TEST(motis, flex_td_offsets_split_overlapping_windows) {
+  auto const long_id = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const short_id = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto const offsets = normalize_flex_td_offsets({
+      {t(100), t(220), n::duration_t{30}, long_id},
+      {t(150), t(180), n::duration_t{10}, short_id},
+  });
+
+  ASSERT_EQ(5U, offsets.size());
+  EXPECT_EQ(t(100), offsets[1].valid_from_);
+  EXPECT_EQ(long_id, offsets[1].transport_mode_id_);
+  EXPECT_EQ(t(150), offsets[2].valid_from_);
+  EXPECT_EQ(short_id, offsets[2].transport_mode_id_);
+  EXPECT_EQ(t(180), offsets[3].valid_from_);
+  EXPECT_EQ(long_id, offsets[3].transport_mode_id_);
+  EXPECT_EQ(t(220), offsets[4].valid_from_);
+  EXPECT_EQ(n::footpath::kMaxDuration, offsets[4].duration_);
+}
+
+TEST(motis, flex_td_offsets_keep_inactive_gaps) {
+  auto const first = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const second = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto const offsets = normalize_flex_td_offsets({
+      {t(100), t(120), n::duration_t{10}, first},
+      {t(150), t(170), n::duration_t{8}, second},
+  });
+
+  ASSERT_EQ(5U, offsets.size());
+  EXPECT_EQ(t(120), offsets[2].valid_from_);
+  EXPECT_EQ(n::footpath::kMaxDuration, offsets[2].duration_);
+  EXPECT_EQ(t(150), offsets[3].valid_from_);
+  EXPECT_EQ(second, offsets[3].transport_mode_id_);
+}
+
+TEST(motis, flex_td_offsets_preserve_mode_id_direction) {
+  auto const backward = flex_id(42U, 3U, osr::direction::kBackward);
+
+  auto const offsets = normalize_flex_td_offsets({
+      {t(100), t(200), n::duration_t{10}, backward},
+  });
+
+  ASSERT_EQ(3U, offsets.size());
+  auto const restored = mode_id{offsets[1].transport_mode_id_};
+  EXPECT_EQ(osr::direction::kBackward, restored.get_dir());
+  EXPECT_EQ(n::flex_transport_idx_t{42U}, restored.get_flex_transport());
+  EXPECT_EQ(static_cast<n::stop_idx_t>(3U), restored.get_stop());
 }

--- a/test/td_offsets_test.cc
+++ b/test/td_offsets_test.cc
@@ -1,0 +1,256 @@
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <initializer_list>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "nigiri/footpath.h"
+#include "nigiri/td_footpath.h"
+
+#include "motis/flex/mode_id.h"
+#include "motis/td_offsets.h"
+
+namespace n = nigiri;
+
+namespace {
+
+n::unixtime_t t(int const minutes) {
+  return n::unixtime_t{n::i32_minutes{minutes}};
+}
+
+n::transport_mode_id_t flex_id(n::flex_transport_idx_t::value_t const transport,
+                               n::stop_idx_t const stop,
+                               osr::direction const dir) {
+  return motis::flex::mode_id{n::flex_transport_idx_t{transport}, stop, dir}
+      .to_id();
+}
+
+struct offer {
+  int from_, to_;
+  n::duration_t duration_;
+  n::transport_mode_id_t mode_;
+};
+
+// Builds the raw input as the producers do: every offer contributes a start
+// entry and a kMaxDuration closer, both tagged with the offer's mode.
+std::vector<n::routing::td_offset> raw(std::initializer_list<offer> offers) {
+  auto v = std::vector<n::routing::td_offset>{};
+  for (auto const& o : offers) {
+    v.push_back({.valid_from_ = t(o.from_),
+                 .duration_ = o.duration_,
+                 .transport_mode_id_ = o.mode_});
+    v.push_back({.valid_from_ = t(o.to_),
+                 .duration_ = n::footpath::kMaxDuration,
+                 .transport_mode_id_ = o.mode_});
+  }
+  return v;
+}
+
+n::routing::td_offset active(int const from,
+                             int const duration,
+                             n::transport_mode_id_t const mode) {
+  return {.valid_from_ = t(from),
+          .duration_ = n::duration_t{duration},
+          .transport_mode_id_ = mode};
+}
+
+n::routing::td_offset inactive(int const from) {
+  return {.valid_from_ = t(from),
+          .duration_ = n::footpath::kMaxDuration,
+          .transport_mode_id_ = 0U};
+}
+
+// Arrival time the routing core (nigiri's get_td_duration) yields for a
+// departure at minute `dep`; std::nullopt if no offer is reachable.
+std::optional<n::unixtime_t> arrival(
+    std::vector<n::routing::td_offset> const& offsets, int const dep) {
+  auto const r = n::get_td_duration<n::direction::kForward>(
+      std::span<n::routing::td_offset const>{offsets}, t(dep));
+  return r.has_value() ? std::optional{t(dep) + r->first} : std::nullopt;
+}
+
+}  // namespace
+
+TEST(motis, td_offsets_keep_shortest_same_window) {
+  auto const slow = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const fast = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto offsets = raw({
+      {100, 200, n::duration_t{30}, slow},
+      {100, 200, n::duration_t{10}, fast},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  EXPECT_EQ((std::vector{inactive(0), active(100, 10, fast), inactive(200)}),
+            offsets);
+}
+
+TEST(motis, td_offsets_deterministic_on_equal_duration) {
+  auto const first = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const second = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto offsets = raw({
+      {100, 200, n::duration_t{10}, first},
+      {100, 200, n::duration_t{10}, second},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  EXPECT_EQ((std::vector{inactive(0), active(100, 10, std::min(first, second)),
+                         inactive(200)}),
+            offsets);
+}
+
+TEST(motis, td_offsets_split_overlapping_windows) {
+  auto const slow = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const fast = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto offsets = raw({
+      {100, 220, n::duration_t{30}, slow},
+      {150, 180, n::duration_t{10}, fast},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  // The slow offer is ended early at 150 + 10 - 30 = 130: departing later than
+  // that, it is faster to wait for the fast offer (FIFO repair). Without it,
+  // departing at 149 (arrival 179) would beat departing at 150 (arrival 160).
+  EXPECT_EQ((std::vector{inactive(0), active(100, 30, slow), inactive(130),
+                         active(150, 10, fast), active(180, 30, slow),
+                         inactive(220)}),
+            offsets);
+
+  // get_td_duration must yield FIFO arrivals. [130, 150) is the cut region
+  // where the slow offer would otherwise let an earlier departure overtake:
+  EXPECT_EQ(t(130), arrival(offsets, 100));
+  EXPECT_EQ(t(159), arrival(offsets, 129));
+  for (auto dep = 130; dep < 150; ++dep) {
+    EXPECT_EQ(t(160), arrival(offsets, dep)) << "at minute " << dep;
+  }
+  EXPECT_EQ(t(160), arrival(offsets, 150));
+  EXPECT_EQ(t(189), arrival(offsets, 179));
+  EXPECT_EQ(t(210), arrival(offsets, 180));
+  EXPECT_EQ(t(249), arrival(offsets, 219));
+}
+
+TEST(motis, td_offsets_fifo_cascade) {
+  auto const a = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const b = flex_id(2U, 0U, osr::direction::kBackward);
+  auto const c = flex_id(3U, 0U, osr::direction::kBackward);
+
+  // Three overlapping offers, each faster than the previous: the FIFO repair
+  // cuts `a` relative to `b` (at 200 + 60 - 90 = 170) and `b` relative to `c`
+  // (at 300 + 10 - 60 = 250).
+  auto offsets = raw({
+      {100, 400, n::duration_t{90}, a},
+      {200, 400, n::duration_t{60}, b},
+      {300, 400, n::duration_t{10}, c},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  EXPECT_EQ((std::vector{inactive(0), active(100, 90, a), inactive(170),
+                         active(200, 60, b), inactive(250), active(300, 10, c),
+                         inactive(400)}),
+            offsets);
+
+  // get_td_duration must yield FIFO arrivals across both cut regions:
+  EXPECT_EQ(t(259), arrival(offsets, 169));
+  for (auto dep = 170; dep < 200; ++dep) {
+    EXPECT_EQ(t(260), arrival(offsets, dep)) << "at minute " << dep;
+  }
+  EXPECT_EQ(t(309), arrival(offsets, 249));
+  for (auto dep = 250; dep < 300; ++dep) {
+    EXPECT_EQ(t(310), arrival(offsets, dep)) << "at minute " << dep;
+  }
+  EXPECT_EQ(t(409), arrival(offsets, 399));
+}
+
+TEST(motis, td_offsets_keep_inactive_gaps) {
+  auto const first = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const second = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto offsets = raw({
+      {100, 120, n::duration_t{10}, first},
+      {150, 170, n::duration_t{8}, second},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  // No FIFO violation: departing at 119 arrives at 129, departing at 150
+  // arrives at 158 -> the slow offer is kept as-is.
+  EXPECT_EQ((std::vector{inactive(0), active(100, 10, first), inactive(120),
+                         active(150, 8, second), inactive(170)}),
+            offsets);
+}
+
+TEST(motis, td_offsets_drop_fully_dominated_window) {
+  auto const slow = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const fast = flex_id(2U, 0U, osr::direction::kBackward);
+
+  auto offsets = raw({
+      {100, 200, n::duration_t{100}, slow},
+      {150, 250, n::duration_t{10}, fast},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  // Waiting from 100 for the fast offer (arrival 160) always beats the slow
+  // offer (arrival >= 200) -> the slow window is fully replaced by an
+  // inactive gap.
+  EXPECT_EQ((std::vector{inactive(0), active(150, 10, fast), inactive(250)}),
+            offsets);
+
+  // The whole slow window is dominated: every departure in [100, 150) arrives
+  // no earlier than waiting for the fast offer (arrival 160) would.
+  for (auto dep = 100; dep < 150; ++dep) {
+    EXPECT_EQ(t(160), arrival(offsets, dep)) << "at minute " << dep;
+  }
+  EXPECT_EQ(t(160), arrival(offsets, 150));
+  EXPECT_EQ(t(259), arrival(offsets, 249));
+}
+
+TEST(motis, td_offsets_merge_inactive_after_cut) {
+  auto const slow = flex_id(1U, 0U, osr::direction::kBackward);
+  auto const fast = flex_id(2U, 0U, osr::direction::kBackward);
+
+  // The slow offer is cut at 250 + 10 - 100 = 160; the envelope already has an
+  // inactive gap at 200 (slow closes, fast not yet open). The cut's inactive
+  // entry and that gap are adjacent kMaxDuration entries -> they must collapse
+  // into a single one.
+  auto offsets = raw({
+      {100, 200, n::duration_t{100}, slow},
+      {250, 400, n::duration_t{10}, fast},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  EXPECT_EQ((std::vector{inactive(0), active(100, 100, slow), inactive(160),
+                         active(250, 10, fast), inactive(400)}),
+            offsets);
+
+  // Verify via nigiri's get_td_duration that the result is FIFO. Before the
+  // cut the slow offer is used directly:
+  EXPECT_EQ(t(200), arrival(offsets, 100));
+  EXPECT_EQ(t(259), arrival(offsets, 159));
+  // During the cut/overlap region departing later must never arrive earlier:
+  // the routing core waits for the fast offer (arrival 260) instead of taking
+  // the slow one, which would arrive at dep + 100 > 260 (the non-FIFO case).
+  for (auto dep = 160; dep < 250; ++dep) {
+    EXPECT_EQ(t(260), arrival(offsets, dep)) << "at minute " << dep;
+  }
+  // Inside the fast window the arrival grows monotonically again:
+  EXPECT_EQ(t(260), arrival(offsets, 250));
+  EXPECT_EQ(t(310), arrival(offsets, 300));
+}
+
+TEST(motis, td_offsets_preserve_mode_id) {
+  auto const backward = flex_id(42U, 3U, osr::direction::kBackward);
+
+  auto offsets = raw({
+      {100, 200, n::duration_t{10}, backward},
+  });
+  motis::normalize_td_offsets(offsets);
+
+  ASSERT_EQ(3U, offsets.size());
+  auto const restored = motis::flex::mode_id{offsets[1].transport_mode_id_};
+  EXPECT_EQ(osr::direction::kBackward, restored.get_dir());
+  EXPECT_EQ(n::flex_transport_idx_t{42U}, restored.get_flex_transport());
+  EXPECT_EQ(static_cast<n::stop_idx_t>(3U), restored.get_stop());
+}


### PR DESCRIPTION
Normalize overlapping GTFS Flex destination access candidates before inserting time-dependent offsets. This prevents slower overlapping Flex candidates from shadowing faster candidates during full itinerary routing.

The normalization should build validity breakpoints from all candidates and emits a piecewise offset sequence where each interval contains the shortest active candidate, or an unavailable offset if no candidate is active.

Relates to #1406 

Note: I am not primarily a C++ developer, so feedback on style or a more idiomatic implementation is very welcome.