### PR TITLE
fastestDirectFactor has been superseded by total non-transit duration filter

### DIFF
--- a/include/motis/journey_to_response.h
+++ b/include/motis/journey_to_response.h
@@ -23,6 +23,8 @@
 
 namespace motis {
 
+api::ModeEnum to_mode(nigiri::transport_mode_id_t);
+
 api::ModeEnum to_mode(osr::search_profile);
 
 double get_level(osr::ways const*,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -779,12 +779,12 @@ paths:
           in: query
           required: false
           description: |
-            Optional. Experimental. Default is `1.0`.
+            Optional. Experimental. Default is `10`.
             Factor with which the duration of the fastest direct non-public-transit connection is multiplied.
             Values > 1.0 allow transit connections that are slower than the fastest direct non-public-transit connection to be found.
           schema:
             type: number
-            default: 1.0
+            default: 10
             minimum: 0
 
         - name: timeout

--- a/src/direct_filter.cc
+++ b/src/direct_filter.cc
@@ -16,8 +16,13 @@ void direct_filter(std::vector<api::Itinerary> const& direct,
                    std::vector<n::routing::journey>& journeys) {
   auto const get_direct_duration = [&](auto const transport_mode_id) {
     auto const m = to_mode(transport_mode_id);
-    auto const i = utl::find_if(
-        direct, [&](auto const& d) { return d.legs_.front().mode_ == m; });
+    auto const i = utl::find_if(direct, [&](auto const& d) {
+      auto const leg_with_actual_mode =
+          d.legs_.size() > 1 && d.legs_.front().mode_ == api::ModeEnum::WALK
+              ? 1
+              : 0;
+      return d.legs_.at(leg_with_actual_mode).mode_ == m;
+    });
     return i != end(direct)
                ? n::duration_t{std::chrono::round<std::chrono::minutes>(
                      std::chrono::seconds{i->duration_})}

--- a/src/direct_filter.cc
+++ b/src/direct_filter.cc
@@ -19,8 +19,8 @@ void direct_filter(std::vector<api::Itinerary> const& direct,
     auto const i = utl::find_if(direct, [&](auto const& d) {
       auto const leg_with_actual_mode =
           d.legs_.size() > 1 && d.legs_.front().mode_ == api::ModeEnum::WALK
-              ? 1
-              : 0;
+              ? 1U
+              : 0U;
       return d.legs_.at(leg_with_actual_mode).mode_ == m;
     });
     return i != end(direct)

--- a/src/direct_filter.cc
+++ b/src/direct_filter.cc
@@ -5,6 +5,8 @@
 
 #include "nigiri/types.h"
 
+#include "motis/journey_to_response.h"
+
 namespace motis {
 
 using namespace std::chrono_literals;
@@ -13,7 +15,7 @@ namespace n = nigiri;
 void direct_filter(std::vector<api::Itinerary> const& direct,
                    std::vector<n::routing::journey>& journeys) {
   auto const get_direct_duration = [&](auto const transport_mode_id) {
-    auto const m = static_cast<api::ModeEnum>(transport_mode_id);
+    auto const m = to_mode(transport_mode_id);
     auto const i = utl::find_if(
         direct, [&](auto const& d) { return d.legs_.front().mode_ == m; });
     return i != end(direct)

--- a/src/itinerary_id.cc
+++ b/src/itinerary_id.cc
@@ -241,12 +241,7 @@ std::string generate_itinerary_id(n::routing::journey const& j,
         },
         [&](n::routing::offset const& o) {
           auto const id = o.type();
-          auto const mode =  // input mode for routing
-              flex::mode_id::is_flex(id)
-                  ? api::ModeEnum::FLEX
-                  : (id >= kGbfsTransportModeIdOffset
-                         ? api::ModeEnum::RENTAL
-                         : to_mode(static_cast<osr::search_profile>(id)));
+          auto const mode = to_mode(id);
           return make_non_pt_leg(jl, mode);
         },
         [&](n::footpath const&) {

--- a/src/journey_to_response.cc
+++ b/src/journey_to_response.cc
@@ -64,6 +64,14 @@ api::ModeEnum to_mode(osr::search_profile const m) {
   std::unreachable();
 }
 
+api::ModeEnum to_mode(n::transport_mode_id_t const id) {
+  return flex::mode_id::is_flex(id)
+             ? api::ModeEnum::FLEX
+             : (id >= kGbfsTransportModeIdOffset
+                    ? api::ModeEnum::RENTAL
+                    : to_mode(static_cast<osr::search_profile>(id)));
+}
+
 void cleanup_intermodal(api::Itinerary& i) {
   if (i.legs_.front().from_.name_ == "END") {
     i.legs_.front().from_.name_ = "START";

--- a/ui/api/openapi/types.gen.ts
+++ b/ui/api/openapi/types.gen.ts
@@ -2085,7 +2085,7 @@ export type PlanData = {
          */
         elevationCosts?: ElevationCosts;
         /**
-         * Optional. Experimental. Default is `1.0`.
+         * Optional. Experimental. Default is `10`.
          * Factor with which the duration of the fastest direct non-public-transit connection is multiplied.
          * Values > 1.0 allow transit connections that are slower than the fastest direct non-public-transit connection to be found.
          *

--- a/ui/src/lib/defaults.ts
+++ b/ui/src/lib/defaults.ts
@@ -41,7 +41,7 @@ export const defaultQuery = {
 	maxDirectTime: 1800,
 	pedestrianSpeed: 1.2,
 	cyclingSpeed: 4.2,
-	fastestDirectFactor: 1.0,
+	fastestDirectFactor: 10,
 	additionalTransferTime: undefined,
 	transferTimeFactor: 1,
 	numItineraries: 5,

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -532,7 +532,7 @@
 						withFares: true,
 						numLegAlternatives: 3,
 						slowDirect,
-						fastestDirectFactor: 1.5,
+						fastestDirectFactor: 10,
 						pedestrianProfile,
 						joinInterlinedLegs: false,
 						transitModes:


### PR DESCRIPTION
this is bad because
1) the UI default differs from the actual default so we don't usually test the actual default
2) in the current state, clients can not turn on faster direct modes by default because they will far too often dominate PT results

This reintroduces some weird cases when selecting faster modes for pre/post than for direct, since then the total non-transit duration filter (direct_filter.cc) doesn't apply. I think these are of minor importance.