### PR TITLE
Mapterhorn relative url to avoid privacy issues

### DIFF
--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -146,7 +146,11 @@ export const getStyle = (
 		? {
 				hillshadeSource: {
 					type: 'raster-dem',
-					url: 'https://tiles.mapterhorn.com/tilejson.json'
+					tiles: [getAbsoluteUrl(apiBaseUrl, 'mapterhorn/{z}/{x}/{y}.webp')],
+					attribution: "<a href='https://mapterhorn.com/attribution'>© Mapterhorn</a>",
+					bounds: [-180, -85.0511287, 180, 85.0511287],
+					encoding: 'terrarium',
+					tileSize: 512
 				} satisfies RasterDEMSourceSpecification
 			}
 		: {};

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1158,6 +1158,9 @@
 			<div class="maplibregl-ctrl maplibregl-ctrl-attrib">
 				<div class="maplibregl-ctrl-attrib-inner">
 					&copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>
+					{#if withHillshades}
+						| <a href="https://mapterhorn.com/attribution" target="_blank">Mapterhorn</a>
+					{/if}
 					{#if dataAttributionLink}
 						| <a href={dataAttributionLink} target="_blank">{t.timetableSources}</a>
 					{/if}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 			'/mapterhorn/': {
 				changeOrigin: true,
 				target: 'https://tiles.mapterhorn.com',
-				rewrite: (path) => path.replace(/^\/mapterhorn/, ''),
+				rewrite: (path) => path.replace(/^\/mapterhorn/, '')
 			}
 		}
 	},

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -6,7 +6,14 @@ export default defineConfig({
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	},
 	server: {
-		fs: { strict: false }
+		fs: { strict: false },
+		proxy: {
+			'/mapterhorn/': {
+				changeOrigin: true,
+				target: 'https://tiles.mapterhorn.com',
+				rewrite: (path) => path.replace(/^\/mapterhorn/, ''),
+			}
+		}
 	},
 	build: {
 		sourcemap: true,


### PR DESCRIPTION
for dev purposes you may use in your vite.config.ts: 
```
proxy: {
			'/mapterhorn/': {
				changeOrigin: true,
				target: 'https://api.transitous.org'
			}
}
```