### PR TITLE
Lenient limits

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -96,9 +96,10 @@ gbfs:
 street_routing:                   # enable street routing (default = false; Using boolean values true/false is supported for backward compatibility)
   elevation_data_dir: srtm/       # folder which contains elevation data, e.g. SRTMGL1 data tiles in HGT format
 limits:
-  stoptimes_max_results: 256      # maximum number of stoptimes results that can be requested
+  stoptimes_max_results: 1024     # maximum number of stoptimes results that can be requested
   plan_max_results: 256           # maximum number of plan results that can be requested via numItineraries parameter
   plan_max_search_window_minutes: 5760 # maximum (minutes) for searchWindow parameter (seconds), highest possible value: 21600 (15 days)
+  stops_max_results: 8192         # maximum number of stops returned in /map/stops
   onetomany_max_many: 128         # maximum accepted number of many locations for one-to-many requests
   onetoall_max_results: 65535     # maximum number of one-to-all results that can be requested
   onetoall_max_travel_minutes: 90 # maximum travel duration for one-to-all query that can be requested
@@ -106,6 +107,8 @@ limits:
   gtfsrt_expose_max_trip_updates: 100 # how many trip updates are allowed to be exposed via the gtfsrt endpoint
   street_routing_max_prepost_transit_seconds: 3600 # limit for maxPre/PostTransitTime API params, see below
   street_routing_max_direct_seconds: 21600 # limit for maxDirectTime API param, high values can lead to long-running, RAM-hungry queries 
+  geocode_max_suggestions: 512    # maximum requestable results for /geocode
+  reverse_geocode_max_results: 512 # maximum requestable results for /reverse-geocode
 logging:
   log_level: debug                # log-level (default = debug; Supported log-levels: error, info, debug)
 osr_footpath: true                # enable routing footpaths instead of using transfers from timetable datasets

--- a/include/motis/config.h
+++ b/include/motis/config.h
@@ -244,7 +244,7 @@ struct config {
 
   struct limits {
     bool operator==(limits const&) const = default;
-    unsigned stoptimes_max_results_{256U};
+    unsigned stoptimes_max_results_{1024U};
     unsigned plan_max_results_{256U};
     unsigned plan_max_search_window_minutes_{5760U};
     unsigned stops_max_results_{8192U};
@@ -255,8 +255,8 @@ struct config {
     unsigned gtfsrt_expose_max_trip_updates_{100U};
     unsigned street_routing_max_prepost_transit_seconds_{3600U};
     unsigned street_routing_max_direct_seconds_{21600U};
-    unsigned geocode_max_suggestions_{10U};
-    unsigned reverse_geocode_max_results_{5U};
+    unsigned geocode_max_suggestions_{512U};
+    unsigned reverse_geocode_max_results_{512U};
   };
   limits get_limits() const { return limits_.value_or(limits{}); }
   std::optional<limits> limits_{};

--- a/src/endpoints/adr/geocode.cc
+++ b/src/endpoints/adr/geocode.cc
@@ -82,13 +82,12 @@ api::geocode_response geocode::operator()(
                     }}};
               })
           .value_or(std::function<bool(adr::place_idx_t)>{});
-  auto const config_limit = config_.get_limits().geocode_max_suggestions_;
-  auto const requested_limit = params.numResults_.value_or(kDefaultSuggestions);
+  auto const config_limit =
+      static_cast<std::int64_t>(config_.get_limits().geocode_max_suggestions_);
+  auto const requested_limit =
+      std::min(params.numResults_.value_or(kDefaultSuggestions), config_limit);
   utl::verify<net::bad_request_exception>(requested_limit >= 1,
                                           "limit must be >= 1");
-  utl::verify<net::bad_request_exception>(
-      requested_limit <= config_limit,
-      "limit must be <= geocode_max_suggestions ({})", config_limit);
   auto const token_pos = a::get_suggestions<false>(
       t_, params.text_, static_cast<unsigned>(requested_limit), lang_indices,
       ctx, place, static_cast<float>(params.placeBias_),

--- a/src/endpoints/adr/reverse_geocode.cc
+++ b/src/endpoints/adr/reverse_geocode.cc
@@ -19,13 +19,12 @@ constexpr auto const kDefaultResults = 5U;
 api::reverseGeocode_response reverse_geocode::operator()(
     boost::urls::url_view const& url) const {
   auto const params = api::reverseGeocode_params{url.params()};
-  auto const config_limit = config_.get_limits().reverse_geocode_max_results_;
-  auto const requested_limit = params.numResults_.value_or(kDefaultResults);
+  auto const config_limit = static_cast<std::int64_t>(
+      config_.get_limits().reverse_geocode_max_results_);
+  auto const requested_limit =
+      std::min(params.numResults_.value_or(kDefaultResults), config_limit);
   utl::verify<net::bad_request_exception>(requested_limit >= 1,
                                           "limit must be >= 1");
-  utl::verify<net::bad_request_exception>(
-      requested_limit <= config_limit,
-      "limit must be <= reverse_geocode_max_results ({})", config_limit);
   return suggestions_to_response(
       t_, f_, ae_, tt_, tags_, w_, pl_, matches_, {}, {},
       r_.lookup(t_, parse_location((params.place_))->pos_,

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -86,7 +86,7 @@ timetable:
 elevators: false
 street_routing: true
 limits:
-  stoptimes_max_results: 256
+  stoptimes_max_results: 1024
   plan_max_results: 256
   plan_max_search_window_minutes: 5760
   stops_max_results: 8192
@@ -97,8 +97,8 @@ limits:
   gtfsrt_expose_max_trip_updates: 100
   street_routing_max_prepost_transit_seconds: 3600
   street_routing_max_direct_seconds: 21600
-  geocode_max_suggestions: 10
-  reverse_geocode_max_results: 5
+  geocode_max_suggestions: 512
+  reverse_geocode_max_results: 512
 osr_footpath: true
 geocoding: true
 reverse_geocoding: false


### PR DESCRIPTION
introducing limits is a breaking change (as we learned today in production) -> clamp them where possible.
In most other places the limits we `utl::verify` are functional limits, i.e. you would get partial results, only then HTTP 400/422 is to be preferred.