### PR TITLE
Ensure 'blocked' is initialized when only using direct routing

### DIFF
--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -496,6 +496,10 @@ std::pair<std::vector<api::Itinerary>, n::duration_t> routing::route_direct(
   if (!w_ || !l_) {
     return {};
   }
+  if (ep::blocked.get() == nullptr) {
+    ep::blocked.reset(new osr::bitvec<osr::node_idx_t>{w_->n_nodes()});
+  }
+
   auto fastest_direct = kInfinityDuration;
   auto cache = street_routing_cache_t{};
   auto itineraries = std::vector<api::Itinerary>{};

--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -496,8 +496,8 @@ std::pair<std::vector<api::Itinerary>, n::duration_t> routing::route_direct(
   if (!w_ || !l_) {
     return {};
   }
-  if (ep::blocked.get() == nullptr) {
-    ep::blocked.reset(new osr::bitvec<osr::node_idx_t>{w_->n_nodes()});
+  if (blocked.get() == nullptr) {
+    blocked.reset(new osr::bitvec<osr::node_idx_t>{w_->n_nodes()});
   }
 
   auto fastest_direct = kInfinityDuration;


### PR DESCRIPTION
Fixes an segmentation fault, when only using direct routing. For example when only running this test: `./motis-test --gtest_filter='motis.routing_osm_only_direct_walk'`