### PR TITLE
GBFS: More metrics and robustness

### DIFF
--- a/include/motis/gbfs/data.h
+++ b/include/motis/gbfs/data.h
@@ -38,12 +38,6 @@
 
 namespace motis::gbfs {
 
-enum class gbfs_version : std::uint8_t {
-  k1 = 0,
-  k2 = 1,
-  k3 = 2,
-};
-
 using vehicle_type_idx_t =
     cista::strong<std::uint16_t, struct vehicle_type_idx_>;
 
@@ -219,7 +213,6 @@ struct zone {
 };
 
 struct geofencing_zones {
-  gbfs_version version_{};
   std::vector<zone> zones_;
   std::vector<rule> global_rules_;
 
@@ -401,6 +394,13 @@ struct gbfs_provider {
   std::chrono::system_clock::time_point last_updated_{};
 
   std::optional<std::string> color_{};
+
+  std::uint64_t skipped_station_infos_{};
+  std::uint64_t skipped_station_status_{};
+  std::uint64_t skipped_vehicle_types_{};
+  std::uint64_t skipped_vehicle_status_{};
+  std::uint64_t skipped_geofencing_zones_{};
+  std::uint64_t skipped_geofencing_rules_{};
 };
 
 struct gbfs_group {

--- a/include/motis/gbfs/data.h
+++ b/include/motis/gbfs/data.h
@@ -398,6 +398,7 @@ struct gbfs_provider {
   vector_map<gbfs_products_idx_t, provider_products> products_;
   bool has_vehicles_to_rent_{};
   geo::box bbox_{};
+  std::chrono::system_clock::time_point last_updated_{};
 
   std::optional<std::string> color_{};
 };

--- a/include/motis/gbfs/parser.h
+++ b/include/motis/gbfs/parser.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+#include <optional>
 #include <string>
 
 #include "boost/json.hpp"
@@ -11,6 +13,9 @@ namespace motis::gbfs {
 
 hash_map<std::string, std::string> parse_discovery(
     boost::json::value const& root);
+
+std::optional<std::chrono::system_clock::time_point> parse_timestamp(
+    boost::json::value const& val);
 
 std::optional<return_constraint> parse_return_constraint(std::string_view s);
 

--- a/include/motis/gbfs/parser.h
+++ b/include/motis/gbfs/parser.h
@@ -17,6 +17,12 @@ hash_map<std::string, std::string> parse_discovery(
 std::optional<std::chrono::system_clock::time_point> parse_timestamp(
     boost::json::value const& val);
 
+std::optional<std::string> as_string(boost::json::value const&);
+
+std::string optional_str(boost::json::object const&, std::string_view);
+
+std::optional<double> as_double(boost::json::value const&);
+
 std::optional<return_constraint> parse_return_constraint(std::string_view s);
 
 void load_system_information(gbfs_provider&, boost::json::value const& root);

--- a/include/motis/metrics_registry.h
+++ b/include/motis/metrics_registry.h
@@ -46,6 +46,7 @@ struct metrics_registry {
   prometheus::Gauge& last_update_gbfs_;
   prometheus::Family<prometheus::Gauge>& gbfs_last_update_timestamp_seconds_;
   prometheus::Family<prometheus::Gauge>& gbfs_feed_timestamp_seconds_;
+  prometheus::Family<prometheus::Gauge>& gbfs_vehicle_count_;
   prometheus::Family<prometheus::Counter>& gbfs_fetch_errors_total_;
   prometheus::Family<prometheus::Counter>& gbfs_skipped_entries_total_;
 

--- a/include/motis/metrics_registry.h
+++ b/include/motis/metrics_registry.h
@@ -46,6 +46,8 @@ struct metrics_registry {
   prometheus::Gauge& last_update_gbfs_;
   prometheus::Family<prometheus::Gauge>& gbfs_last_update_timestamp_seconds_;
   prometheus::Family<prometheus::Gauge>& gbfs_feed_timestamp_seconds_;
+  prometheus::Family<prometheus::Counter>& gbfs_fetch_errors_total_;
+  prometheus::Family<prometheus::Counter>& gbfs_skipped_entries_total_;
 
 private:
   metrics_registry(prometheus::Histogram::BucketBoundaries event_boundaries,

--- a/include/motis/metrics_registry.h
+++ b/include/motis/metrics_registry.h
@@ -45,6 +45,7 @@ struct metrics_registry {
   prometheus::Gauge& last_update_rt_;
   prometheus::Gauge& last_update_gbfs_;
   prometheus::Family<prometheus::Gauge>& gbfs_last_update_timestamp_seconds_;
+  prometheus::Family<prometheus::Gauge>& gbfs_feed_timestamp_seconds_;
 
 private:
   metrics_registry(prometheus::Histogram::BucketBoundaries event_boundaries,

--- a/include/motis/metrics_registry.h
+++ b/include/motis/metrics_registry.h
@@ -44,6 +44,7 @@ struct metrics_registry {
   prometheus::Family<prometheus::Gauge>& last_update_;
   prometheus::Gauge& last_update_rt_;
   prometheus::Gauge& last_update_gbfs_;
+  prometheus::Family<prometheus::Gauge>& gbfs_last_update_timestamp_seconds_;
 
 private:
   metrics_registry(prometheus::Histogram::BucketBoundaries event_boundaries,

--- a/src/endpoints/metrics.cc
+++ b/src/endpoints/metrics.cc
@@ -138,12 +138,15 @@ void update_all_runs_metrics(nigiri::timetable const& tt,
 }
 
 net::reply metrics::operator()(net::route_request const& req, bool) const {
-  utl::verify(metrics_ != nullptr && tt_ != nullptr && tags_ != nullptr,
-              "no metrics initialized");
+  utl::verify(metrics_ != nullptr, "no metrics initialized");
   auto const rt = std::atomic_load(&rt_);
-  update_all_runs_metrics(*tt_, rt->rtt_.get(), *tags_, *metrics_);
-  metrics_->total_trips_with_realtime_count_.Set(
-      static_cast<double>(rt->rtt_->rt_transport_src_.size()));
+  if (tt_ != nullptr && tags_ != nullptr) {
+    update_all_runs_metrics(*tt_, rt->rtt_.get(), *tags_, *metrics_);
+  }
+  if (rt != nullptr && rt->rtt_ != nullptr) {
+    metrics_->total_trips_with_realtime_count_.Set(
+        static_cast<double>(rt->rtt_->rt_transport_src_.size()));
+  }
   auto res = net::web_server::string_res_t{boost::beast::http::status::ok,
                                            req.version()};
   res.insert(boost::beast::http::field::content_type,

--- a/src/gbfs/parser.cc
+++ b/src/gbfs/parser.cc
@@ -1,7 +1,11 @@
 #include <algorithm>
+#include <chrono>
 #include <optional>
+#include <sstream>
 #include <string_view>
 #include <vector>
+
+#include "date/date.h"
 
 #include "motis/gbfs/parser.h"
 
@@ -14,6 +18,37 @@
 namespace json = boost::json;
 
 namespace motis::gbfs {
+
+std::optional<std::chrono::system_clock::time_point> parse_timestamp(
+    json::value const& val) {
+  if (val.is_int64()) {
+    return std::chrono::system_clock::time_point{
+        std::chrono::seconds{val.to_number<std::int64_t>()}};
+  }
+  if (val.is_uint64()) {
+    return std::chrono::system_clock::time_point{std::chrono::seconds{
+        static_cast<std::int64_t>(val.to_number<std::uint64_t>())}};
+  }
+  if (val.is_string()) {
+    auto const s = std::string{val.as_string()};
+    auto tp = std::chrono::system_clock::time_point{};
+    auto iss = std::istringstream{s};
+    if (iss >> date::parse("%FT%T%Ez", tp); !iss.fail()) {
+      return tp;
+    }
+    iss.clear();
+    iss.str(s);
+    if (iss >> date::parse("%FT%T%z", tp); !iss.fail()) {
+      return tp;
+    }
+    iss.clear();
+    iss.str(s);
+    if (iss >> date::parse("%FT%T", tp); !iss.fail()) {
+      return tp;
+    }
+  }
+  return std::nullopt;
+}
 
 gbfs_version get_version(json::value const& root) {
   auto const& root_obj = root.as_object();

--- a/src/gbfs/parser.cc
+++ b/src/gbfs/parser.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <optional>
 #include <sstream>
 #include <string_view>
@@ -12,12 +13,51 @@
 #include "cista/hash.h"
 
 #include "utl/helpers/algorithm.h"
+#include "utl/parser/arg_parser.h"
 #include "utl/raii.h"
 #include "utl/to_vec.h"
 
 namespace json = boost::json;
 
 namespace motis::gbfs {
+
+std::optional<std::string> as_string(json::value const& v) {
+  if (v.is_string()) {
+    return static_cast<std::string>(v.as_string());
+  } else if (v.is_int64()) {
+    return std::to_string(v.as_int64());
+  } else if (v.is_uint64()) {
+    return std::to_string(v.as_uint64());
+  } else if (v.is_double()) {
+    return std::to_string(v.as_double());
+  }
+  return std::nullopt;
+}
+
+std::optional<double> as_double(json::value const& v) {
+  if (v.is_double()) {
+    return v.as_double();
+  } else if (v.is_int64()) {
+    return static_cast<double>(v.as_int64());
+  } else if (v.is_uint64()) {
+    return static_cast<double>(v.as_uint64());
+  } else if (v.is_string()) {
+    auto const s = std::string{v.as_string()};
+    auto c = utl::cstr{s.c_str(), s.size()};
+    auto d = double{};
+    if (utl::parse_fp(c, d) && c.len == 0) {
+      return d;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<unsigned> as_count(json::value const& v) {
+  if (auto const d = as_double(v); d) {
+    return static_cast<unsigned>(std::max(0.0, *d));
+  }
+  return std::nullopt;
+}
 
 std::optional<std::chrono::system_clock::time_point> parse_timestamp(
     json::value const& val) {
@@ -31,6 +71,12 @@ std::optional<std::chrono::system_clock::time_point> parse_timestamp(
   }
   if (val.is_string()) {
     auto const s = std::string{val.as_string()};
+    auto* end = static_cast<char*>(nullptr);
+    auto const ts = std::strtoll(s.c_str(), &end, 10);
+    if (end != s.c_str() && *end == '\0') {
+      return std::chrono::system_clock::time_point{std::chrono::seconds{ts}};
+    }
+
     auto tp = std::chrono::system_clock::time_point{};
     auto iss = std::istringstream{s};
     if (iss >> date::parse("%FT%T%Ez", tp); !iss.fail()) {
@@ -50,31 +96,24 @@ std::optional<std::chrono::system_clock::time_point> parse_timestamp(
   return std::nullopt;
 }
 
-gbfs_version get_version(json::value const& root) {
-  auto const& root_obj = root.as_object();
-  if (!root_obj.contains("version")) {
-    // 1.0 doesn't have the version key
-    return gbfs_version::k1;
+std::string optional_str(json::object const& obj, std::string_view key) {
+  auto const it = obj.find(key);
+  if (it == obj.end()) {
+    return "";
   }
-  auto const version =
-      static_cast<std::string_view>(root.at("version").as_string());
-  if (version.starts_with("1.")) {
-    return gbfs_version::k1;
-  } else if (version.starts_with("2.")) {
-    return gbfs_version::k2;
-  } else if (version.starts_with("3.")) {
-    return gbfs_version::k3;
-  } else {
-    throw utl::fail("unsupported GBFS version: {}", version);
-  }
+  return as_string(it->value()).value_or("");
 }
 
 std::string get_localized_string(json::value const& v) {
   if (v.is_array()) {
-    auto const& arr = v.as_array();
-    if (!arr.empty()) {
-      return static_cast<std::string>(
-          arr[0].as_object().at("text").as_string());
+    for (auto const& entry : v.as_array()) {
+      if (!entry.is_object()) {
+        continue;
+      }
+      auto const text = optional_str(entry.as_object(), "text");
+      if (!text.empty()) {
+        return text;
+      }
     }
     return "";
   } else if (v.is_string()) {
@@ -84,23 +123,6 @@ std::string get_localized_string(json::value const& v) {
   }
 }
 
-std::string get_as_string(json::object const& obj, std::string_view const key) {
-  auto const val = obj.at(key);
-  if (val.is_string()) {
-    return static_cast<std::string>(val.as_string());
-  } else if (val.is_int64()) {
-    return std::to_string(val.as_int64());
-  } else if (val.is_uint64()) {
-    return std::to_string(val.as_uint64());
-  } else {
-    return json::serialize(val);
-  }
-}
-
-std::string optional_str(json::object const& obj, std::string_view key) {
-  return obj.contains(key) ? get_as_string(obj, key) : "";
-}
-
 std::string optional_localized_str(json::object const& obj,
                                    std::string_view key) {
   return obj.contains(key) ? get_localized_string(obj.at(key)) : "";
@@ -108,17 +130,27 @@ std::string optional_localized_str(json::object const& obj,
 
 bool get_bool(json::object const& obj,
               std::string_view const key,
-              std::optional<bool> const def = std::nullopt) {
-  if (!obj.contains(key) && def.has_value()) {
-    return *def;
+              bool const def) {
+  auto const it = obj.find(key);
+  if (it == obj.end()) {
+    return def;
   }
-  auto const val = obj.at(key);
+  auto const& val = it->value();
   if (val.is_bool()) {
     return val.as_bool();
   } else if (val.is_number()) {
     return val.to_number<int>() == 1;
+  } else if (val.is_string()) {
+    auto const s = std::string_view{val.as_string()};
+    if (s == "true" || s == "1" || s == "yes") {
+      return true;
+    }
+    if (s == "false" || s == "0" || s == "no") {
+      return false;
+    }
+    return def;
   } else {
-    return *def;
+    return def;
   }
 }
 
@@ -145,7 +177,11 @@ tg_geom* parse_multipolygon(json::object const& json) {
       auto points = utl::to_vec(j_ring.as_array(), [&](auto const& j_pt) {
         auto const& j_pt_arr = j_pt.as_array();
         utl::verify(j_pt_arr.size() >= 2, "invalid point in polygon ring");
-        return tg_point{j_pt_arr[0].as_double(), j_pt_arr[1].as_double()};
+        auto const x = as_double(j_pt_arr[0]);
+        auto const y = as_double(j_pt_arr[1]);
+        utl::verify(x.has_value() && y.has_value(),
+                    "invalid point in polygon ring");
+        return tg_point{*x, *y};
       });
       utl::verify(points.size() > 2, "empty ring in polygon");
       // handle invalid polygons that don't have closed rings
@@ -179,16 +215,39 @@ hash_map<std::string, std::string> parse_discovery(json::value const& root) {
   if (data.empty()) {
     return urls;
   }
-  auto const& feeds =
-      data.contains("feeds")
-          ? data.at("feeds").as_array()
-          : data.begin()->value().as_object().at("feeds").as_array();
 
-  for (auto const& feed : feeds) {
-    auto const& name =
-        static_cast<std::string>(feed.as_object().at("name").as_string());
-    auto const& url =
-        static_cast<std::string>(feed.as_object().at("url").as_string());
+  auto const* feeds = static_cast<json::array const*>(nullptr);
+  if (auto const it = data.find("feeds");
+      it != data.end() && it->value().is_array()) {
+    feeds = &it->value().as_array();
+  } else {
+    for (auto const& [_, lang] : data) {
+      if (!lang.is_object()) {
+        continue;
+      }
+      auto const& lang_obj = lang.as_object();
+      if (auto const feeds_it = lang_obj.find("feeds");
+          feeds_it != lang_obj.end() && feeds_it->value().is_array()) {
+        feeds = &feeds_it->value().as_array();
+        break;
+      }
+    }
+  }
+
+  if (feeds == nullptr) {
+    return urls;
+  }
+
+  for (auto const& feed : *feeds) {
+    if (!feed.is_object()) {
+      continue;
+    }
+    auto const& feed_obj = feed.as_object();
+    auto const name = optional_str(feed_obj, "name");
+    auto const url = optional_str(feed_obj, "url");
+    if (name.empty() || url.empty()) {
+      continue;
+    }
     urls[name] = url;
   }
   return urls;
@@ -197,8 +256,9 @@ hash_map<std::string, std::string> parse_discovery(json::value const& root) {
 rental_uris parse_rental_uris(json::object const& parent) {
   auto uris = rental_uris{};
 
-  if (parent.contains("rental_uris")) {
-    auto const& o = parent.at("rental_uris").as_object();
+  if (auto const it = parent.find("rental_uris");
+      it != parent.end() && it->value().is_object()) {
+    auto const& o = it->value().as_object();
     uris.android_ = optional_str(o, "android");
     uris.ios_ = optional_str(o, "ios");
     uris.web_ = optional_str(o, "web");
@@ -252,15 +312,22 @@ void load_system_information(gbfs_provider& provider, json::value const& root) {
   auto const& data = root.at("data").as_object();
 
   auto& si = provider.sys_info_;
-  si.id_ = static_cast<std::string>(data.at("system_id").as_string());
-  si.name_ = get_localized_string(data.at("name"));
+  si.id_ = optional_str(data, "system_id");
+  if (si.id_.empty()) {
+    si.id_ = provider.id_;
+  }
+  si.name_ = optional_localized_str(data, "name");
+  if (si.name_.empty()) {
+    si.name_ = provider.id_;
+  }
   si.name_short_ = optional_localized_str(data, "name_short");
   si.operator_ = optional_localized_str(data, "operator");
   si.url_ = optional_str(data, "url");
   si.purchase_url_ = optional_str(data, "purchase_url");
   si.mail_ = optional_str(data, "email");
-  if (data.contains("brand_assets")) {
-    auto const& ba = data.at("brand_assets").as_object();
+  if (auto const it = data.find("brand_assets");
+      it != data.end() && it->value().is_object()) {
+    auto const& ba = it->value().as_object();
     si.color_ = optional_str(ba, "color");
   } else {
     si.color_ = "";
@@ -269,51 +336,67 @@ void load_system_information(gbfs_provider& provider, json::value const& root) {
 
 void load_station_information(gbfs_provider& provider,
                               json::value const& root) {
+  auto const& stations_arr = root.at("data").at("stations").as_array();
+
   provider.stations_.clear();
 
-  auto const& stations_arr = root.at("data").at("stations").as_array();
   for (auto const& s : stations_arr) {
-    auto const& station_obj = s.as_object();
-    auto const station_id = get_as_string(station_obj, "station_id");
-    try {
-      auto const name = get_localized_string(station_obj.at("name"));
-      auto const lat = station_obj.at("lat").as_double();
-      auto const lon = station_obj.at("lon").as_double();
-
-      tg_geom* area = nullptr;
-      if (station_obj.contains("station_area")) {
-        try {
-          area = parse_multipolygon(station_obj.at("station_area").as_object());
-        } catch (std::exception const& ex) {
-          std::cerr << "[GBFS] (" << provider.id_
-                    << ") invalid station_area: " << ex.what() << "\n";
-        }
-      }
-
-      provider.stations_[station_id] = station{
-          .info_ = {.id_ = station_id,
-                    .name_ = name,
-                    .pos_ = geo::latlng{lat, lon},
-                    .address_ = optional_str(station_obj, "address"),
-                    .cross_street_ = optional_str(station_obj, "cross_street"),
-                    .rental_uris_ = parse_rental_uris(station_obj),
-                    .station_area_ =
-                        std::shared_ptr<tg_geom>(area, tg_geom_deleter{})}};
-    } catch (std::exception const& ex) {
-      std::cerr << "[GBFS] (" << provider.id_ << ") error parsing station "
-                << station_id << ": " << ex.what() << "\n";
+    if (!s.is_object()) {
+      ++provider.skipped_station_infos_;
+      continue;
     }
+    auto const& station_obj = s.as_object();
+    auto const station_id = optional_str(station_obj, "station_id");
+    auto const lat = station_obj.contains("lat")
+                         ? as_double(station_obj.at("lat"))
+                         : std::nullopt;
+    auto const lon = station_obj.contains("lon")
+                         ? as_double(station_obj.at("lon"))
+                         : std::nullopt;
+    if (station_id.empty() || !lat || !lon) {
+      ++provider.skipped_station_infos_;
+      continue;
+    }
+
+    auto const name = optional_localized_str(station_obj, "name");
+
+    tg_geom* area = nullptr;
+    if (auto const it = station_obj.find("station_area");
+        it != station_obj.end() && it->value().is_object()) {
+      try {
+        area = parse_multipolygon(it->value().as_object());
+      } catch (std::exception const& ex) {
+        std::cerr << "[GBFS] (" << provider.id_
+                  << ") invalid station_area: " << ex.what() << "\n";
+      }
+    }
+
+    provider.stations_[station_id] = station{
+        .info_ = {.id_ = station_id,
+                  .name_ = name,
+                  .pos_ = geo::latlng{*lat, *lon},
+                  .address_ = optional_str(station_obj, "address"),
+                  .cross_street_ = optional_str(station_obj, "cross_street"),
+                  .rental_uris_ = parse_rental_uris(station_obj),
+                  .station_area_ =
+                      std::shared_ptr<tg_geom>(area, tg_geom_deleter{})}};
   }
 }
 
 void load_station_status(gbfs_provider& provider, json::value const& root) {
   auto const& stations_arr = root.at("data").at("stations").as_array();
+
   for (auto const& s : stations_arr) {
+    if (!s.is_object()) {
+      ++provider.skipped_station_status_;
+      continue;
+    }
     auto const& station_obj = s.as_object();
-    auto const station_id = get_as_string(station_obj, "station_id");
+    auto const station_id = optional_str(station_obj, "station_id");
 
     auto const station_it = provider.stations_.find(station_id);
     if (station_it == end(provider.stations_)) {
+      ++provider.skipped_station_status_;
       continue;
     }
 
@@ -326,26 +409,38 @@ void load_station_status(gbfs_provider& provider, json::value const& root) {
     if (station_obj.contains("num_vehicles_available")) {
       // GBFS 3.x (but some 2.x feeds use this as well)
       station.status_.num_vehicles_available_ =
-          station_obj.at("num_vehicles_available").to_number<unsigned>();
+          as_count(station_obj.at("num_vehicles_available")).value_or(0U);
     } else if (station_obj.contains("num_bikes_available")) {
       // GBFS 2.x
       station.status_.num_vehicles_available_ =
-          station_obj.at("num_bikes_available").to_number<unsigned>();
+          as_count(station_obj.at("num_bikes_available")).value_or(0U);
     }
 
-    if (station_obj.contains("vehicle_types_available")) {
-      auto const& vta = station_obj.at("vehicle_types_available").as_array();
+    if (auto const it = station_obj.find("vehicle_types_available");
+        it != station_obj.end() && it->value().is_array()) {
+      auto const& vta = it->value().as_array();
       auto unrestricted_available = 0U;
       auto any_station_available = 0U;
       auto roundtrip_available = 0U;
+      auto has_typed_availability = false;
       for (auto const& vt : vta) {
-        auto const vehicle_type_id =
-            static_cast<std::string>(vt.at("vehicle_type_id").as_string());
-        auto const count =
-            static_cast<unsigned>(std::max(0, vt.at("count").to_number<int>()));
+        if (!vt.is_object()) {
+          ++provider.skipped_station_status_;
+          continue;
+        }
+        auto const& vt_obj = vt.as_object();
+        auto const vehicle_type_id = optional_str(vt_obj, "vehicle_type_id");
+        if (vehicle_type_id.empty()) {
+          ++provider.skipped_station_status_;
+          continue;
+        }
+        auto const count = vt_obj.contains("count")
+                               ? as_count(vt_obj.at("count")).value_or(0U)
+                               : 0U;
         if (auto const vt_idx = get_vehicle_type(provider, vehicle_type_id,
                                                  vehicle_start_type::kStation);
             vt_idx) {
+          has_typed_availability = true;
           station.status_.vehicle_types_available_[*vt_idx] = count;
           switch (provider.vehicle_types_[*vt_idx].return_constraint_) {
             case return_constraint::kFreeFloating:
@@ -360,8 +455,11 @@ void load_station_status(gbfs_provider& provider, json::value const& root) {
           }
         }
       }
-      station.status_.num_vehicles_available_ =
-          unrestricted_available + any_station_available + roundtrip_available;
+      if (has_typed_availability) {
+        station.status_.num_vehicles_available_ = unrestricted_available +
+                                                  any_station_available +
+                                                  roundtrip_available;
+      }
     } else {
       if (auto const vt_idx =
               get_vehicle_type(provider, "", vehicle_start_type::kStation);
@@ -371,21 +469,30 @@ void load_station_status(gbfs_provider& provider, json::value const& root) {
       }
     }
 
-    if (station_obj.contains("vehicle_docks_available")) {
-      for (auto const& vt :
-           station_obj.at("vehicle_docks_available").as_array()) {
-        auto& vto = vt.as_object();
-        if (vto.contains("vehicle_type_ids") && vto.contains("count")) {
-          for (auto const& vti : vto.at("vehicle_type_ids").as_array()) {
-            auto const vehicle_type_id =
-                static_cast<std::string>(vti.as_string());
-            if (auto const vt_idx = get_vehicle_type(
-                    provider, vehicle_type_id, vehicle_start_type::kStation);
-                vt_idx) {
-              station.status_.vehicle_docks_available_[*vt_idx] =
-                  static_cast<unsigned>(
-                      std::max(0, vto.at("count").to_number<int>()));
-            }
+    if (auto const it = station_obj.find("vehicle_docks_available");
+        it != station_obj.end() && it->value().is_array()) {
+      for (auto const& vt : it->value().as_array()) {
+        if (!vt.is_object()) {
+          ++provider.skipped_station_status_;
+          continue;
+        }
+        auto const& vto = vt.as_object();
+        if (!vto.contains("vehicle_type_ids") || !vto.contains("count") ||
+            !vto.at("vehicle_type_ids").is_array()) {
+          ++provider.skipped_station_status_;
+          continue;
+        }
+        auto const count = as_count(vto.at("count")).value_or(0U);
+        for (auto const& vti : vto.at("vehicle_type_ids").as_array()) {
+          auto const vehicle_type_id = as_string(vti).value_or("");
+          if (vehicle_type_id.empty()) {
+            ++provider.skipped_station_status_;
+            continue;
+          }
+          if (auto const vt_idx = get_vehicle_type(
+                  provider, vehicle_type_id, vehicle_start_type::kStation);
+              vt_idx) {
+            station.status_.vehicle_docks_available_[*vt_idx] = count;
           }
         }
       }
@@ -444,24 +551,35 @@ std::optional<return_constraint> parse_return_constraint(
 std::optional<return_constraint> parse_return_constraint(
     json::object const& vt) {
   if (vt.contains("return_constraint")) {
-    return parse_return_constraint(vt.at("return_constraint").as_string());
+    return parse_return_constraint(optional_str(vt, "return_constraint"));
   }
   return {};
 }
 
 void load_vehicle_types(gbfs_provider& provider, json::value const& root) {
+  auto const& vehicle_types = root.at("data").at("vehicle_types").as_array();
+
   provider.vehicle_types_.clear();
   provider.vehicle_types_map_.clear();
   provider.temp_vehicle_types_.clear();
-  for (auto const& v : root.at("data").at("vehicle_types").as_array()) {
-    auto const id =
-        static_cast<std::string>(v.at("vehicle_type_id").as_string());
-    auto const name = optional_localized_str(v.as_object(), "name");
-    auto const rc = parse_return_constraint(v.as_object());
+
+  for (auto const& v : vehicle_types) {
+    if (!v.is_object()) {
+      ++provider.skipped_vehicle_types_;
+      continue;
+    }
+    auto const& vt_obj = v.as_object();
+    auto const id = optional_str(vt_obj, "vehicle_type_id");
+    if (id.empty()) {
+      ++provider.skipped_vehicle_types_;
+      continue;
+    }
+    auto const name = optional_localized_str(vt_obj, "name");
+    auto const rc = parse_return_constraint(vt_obj);
     auto const form_factor =
-        parse_form_factor(optional_str(v.as_object(), "form_factor"));
+        parse_form_factor(optional_str(vt_obj, "form_factor"));
     auto const propulsion_type =
-        parse_propulsion_type(optional_str(v.as_object(), "propulsion_type"));
+        parse_propulsion_type(optional_str(vt_obj, "propulsion_type"));
     if (rc) {
       auto const idx = vehicle_type_idx_t{provider.vehicle_types_.size()};
       provider.vehicle_types_.emplace_back(
@@ -487,39 +605,56 @@ void load_vehicle_types(gbfs_provider& provider, json::value const& root) {
 }
 
 void load_vehicle_status(gbfs_provider& provider, json::value const& root) {
+  auto const& data = root.at("data").as_object();
+  auto const get_array = [&](std::string_view const key) {
+    auto const it = data.find(key);
+    return it != data.end() && it->value().is_array() ? &it->value().as_array()
+                                                      : nullptr;
+  };
+  auto const* vehicles_arr = get_array("vehicles");
+  vehicles_arr = vehicles_arr != nullptr ? vehicles_arr : get_array("bikes");
+  utl::verify(vehicles_arr != nullptr, "missing vehicles/bikes array");
+
   provider.vehicle_status_.clear();
 
-  auto const version = get_version(root);
-  auto const& vehicles_arr =
-      root.at("data")
-          .at(version == gbfs_version::k3 ? "vehicles" : "bikes")
-          .as_array();
-  for (auto const& v : vehicles_arr) {
+  for (auto const& v : *vehicles_arr) {
+    if (!v.is_object()) {
+      ++provider.skipped_vehicle_status_;
+      continue;
+    }
     auto const& vehicle_obj = v.as_object();
 
     auto pos = geo::latlng{};
     if (vehicle_obj.contains("lat") && vehicle_obj.contains("lon")) {
-      auto const lat = vehicle_obj.at("lat");
-      auto const lon = vehicle_obj.at("lon");
-      if (!lat.is_double() || !lon.is_double()) {
+      auto const lat = as_double(vehicle_obj.at("lat"));
+      auto const lon = as_double(vehicle_obj.at("lon"));
+      if (!lat || !lon) {
+        ++provider.skipped_vehicle_status_;
         continue;
       }
-      pos = geo::latlng{vehicle_obj.at("lat").as_double(),
-                        vehicle_obj.at("lon").as_double()};
+      pos = geo::latlng{*lat, *lon};
     } else if (vehicle_obj.contains("station_id")) {
-      auto const station_id = get_as_string(vehicle_obj, "station_id");
+      auto const station_id = optional_str(vehicle_obj, "station_id");
       if (auto const it = provider.stations_.find(station_id);
           it != end(provider.stations_)) {
         pos = it->second.info_.pos_;
       } else {
+        ++provider.skipped_vehicle_status_;
         continue;
       }
     } else {
+      ++provider.skipped_vehicle_status_;
       continue;
     }
 
-    auto const id = get_as_string(
-        vehicle_obj, version == gbfs_version::k3 ? "vehicle_id" : "bike_id");
+    auto id = optional_str(vehicle_obj, "vehicle_id");
+    if (id.empty()) {
+      id = optional_str(vehicle_obj, "bike_id");
+    }
+    if (id.empty()) {
+      ++provider.skipped_vehicle_status_;
+      continue;
+    }
 
     auto const type_id = optional_str(vehicle_obj, "vehicle_type_id");
     auto type_idx = vehicle_type_idx_t::invalid();
@@ -544,64 +679,106 @@ void load_vehicle_status(gbfs_provider& provider, json::value const& root) {
   utl::sort(provider.vehicle_status_);
 }
 
-rule parse_rule(gbfs_provider& provider,
-                gbfs_version const version,
-                json::value const& r) {
-  auto const vti_key =
-      version == gbfs_version::k2 ? "vehicle_type_id" : "vehicle_type_ids";
+rule parse_rule(gbfs_provider& provider, json::value const& r) {
   auto const& rule_obj = r.as_object();
 
   auto vehicle_type_idxs = std::vector<vehicle_type_idx_t>{};
-  if (rule_obj.contains(vti_key)) {
-    for (auto const& vt : rule_obj.at(vti_key).as_array()) {
-      auto const vt_id = static_cast<std::string>(vt.as_string());
-      if (auto const it = provider.vehicle_types_map_.find(
-              {vt_id, vehicle_start_type::kStation});
-          it != end(provider.vehicle_types_map_)) {
-        vehicle_type_idxs.emplace_back(it->second);
+  auto const parse_vehicle_type_ids = [](json::value const& val) {
+    auto vehicle_type_ids = std::vector<std::string>{};
+    if (val.is_array()) {
+      for (auto const& vt : val.as_array()) {
+        if (auto const vt_id = as_string(vt); vt_id) {
+          vehicle_type_ids.emplace_back(*vt_id);
+        }
       }
-      if (auto const it = provider.vehicle_types_map_.find(
-              {vt_id, vehicle_start_type::kFreeFloating});
-          it != end(provider.vehicle_types_map_)) {
-        vehicle_type_idxs.emplace_back(it->second);
-      }
+    } else if (auto const vt_id = as_string(val); vt_id) {
+      vehicle_type_ids.emplace_back(*vt_id);
+    }
+    return vehicle_type_ids;
+  };
+
+  auto vehicle_type_ids = std::vector<std::string>{};
+  if (auto const it = rule_obj.find("vehicle_type_ids"); it != rule_obj.end()) {
+    vehicle_type_ids = parse_vehicle_type_ids(it->value());
+  }
+  if (vehicle_type_ids.empty()) {
+    if (auto const it = rule_obj.find("vehicle_type_id");
+        it != rule_obj.end()) {
+      vehicle_type_ids = parse_vehicle_type_ids(it->value());
     }
   }
 
+  for (auto const& vt_id : vehicle_type_ids) {
+    if (auto const station_vt_it = provider.vehicle_types_map_.find(
+            {vt_id, vehicle_start_type::kStation});
+        station_vt_it != end(provider.vehicle_types_map_)) {
+      vehicle_type_idxs.emplace_back(station_vt_it->second);
+    }
+    if (auto const free_floating_vt_it = provider.vehicle_types_map_.find(
+            {vt_id, vehicle_start_type::kFreeFloating});
+        free_floating_vt_it != end(provider.vehicle_types_map_)) {
+      vehicle_type_idxs.emplace_back(free_floating_vt_it->second);
+    }
+  }
+
+  auto const ride_allowed = get_bool(rule_obj, "ride_allowed", true);
   return rule{
       .vehicle_type_idxs_ = std::move(vehicle_type_idxs),
-      .ride_start_allowed_ = version == gbfs_version::k2
-                                 ? rule_obj.at("ride_allowed").as_bool()
-                                 : rule_obj.at("ride_start_allowed").as_bool(),
-      .ride_end_allowed_ = version == gbfs_version::k2
-                               ? rule_obj.at("ride_allowed").as_bool()
-                               : rule_obj.at("ride_end_allowed").as_bool(),
-      .ride_through_allowed_ = rule_obj.at("ride_through_allowed").as_bool(),
+      .ride_start_allowed_ =
+          get_bool(rule_obj, "ride_start_allowed", ride_allowed),
+      .ride_end_allowed_ = get_bool(rule_obj, "ride_end_allowed", ride_allowed),
+      .ride_through_allowed_ =
+          get_bool(rule_obj, "ride_through_allowed", ride_allowed),
       .station_parking_ =
           rule_obj.contains("station_parking")
-              ? std::optional{rule_obj.at("station_parking").as_bool()}
+              ? std::optional{get_bool(rule_obj, "station_parking", false)}
               : std::nullopt};
 }
 
 void load_geofencing_zones(gbfs_provider& provider, json::value const& root) {
-  auto const version = get_version(root);
-
-  auto const& zones_obj = root.at("data").at("geofencing_zones").as_object();
-  utl::verify(zones_obj.at("type") == "FeatureCollection",
-              "invalid geofencing_zones");
+  auto const& data = root.at("data").as_object();
+  auto const it = data.find("geofencing_zones");
+  utl::verify(it != data.end() && it->value().is_object(),
+              "missing geofencing_zones object");
+  auto const& zones_obj = it->value().as_object();
+  utl::verify(optional_str(zones_obj, "type") == "FeatureCollection",
+              "geofencing_zones is not a FeatureCollection");
 
   auto zones = std::vector<zone>{};
-  auto const zones_arr = zones_obj.at("features").as_array();
+  auto const features_it = zones_obj.find("features");
+  utl::verify(features_it != zones_obj.end() && features_it->value().is_array(),
+              "missing geofencing_zones features array");
+  auto const zones_arr = features_it->value().as_array();
   zones.reserve(zones_arr.size());
   for (auto const& z : zones_arr) {
     try {
-      auto const& props = z.at("properties").as_object();
-      if (!props.contains("rules") || !props.at("rules").is_array()) {
+      if (!z.is_object()) {
+        ++provider.skipped_geofencing_zones_;
         continue;
       }
-      auto rules = utl::to_vec(
-          props.at("rules").as_array(),
-          [&](auto const& r) { return parse_rule(provider, version, r); });
+      auto const& props = z.at("properties").as_object();
+      if (!props.contains("rules") || !props.at("rules").is_array()) {
+        ++provider.skipped_geofencing_zones_;
+        continue;
+      }
+      auto rules = std::vector<rule>{};
+      for (auto const& r : props.at("rules").as_array()) {
+        try {
+          if (r.is_object()) {
+            rules.emplace_back(parse_rule(provider, r));
+          } else {
+            ++provider.skipped_geofencing_rules_;
+          }
+        } catch (std::exception const& ex) {
+          ++provider.skipped_geofencing_rules_;
+          std::cerr << "[GBFS] (" << provider.id_
+                    << ") invalid geofencing rule: " << ex.what() << "\n";
+        }
+      }
+      if (rules.empty()) {
+        ++provider.skipped_geofencing_zones_;
+        continue;
+      }
 
       auto* geom = parse_multipolygon(z.at("geometry").as_object());
 
@@ -609,21 +786,31 @@ void load_geofencing_zones(gbfs_provider& provider, json::value const& root) {
 
       zones.emplace_back(geom, std::move(rules), std::move(name));
     } catch (std::exception const& ex) {
+      ++provider.skipped_geofencing_zones_;
       std::cerr << "[GBFS] (" << provider.id_
                 << ") invalid geofencing zone: " << ex.what() << "\n";
     }
   }
 
   //  required in 3.0, but some feeds don't have it
-  auto global_rules =
-      root.at("data").as_object().contains("global_rules") &&
-              root.at("data").at("global_rules").is_array()
-          ? utl::to_vec(
-                root.at("data").at("global_rules").as_array(),
-                [&](auto const& r) { return parse_rule(provider, version, r); })
-          : std::vector<rule>{};
+  auto global_rules = std::vector<rule>{};
+  if (auto const global_rules_it = data.find("global_rules");
+      global_rules_it != data.end() && global_rules_it->value().is_array()) {
+    for (auto const& r : global_rules_it->value().as_array()) {
+      try {
+        if (r.is_object()) {
+          global_rules.emplace_back(parse_rule(provider, r));
+        } else {
+          ++provider.skipped_geofencing_rules_;
+        }
+      } catch (std::exception const& ex) {
+        ++provider.skipped_geofencing_rules_;
+        std::cerr << "[GBFS] (" << provider.id_
+                  << ") invalid global geofencing rule: " << ex.what() << "\n";
+      }
+    }
+  }
 
-  provider.geofencing_zones_.version_ = version;
   provider.geofencing_zones_.zones_ = std::move(zones);
   provider.geofencing_zones_.global_rules_ = std::move(global_rules);
 }

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -193,24 +193,8 @@ struct gbfs_update {
                                            .color_ = group.color_});
       }
 
-      auto awaitables = utl::to_vec(c_.feeds_, [&](auto const& f) {
-        auto const& id = f.first;
-        auto const& feed = f.second;
-        auto const dir =
-            feed.url_.starts_with("http:") || feed.url_.starts_with("https:")
-                ? std::nullopt
-                : std::optional<std::filesystem::path>{feed.url_};
-
-        return boost::asio::co_spawn(
-            executor,
-            [this, id, feed, dir]() -> awaitable<void> {
-              co_await init_feed(id, feed, dir);
-            },
-            asio::deferred);
-      });
-
-      co_await asio::experimental::make_parallel_group(awaitables)
-          .async_wait(asio::experimental::wait_for_all(), asio::use_awaitable);
+      co_await init_config_feeds(
+          utl::to_vec(c_.feeds_, [](auto const& f) { return f.first; }));
     } else {
       // update run: copy over data from previous state and update feeds
       // where necessary
@@ -261,13 +245,66 @@ struct gbfs_update {
             .async_wait(asio::experimental::wait_for_all(),
                         asio::use_awaitable);
       }
+
+      co_await init_missing_config_feeds();
     }
+  }
+
+  void ensure_gbfs_metrics(std::string const& id) {
+    metrics_->gbfs_last_update_timestamp_seconds_.Add({{"provider_id", id}});
+    metrics_->gbfs_feed_timestamp_seconds_.Add({{"provider_id", id}});
+  }
+
+  bool is_config_feed_initialized(std::string const& id) const {
+    return utl::any_of(*d_->standalone_feeds_,
+                       [&](auto const& pf) { return pf->id_ == id; }) ||
+           utl::any_of(*d_->aggregated_feeds_,
+                       [&](auto const& af) { return af->id_ == id; });
+  }
+
+  awaitable<void> init_missing_config_feeds() {
+    auto ids = std::vector<std::string>{};
+    for (auto const& [id, _] : c_.feeds_) {
+      if (!is_config_feed_initialized(id)) {
+        ids.emplace_back(id);
+      }
+    }
+
+    co_return co_await init_config_feeds(std::move(ids));
+  }
+
+  awaitable<void> init_config_feeds(std::vector<std::string> ids) {
+    if (ids.empty()) {
+      co_return;
+    }
+
+    auto executor = co_await asio::this_coro::executor;
+    co_await asio::experimental::make_parallel_group(
+        utl::to_vec(ids,
+                    [&](auto const& id) {
+                      auto const& feed = c_.feeds_.at(id);
+                      auto const dir =
+                          feed.url_.starts_with("http:") ||
+                                  feed.url_.starts_with("https:")
+                              ? std::nullopt
+                              : std::optional<std::filesystem::path>{feed.url_};
+
+                      return boost::asio::co_spawn(
+                          executor,
+                          [this, id, feed, dir]() -> awaitable<void> {
+                            co_await init_feed(id, feed, dir);
+                          },
+                          asio::deferred);
+                    }))
+        .async_wait(asio::experimental::wait_for_all(), asio::use_awaitable);
   }
 
   awaitable<void> init_feed(std::string const& id,
                             config::gbfs::feed const& config,
                             std::optional<std::filesystem::path> const& dir) {
     // initialization of a (standalone or aggregated) feed from the config
+    ensure_gbfs_metrics(id);
+
     try {
       auto const headers = config.headers_.value_or(headers_t{});
       auto oauth = std::shared_ptr<oauth_state>{};
@@ -337,6 +374,7 @@ struct gbfs_update {
   awaitable<void> update_provider_feed(
       provider_feed const& pf,
       std::optional<gbfs_file> discovery = std::nullopt) {
+    ensure_gbfs_metrics(pf.id_);
     auto& provider = add_provider(pf);
 
     // check if exists in old data - if so, reuse existing file infos
@@ -535,7 +573,7 @@ struct gbfs_update {
           .Add({{"provider_id", pf.id_}})
           .SetToCurrentTime();
 
-      metrics_->gbfs_feed_timestamp_seconds_.Add({{"tag", pf.id_}})
+      metrics_->gbfs_feed_timestamp_seconds_.Add({{"provider_id", pf.id_}})
           .Set(std::chrono::duration_cast<std::chrono::duration<double>>(
                    provider.last_updated_.time_since_epoch())
                    .count());
@@ -779,20 +817,19 @@ struct gbfs_update {
       boost::json::object const& root,
       std::map<std::string, unsigned> const& default_ttl = {},
       std::map<std::string, unsigned> const& overwrite_ttl = {}) {
-    auto af =
-        d_->aggregated_feeds_
-            ->emplace_back(std::make_unique<aggregated_feed>(aggregated_feed{
-                .id_ = prefix,
-                .url_ = url,
-                .headers_ = headers,
-                .expiry_ = get_expiry(root, std::chrono::hours{1}, default_ttl,
-                                      overwrite_ttl, "manifest"),
-                .oauth_ = std::move(oauth),
-                .default_ttl_ = default_ttl,
-                .overwrite_ttl_ = overwrite_ttl}))
-            .get();
+    auto af = aggregated_feed{
+        .id_ = prefix,
+        .url_ = url,
+        .headers_ = headers,
+        .expiry_ = get_expiry(root, std::chrono::hours{1}, default_ttl,
+                              overwrite_ttl, "manifest"),
+        .oauth_ = std::move(oauth),
+        .default_ttl_ = default_ttl,
+        .overwrite_ttl_ = overwrite_ttl};
 
-    co_return co_await process_aggregated_feed(*af, root);
+    co_await process_aggregated_feed(af, root);
+    d_->aggregated_feeds_->emplace_back(
+        std::make_unique<aggregated_feed>(std::move(af)));
   }
 
   awaitable<void> update_aggregated_feed(aggregated_feed& af) {

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <set>
@@ -139,11 +140,12 @@ std::chrono::system_clock::time_point get_expiry(
     return now + std::chrono::seconds{it->second};
   }
   if (root.contains("data")) {
-    auto const& data = root.at("data").as_object();
-    if (data.contains("ttl")) {
-      auto const ttl = data.at("ttl").to_number<int>();
-      if (ttl > 0) {
-        return now + std::chrono::seconds{ttl};
+    auto const& data_val = root.at("data");
+    if (data_val.is_object() && data_val.as_object().contains("ttl")) {
+      auto const& ttl_val = data_val.as_object().at("ttl");
+      if (auto const ttl = as_double(ttl_val);
+          ttl.has_value() && static_cast<int>(*ttl) > 0) {
+        return now + std::chrono::seconds{static_cast<int>(*ttl)};
       }
     }
   }
@@ -253,6 +255,35 @@ struct gbfs_update {
   void ensure_gbfs_metrics(std::string const& id) {
     metrics_->gbfs_last_update_timestamp_seconds_.Add({{"provider_id", id}});
     metrics_->gbfs_feed_timestamp_seconds_.Add({{"provider_id", id}});
+  }
+
+  void inc_fetch_error(std::string const& id, std::string_view const file) {
+    metrics_->gbfs_fetch_errors_total_
+        .Add({{"provider_id", id}, {"file", std::string{file}}})
+        .Increment();
+  }
+
+  void add_skipped_entries(std::string const& id,
+                           std::string_view const file,
+                           std::uint64_t const count) {
+    if (count == 0U) {
+      return;
+    }
+    metrics_->gbfs_skipped_entries_total_
+        .Add({{"provider_id", id}, {"file", std::string{file}}})
+        .Increment(static_cast<double>(count));
+  }
+
+  void add_skipped_entries(std::string const& id,
+                           gbfs_provider const& provider) {
+    add_skipped_entries(id, "station_information",
+                        provider.skipped_station_infos_);
+    add_skipped_entries(id, "station_status", provider.skipped_station_status_);
+    add_skipped_entries(id, "vehicle_types", provider.skipped_vehicle_types_);
+    add_skipped_entries(id, "vehicle_status", provider.skipped_vehicle_status_);
+    add_skipped_entries(id, "geofencing_zones",
+                        provider.skipped_geofencing_zones_ +
+                            provider.skipped_geofencing_rules_);
   }
 
   bool is_config_feed_initialized(std::string const& id) const {
@@ -366,6 +397,7 @@ struct gbfs_update {
 
       co_return co_await update_provider_feed(*saf, std::move(discovery));
     } catch (std::exception const& ex) {
+      inc_fetch_error(id, "gbfs");
       std::cerr << "[GBFS] error initializing feed " << id << " ("
                 << config.url_ << "): " << ex.what() << "\n";
     }
@@ -446,7 +478,9 @@ struct gbfs_update {
                                 pf.dir_, pf.default_ttl_, pf.overwrite_ttl_);
       }
       if (discovery) {
-        file_infos->urls_ = parse_discovery(discovery->json_);
+        auto urls = parse_discovery(discovery->json_);
+        utl::verify(!urls.empty(), "GBFS discovery contains no file URLs");
+        file_infos->urls_ = std::move(urls);
         file_infos->urls_fi_.expiry_ = discovery->next_refresh_;
         file_infos->urls_fi_.hash_ = discovery->hash_;
       }
@@ -458,19 +492,25 @@ struct gbfs_update {
           co_return false;
         }
         if (force || needs_refresh(fi)) {
-          auto file = co_await fetch_file(name, file_infos->urls_.at(name),
-                                          pf.headers_, pf.oauth_, pf.dir_,
-                                          pf.default_ttl_, pf.overwrite_ttl_);
-          if (file.last_updated_.has_value() &&
-              *file.last_updated_ > provider.last_updated_) {
-            provider.last_updated_ = *file.last_updated_;
+          try {
+            auto file = co_await fetch_file(name, file_infos->urls_.at(name),
+                                            pf.headers_, pf.oauth_, pf.dir_,
+                                            pf.default_ttl_, pf.overwrite_ttl_);
+            auto const hash_changed = file.hash_ != fi.hash_;
+            fn(provider, file.json_);
+            if (file.last_updated_.has_value() &&
+                *file.last_updated_ > provider.last_updated_) {
+              provider.last_updated_ = *file.last_updated_;
+            }
+            fi.expiry_ = file.next_refresh_;
+            fi.hash_ = file.hash_;
+            co_return hash_changed;
+          } catch (std::exception const& ex) {
+            inc_fetch_error(pf.id_, name);
+            std::cerr << "[GBFS] error processing " << name << " for feed "
+                      << pf.id_ << " (" << file_infos->urls_.at(name)
+                      << "): " << ex.what() << "\n";
           }
-          auto const hash_changed = file.hash_ != fi.hash_;
-          auto j_root = file.json_.as_object();
-          fi.expiry_ = file.next_refresh_;
-          fi.hash_ = file.hash_;
-          fn(provider, file.json_);
-          co_return hash_changed;
         }
         co_return false;
       };
@@ -578,6 +618,7 @@ struct gbfs_update {
                    provider.last_updated_.time_since_epoch())
                    .count());
     } catch (std::exception const& ex) {
+      inc_fetch_error(pf.id_, "gbfs");
       std::cerr << "[GBFS] error processing feed " << pf.id_ << " (" << pf.url_
                 << "): " << ex.what() << "\n";
       if (!std::string_view{ex.what()}.starts_with("HTTP ")) {
@@ -602,6 +643,8 @@ struct gbfs_update {
         provider.last_updated_ = prev_provider->last_updated_;
       }
     }
+
+    add_skipped_entries(pf.id_, provider);
 
     if (data_changed) {
       try {
@@ -833,73 +876,117 @@ struct gbfs_update {
   }
 
   awaitable<void> update_aggregated_feed(aggregated_feed& af) {
-    if (af.needs_update()) {
-      auto const file =
-          co_await fetch_file("manifest", af.url_, af.headers_, af.oauth_,
-                              std::nullopt, af.default_ttl_, af.overwrite_ttl_);
-      co_await process_aggregated_feed(af, file.json_.as_object());
-    } else {
-      co_await update_aggregated_feed_provider_feeds(af);
+    try {
+      if (af.needs_update()) {
+        auto const file = co_await fetch_file(
+            "manifest", af.url_, af.headers_, af.oauth_, std::nullopt,
+            af.default_ttl_, af.overwrite_ttl_);
+        co_await process_aggregated_feed(af, file.json_.as_object());
+      } else {
+        co_await update_aggregated_feed_provider_feeds(af);
+      }
+    } catch (std::exception const& ex) {
+      inc_fetch_error(af.id_, "manifest");
+      std::cerr << "[GBFS] error processing aggregated feed " << af.id_ << " ("
+                << af.url_ << "): " << ex.what() << "\n";
     }
   }
 
   awaitable<void> process_aggregated_feed(aggregated_feed& af,
                                           boost::json::object const& root) {
     auto feeds = std::vector<provider_feed>{};
-    if (root.contains("data") &&
-        root.at("data").as_object().contains("datasets")) {
+    auto skipped_entries = 0U;
+
+    if (root.contains("data") && root.at("data").is_object() &&
+        root.at("data").as_object().contains("datasets") &&
+        root.at("data").as_object().at("datasets").is_array()) {
       // GBFS 3.x manifest.json
       for (auto const& dataset : root.at("data").at("datasets").as_array()) {
-        auto const system_id =
-            static_cast<std::string>(dataset.at("system_id").as_string());
-        auto const combined_id = fmt::format("{}:{}", af.id_, system_id);
+        try {
+          if (!dataset.is_object()) {
+            ++skipped_entries;
+            continue;
+          }
+          auto const& dataset_obj = dataset.as_object();
+          auto const system_id = optional_str(dataset_obj, "system_id");
+          auto const versions_it = dataset_obj.find("versions");
+          if (system_id.empty() || versions_it == dataset_obj.end() ||
+              !versions_it->value().is_array() ||
+              versions_it->value().as_array().empty()) {
+            ++skipped_entries;
+            continue;
+          }
 
-        auto const& versions = dataset.at("versions").as_array();
-        if (versions.empty()) {
-          continue;
+          // versions array must be sorted by increasing version number
+          auto const& latest_version =
+              versions_it->value().as_array().back().as_object();
+          auto const url = optional_str(latest_version, "url");
+          if (url.empty()) {
+            ++skipped_entries;
+            continue;
+          }
+          auto const combined_id = fmt::format("{}:{}", af.id_, system_id);
+          feeds.emplace_back(provider_feed{
+              .id_ = combined_id,
+              .url_ = url,
+              .headers_ = af.headers_,
+              .default_restrictions_ =
+                  lookup_default_restrictions(af.id_, combined_id),
+              .default_return_constraint_ =
+                  lookup_default_return_constraint(af.id_, combined_id),
+              .config_group_ = lookup_group(af.id_, system_id),
+              .config_name_ = lookup_name(af.id_, system_id),
+              .config_color_ = lookup_color(af.id_, system_id),
+              .ignore_geofencing_ = lookup_ignore_geofencing(af.id_, system_id),
+              .oauth_ = af.oauth_,
+              .default_ttl_ = af.default_ttl_,
+              .overwrite_ttl_ = af.overwrite_ttl_});
+        } catch (std::exception const& ex) {
+          ++skipped_entries;
+          std::cerr << "[GBFS] (" << af.id_
+                    << ") invalid manifest dataset: " << ex.what() << "\n";
         }
-        // versions array must be sorted by increasing version number
-        auto const& latest_version = versions.back().as_object();
-        feeds.emplace_back(provider_feed{
-            .id_ = combined_id,
-            .url_ =
-                static_cast<std::string>(latest_version.at("url").as_string()),
-            .headers_ = af.headers_,
-            .default_restrictions_ =
-                lookup_default_restrictions(af.id_, combined_id),
-            .default_return_constraint_ =
-                lookup_default_return_constraint(af.id_, combined_id),
-            .config_group_ = lookup_group(af.id_, system_id),
-            .config_name_ = lookup_name(af.id_, system_id),
-            .config_color_ = lookup_color(af.id_, system_id),
-            .ignore_geofencing_ = lookup_ignore_geofencing(af.id_, system_id),
-            .oauth_ = af.oauth_,
-            .default_ttl_ = af.default_ttl_,
-            .overwrite_ttl_ = af.overwrite_ttl_});
       }
-    } else if (root.contains("systems")) {
+    } else if (root.contains("systems") && root.at("systems").is_array()) {
       // Lamassu 2.3 format
       for (auto const& system : root.at("systems").as_array()) {
-        auto const system_id =
-            static_cast<std::string>(system.at("id").as_string());
-        auto const combined_id = fmt::format("{}:{}", af.id_, system_id);
-        feeds.emplace_back(provider_feed{
-            .id_ = combined_id,
-            .url_ = static_cast<std::string>(system.at("url").as_string()),
-            .headers_ = af.headers_,
-            .default_restrictions_ =
-                lookup_default_restrictions(af.id_, combined_id),
-            .default_return_constraint_ =
-                lookup_default_return_constraint(af.id_, combined_id),
-            .config_group_ = lookup_group(af.id_, system_id),
-            .config_name_ = lookup_name(af.id_, system_id),
-            .config_color_ = lookup_color(af.id_, system_id),
-            .ignore_geofencing_ = lookup_ignore_geofencing(af.id_, system_id),
-            .oauth_ = af.oauth_,
-            .default_ttl_ = af.default_ttl_,
-            .overwrite_ttl_ = af.overwrite_ttl_});
+        try {
+          if (!system.is_object()) {
+            ++skipped_entries;
+            continue;
+          }
+          auto const& system_obj = system.as_object();
+          auto const system_id = optional_str(system_obj, "id");
+          auto const url = optional_str(system_obj, "url");
+          if (system_id.empty() || url.empty()) {
+            ++skipped_entries;
+            continue;
+          }
+          auto const combined_id = fmt::format("{}:{}", af.id_, system_id);
+          feeds.emplace_back(provider_feed{
+              .id_ = combined_id,
+              .url_ = url,
+              .headers_ = af.headers_,
+              .default_restrictions_ =
+                  lookup_default_restrictions(af.id_, combined_id),
+              .default_return_constraint_ =
+                  lookup_default_return_constraint(af.id_, combined_id),
+              .config_group_ = lookup_group(af.id_, system_id),
+              .config_name_ = lookup_name(af.id_, system_id),
+              .config_color_ = lookup_color(af.id_, system_id),
+              .ignore_geofencing_ = lookup_ignore_geofencing(af.id_, system_id),
+              .oauth_ = af.oauth_,
+              .default_ttl_ = af.default_ttl_,
+              .overwrite_ttl_ = af.overwrite_ttl_});
+        } catch (std::exception const& ex) {
+          ++skipped_entries;
+          std::cerr << "[GBFS] (" << af.id_
+                    << ") invalid Lamassu system: " << ex.what() << "\n";
+        }
       }
     }
+
+    add_skipped_entries(af.id_, "manifest", skipped_entries);
 
     af.feeds_ = std::move(feeds);
 

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -1,6 +1,7 @@
 #include "motis/gbfs/update.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <chrono>
 #include <cstdint>
@@ -45,6 +46,7 @@
 #include "motis/repeat.h"
 
 #include "motis/gbfs/compression.h"
+#include "motis/gbfs/mode.h"
 #include "motis/gbfs/osr_mapping.h"
 #include "motis/gbfs/parser.h"
 #include "motis/gbfs/partition.h"
@@ -284,6 +286,69 @@ struct gbfs_update {
     add_skipped_entries(id, "geofencing_zones",
                         provider.skipped_geofencing_zones_ +
                             provider.skipped_geofencing_rules_);
+  }
+
+  static constexpr auto kFormFactorCount =
+      static_cast<std::size_t>(vehicle_form_factor::kOther) + 1U;
+
+  vehicle_form_factor get_form_factor(gbfs_provider const& provider,
+                                      vehicle_type_idx_t const vt) const {
+    if (vt == vehicle_type_idx_t::invalid() ||
+        cista::to_idx(vt) >= provider.vehicle_types_.size()) {
+      return vehicle_form_factor::kOther;
+    }
+    return provider.vehicle_types_.at(vt).form_factor_;
+  }
+
+  void set_vehicle_count(std::string const& provider_id,
+                         std::string const& provider_group_id,
+                         vehicle_form_factor const ff,
+                         std::uint64_t const count) {
+    metrics_->gbfs_vehicle_count_
+        .Add({{"provider_id", provider_id},
+              {"provider_group_id", provider_group_id},
+              {"form_factor",
+               static_cast<std::string>(
+                   json::value_from(to_api_form_factor(ff)).as_string())}})
+        .Set(static_cast<double>(count));
+  }
+
+  void reset_vehicle_count(gbfs_provider const& provider) {
+    for (auto i = 0U; i != kFormFactorCount; ++i) {
+      auto const ff = static_cast<vehicle_form_factor>(i);
+      set_vehicle_count(provider.id_, provider.group_id_, ff, 0U);
+    }
+  }
+
+  void update_vehicle_count(gbfs_provider const& provider,
+                            gbfs_provider const* prev_provider) {
+    if (prev_provider != nullptr &&
+        (prev_provider->id_ != provider.id_ ||
+         prev_provider->group_id_ != provider.group_id_)) {
+      reset_vehicle_count(*prev_provider);
+    }
+
+    auto counts = std::array<std::uint64_t, kFormFactorCount>{};
+    auto has_station_counts = false;
+    for (auto const& station : provider.stations_ | std::views::values) {
+      for (auto const& [vt, count] : station.status_.vehicle_types_available_) {
+        has_station_counts = true;
+        counts[static_cast<std::size_t>(get_form_factor(provider, vt))] +=
+            count;
+      }
+    }
+    for (auto const& vehicle : provider.vehicle_status_) {
+      if (has_station_counts && !vehicle.station_id_.empty()) {
+        continue;
+      }
+      ++counts[static_cast<std::size_t>(
+          get_form_factor(provider, vehicle.vehicle_type_idx_))];
+    }
+
+    for (auto i = 0U; i != kFormFactorCount; ++i) {
+      set_vehicle_count(provider.id_, provider.group_id_,
+                        static_cast<vehicle_form_factor>(i), counts[i]);
+    }
   }
 
   bool is_config_feed_initialized(std::string const& id) const {
@@ -593,6 +658,8 @@ struct gbfs_update {
       } else {
         it->second.providers_.push_back(provider.idx_);
       }
+
+      update_vehicle_count(provider, prev_provider);
 
       if (stations_updated || vehicle_status_updated) {
         for (auto const& st : provider.stations_ | std::views::values) {

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -158,8 +158,10 @@ struct gbfs_update {
               osr::ways const& w,
               osr::lookup const& l,
               gbfs_data* d,
-              gbfs_data const* prev_d)
-      : c_{c},
+              gbfs_data const* prev_d,
+              metrics_registry const* metrics)
+      : metrics_{metrics},
+        c_{c},
         w_{w},
         l_{l},
         d_{d},
@@ -522,6 +524,10 @@ struct gbfs_update {
       data_changed = vehicle_types_updated || stations_updated ||
                      station_status_updated || vehicle_status_updated ||
                      geofencing_updated;
+
+      metrics_->gbfs_last_update_timestamp_seconds_
+          .Add({{"provider_id", pf.id_}})
+          .SetToCurrentTime();
     } catch (std::exception const& ex) {
       std::cerr << "[GBFS] error processing feed " << pf.id_ << " (" << pf.url_
                 << "): " << ex.what() << "\n";
@@ -847,6 +853,10 @@ struct gbfs_update {
     }
 
     af.feeds_ = std::move(feeds);
+
+    metrics_->gbfs_last_update_timestamp_seconds_.Add({{"provider_id", af.id_}})
+        .SetToCurrentTime();
+
     co_await update_aggregated_feed_provider_feeds(af);
   }
 
@@ -1109,6 +1119,8 @@ struct gbfs_update {
         .value_or(false);
   }
 
+  metrics_registry const* metrics_{};
+
   config::gbfs const& c_;
   osr::ways const& w_;
   osr::lookup const& l_;
@@ -1134,7 +1146,7 @@ awaitable<void> update(config const& c,
   auto const prev_d = data_ptr;
   auto const d = std::make_shared<gbfs_data>(c.gbfs_->cache_size_);
 
-  auto update = gbfs_update{*c.gbfs_, w, l, d.get(), prev_d.get()};
+  auto update = gbfs_update{*c.gbfs_, w, l, d.get(), prev_d.get(), metrics};
   try {
     co_await update.run();
   } catch (std::exception const& e) {

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -61,6 +61,7 @@ struct gbfs_file {
   json::value json_;
   cista::hash_t hash_{};
   std::chrono::system_clock::time_point next_refresh_;
+  std::optional<std::chrono::system_clock::time_point> last_updated_{};
 };
 
 std::string read_file(std::filesystem::path const& path) {
@@ -346,6 +347,7 @@ struct gbfs_update {
         prev_provider = prev_d_->providers_[it->second].get();
         if (prev_provider != nullptr) {
           provider.file_infos_ = prev_provider->file_infos_;
+          provider.last_updated_ = prev_provider->last_updated_;
         }
       }
     }
@@ -421,6 +423,10 @@ struct gbfs_update {
           auto file = co_await fetch_file(name, file_infos->urls_.at(name),
                                           pf.headers_, pf.oauth_, pf.dir_,
                                           pf.default_ttl_, pf.overwrite_ttl_);
+          if (file.last_updated_.has_value() &&
+              *file.last_updated_ > provider.last_updated_) {
+            provider.last_updated_ = *file.last_updated_;
+          }
           auto const hash_changed = file.hash_ != fi.hash_;
           auto j_root = file.json_.as_object();
           fi.expiry_ = file.next_refresh_;
@@ -528,6 +534,11 @@ struct gbfs_update {
       metrics_->gbfs_last_update_timestamp_seconds_
           .Add({{"provider_id", pf.id_}})
           .SetToCurrentTime();
+
+      metrics_->gbfs_feed_timestamp_seconds_.Add({{"tag", pf.id_}})
+          .Set(std::chrono::duration_cast<std::chrono::duration<double>>(
+                   provider.last_updated_.time_since_epoch())
+                   .count());
     } catch (std::exception const& ex) {
       std::cerr << "[GBFS] error processing feed " << pf.id_ << " (" << pf.url_
                 << "): " << ex.what() << "\n";
@@ -550,6 +561,7 @@ struct gbfs_update {
         provider.geofencing_zones_ = prev_provider->geofencing_zones_;
         provider.has_vehicles_to_rent_ = prev_provider->has_vehicles_to_rent_;
         provider.bbox_ = prev_provider->bbox_;
+        provider.last_updated_ = prev_provider->last_updated_;
       }
     }
 
@@ -901,9 +913,14 @@ struct gbfs_update {
     auto j_root = j.as_object();
     auto const next_refresh = get_expiry(j_root, std::chrono::seconds{0},
                                          default_ttl, overwrite_ttl, name);
+    auto last_updated = std::optional<std::chrono::system_clock::time_point>{};
+    if (auto const it = j_root.find("last_updated"); it != j_root.end()) {
+      last_updated = parse_timestamp(it->value());
+    }
     co_return gbfs_file{.json_ = std::move(j),
                         .hash_ = hash_gbfs_data(content),
-                        .next_refresh_ = next_refresh};
+                        .next_refresh_ = next_refresh,
+                        .last_updated_ = last_updated};
   }
 
   awaitable<void> get_oauth_token(std::shared_ptr<oauth_state> const& oauth,

--- a/src/metrics_registry.cc
+++ b/src/metrics_registry.cc
@@ -134,7 +134,12 @@ metrics_registry::metrics_registry(
                        .Help("Timestamp of last RT, GBFS, Elevator updates")
                        .Register(registry_)},
       last_update_rt_{last_update_.Add({{"feed", "rt"}})},
-      last_update_gbfs_{last_update_.Add({{"feed", "gbfs"}})} {}
+      last_update_gbfs_{last_update_.Add({{"feed", "gbfs"}})},
+      gbfs_last_update_timestamp_seconds_{
+          prometheus::BuildGauge()
+              .Name("gbfs_last_update_timestamp_seconds")
+              .Help("Timestamp of last successful GBFS update per provider")
+              .Register(registry_)} {}
 
 metrics_registry::~metrics_registry() = default;
 

--- a/src/metrics_registry.cc
+++ b/src/metrics_registry.cc
@@ -144,6 +144,16 @@ metrics_registry::metrics_registry(
           prometheus::BuildGauge()
               .Name("gbfs_feed_timestamp_seconds")
               .Help("Timestamp from the last_updated field of the GBFS feed")
+              .Register(registry_)},
+      gbfs_fetch_errors_total_{
+          prometheus::BuildCounter()
+              .Name("gbfs_fetch_errors_total")
+              .Help("Number of GBFS file fetch or file-level parse errors")
+              .Register(registry_)},
+      gbfs_skipped_entries_total_{
+          prometheus::BuildCounter()
+              .Name("gbfs_skipped_entries_total")
+              .Help("Number of malformed GBFS entries skipped while parsing")
               .Register(registry_)} {}
 
 metrics_registry::~metrics_registry() = default;

--- a/src/metrics_registry.cc
+++ b/src/metrics_registry.cc
@@ -137,22 +137,27 @@ metrics_registry::metrics_registry(
       last_update_gbfs_{last_update_.Add({{"feed", "gbfs"}})},
       gbfs_last_update_timestamp_seconds_{
           prometheus::BuildGauge()
-              .Name("gbfs_last_update_timestamp_seconds")
+              .Name("motis_gbfs_last_update_timestamp_seconds")
               .Help("Timestamp of last successful GBFS update per provider")
               .Register(registry_)},
       gbfs_feed_timestamp_seconds_{
           prometheus::BuildGauge()
-              .Name("gbfs_feed_timestamp_seconds")
+              .Name("motis_gbfs_feed_timestamp_seconds")
               .Help("Timestamp from the last_updated field of the GBFS feed")
+              .Register(registry_)},
+      gbfs_vehicle_count_{
+          prometheus::BuildGauge()
+              .Name("motis_gbfs_vehicle_count")
+              .Help("Current number of GBFS vehicles known to MOTIS")
               .Register(registry_)},
       gbfs_fetch_errors_total_{
           prometheus::BuildCounter()
-              .Name("gbfs_fetch_errors_total")
+              .Name("motis_gbfs_fetch_errors_total")
               .Help("Number of GBFS file fetch or file-level parse errors")
               .Register(registry_)},
       gbfs_skipped_entries_total_{
           prometheus::BuildCounter()
-              .Name("gbfs_skipped_entries_total")
+              .Name("motis_gbfs_skipped_entries_total")
               .Help("Number of malformed GBFS entries skipped while parsing")
               .Register(registry_)} {}
 

--- a/src/metrics_registry.cc
+++ b/src/metrics_registry.cc
@@ -139,6 +139,11 @@ metrics_registry::metrics_registry(
           prometheus::BuildGauge()
               .Name("gbfs_last_update_timestamp_seconds")
               .Help("Timestamp of last successful GBFS update per provider")
+              .Register(registry_)},
+      gbfs_feed_timestamp_seconds_{
+          prometheus::BuildGauge()
+              .Name("gbfs_feed_timestamp_seconds")
+              .Help("Timestamp from the last_updated field of the GBFS feed")
               .Register(registry_)} {}
 
 metrics_registry::~metrics_registry() = default;


### PR DESCRIPTION
- New metrics (#1464)
  - `motis_gbfs_last_update_timestamp_seconds` - when the feed was last fetched
    -  Example: `motis_gbfs_last_update_timestamp_seconds{provider_id="no-Entur-Mobility:rydeaalesund"} 1781881059`
  - `motis_gbfs_feed_timestamp_seconds` - last update reported by the feed
    - Example: `motis_gbfs_feed_timestamp_seconds{provider_id="no-Entur-Mobility:rydeaalesund"} 1781881029`
  - `motis_gbfs_fetch_errors_total` counts the number of times a file either couldn't be downloaded or parsed at all (i.e. no JSON returned / no top level data entry)
    - Example: `motis_gbfs_fetch_errors_total{file="gbfs",provider_id="si-nextbike-ck"} 2`
  - `motis_gbfs_skipped_entries_total` counts the number of entries (stations, geofencing zones, vehicles...) that couldn't be parsed
    - Example: `motis_gbfs_skipped_entries_total{file="geofencing_zones",provider_id="fr-citiz-autopartage-provence"} 32`
  - `motis_gbfs_vehicle_count` gives the current number of vehicles (free floating + available at stations)
    - Example: `motis_gbfs_vehicle_count{form_factor="SCOOTER_STANDING",provider_group_id="Dott trondheim",provider_id="no-Entur-Mobility:dotttrondheim"} 2631`
- Retry feeds even if the initial load failed (both standalone + aggregated feeds)
- More lenient parser
  - Accept both GBFS v2/3 fields everywhere (no more version check)
  - Ignore missing fields where possible
  - Parse as much data as possible and skip as little as necessary
  - Accept more invalid (according to spec) data types
- `/metrics` endpoint now also works with no timetable loaded