### PR TITLE
Fix compiler errors on Linux builds

### DIFF
--- a/test/util.cc
+++ b/test/util.cc
@@ -71,8 +71,8 @@ transit_realtime::FeedMessage to_feed_msg(
                 }
                 if (stop_upd.time_.has_value()) {
                   auto const t = to_unix(*stop_upd.time_);
-                  upd->mutable_arrival()->set_time(t);
-                  upd->mutable_departure()->set_time(t);
+                  upd->mutable_arrival()->set_time(static_cast<signed>(t));
+                  upd->mutable_departure()->set_time(static_cast<signed>(t));
                 }
                 if (stop_upd.skip_) {
                   upd->set_schedule_relationship(

--- a/test/util.h
+++ b/test/util.h
@@ -14,9 +14,9 @@ using namespace std::chrono_literals;
 
 struct trip_descriptor {
   std::string trip_id_;
-  std::optional<std::string> start_time_;
-  std::optional<std::string> date_;
-  std::optional<std::string> route_id_;
+  std::optional<std::string> start_time_{};
+  std::optional<std::string> date_{};
+  std::optional<std::string> route_id_{};
 };
 
 struct trip_update {


### PR DESCRIPTION
Fixes the compiler errors on Linux builds, introduced by recent changes.
As each optional member is not provided for at least one test instance, providing a default seems reasonable.