### PR TITLE
GBFS Tests

### DIFF
--- a/include/motis/gbfs/data.h
+++ b/include/motis/gbfs/data.h
@@ -373,7 +373,7 @@ struct gbfs_products_ref {
 struct gbfs_provider {
   std::string id_;  // from config
   gbfs_provider_idx_t idx_{gbfs_provider_idx_t::invalid()};
-  std::string group_id_;
+  std::string group_id_{};
 
   std::shared_ptr<provider_file_infos> file_infos_{};
 
@@ -383,12 +383,12 @@ struct gbfs_provider {
   hash_map<std::pair<std::string, vehicle_start_type>, vehicle_type_idx_t>
       vehicle_types_map_{};
   hash_map<std::string, temp_vehicle_type> temp_vehicle_types_{};
-  std::vector<vehicle_status> vehicle_status_;
+  std::vector<vehicle_status> vehicle_status_{};
   geofencing_zones geofencing_zones_{};
   geofencing_restrictions default_restrictions_{};
   std::optional<return_constraint> default_return_constraint_{};
 
-  vector_map<gbfs_products_idx_t, provider_products> products_;
+  vector_map<gbfs_products_idx_t, provider_products> products_{};
   bool has_vehicles_to_rent_{};
   geo::box bbox_{};
   std::chrono::system_clock::time_point last_updated_{};
@@ -451,6 +451,7 @@ struct aggregated_feed {
   std::string id_;
   std::string url_;
   headers_t headers_{};
+  std::optional<std::filesystem::path> dir_{};
   std::optional<std::chrono::system_clock::time_point> expiry_{};
   std::vector<provider_feed> feeds_{};
   std::shared_ptr<oauth_state> oauth_{};

--- a/include/motis/gbfs/partition.h
+++ b/include/motis/gbfs/partition.h
@@ -31,7 +31,9 @@ struct partition {
     auto in_s =
         std::vector<bool>(static_cast<std::size_t>(cista::to_idx(n_)), false);
     for (auto const elem : s) {
-      assert(elem < n_);
+      if (elem >= n_) {
+        continue;
+      }
       in_s[static_cast<std::size_t>(cista::to_idx(elem))] = true;
     }
 

--- a/src/gbfs/parser.cc
+++ b/src/gbfs/parser.cc
@@ -453,6 +453,8 @@ void load_station_status(gbfs_provider& provider, json::value const& root) {
               roundtrip_available += count;
               break;
           }
+        } else {
+          ++provider.skipped_station_status_;
         }
       }
       if (has_typed_availability) {
@@ -719,6 +721,9 @@ rule parse_rule(gbfs_provider& provider, json::value const& r) {
         free_floating_vt_it != end(provider.vehicle_types_map_)) {
       vehicle_type_idxs.emplace_back(free_floating_vt_it->second);
     }
+  }
+  if (!vehicle_type_ids.empty() && vehicle_type_idxs.empty()) {
+    vehicle_type_idxs.emplace_back(vehicle_type_idx_t::invalid());
   }
 
   auto const ride_allowed = get_bool(rule_obj, "ride_allowed", true);

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -78,6 +78,10 @@ bool needs_refresh(file_info const& fi) {
   return fi.needs_update(std::chrono::system_clock::now());
 }
 
+bool is_http_url(std::string_view const url) {
+  return url.starts_with("http:") || url.starts_with("https:");
+}
+
 // try to hash only the value of the "data" key to ignore fields like
 // "last_updated"
 cista::hash_t hash_gbfs_data(std::string_view const json) {
@@ -141,14 +145,11 @@ std::chrono::system_clock::time_point get_expiry(
       it != end(overwrite_ttl)) {
     return now + std::chrono::seconds{it->second};
   }
-  if (root.contains("data")) {
-    auto const& data_val = root.at("data");
-    if (data_val.is_object() && data_val.as_object().contains("ttl")) {
-      auto const& ttl_val = data_val.as_object().at("ttl");
-      if (auto const ttl = as_double(ttl_val);
-          ttl.has_value() && static_cast<int>(*ttl) > 0) {
-        return now + std::chrono::seconds{static_cast<int>(*ttl)};
-      }
+  if (root.contains("ttl")) {
+    auto const& ttl_val = root.at("ttl");
+    if (auto const ttl = as_double(ttl_val);
+        ttl.has_value() && static_cast<int>(*ttl) > 0) {
+      return now + std::chrono::seconds{static_cast<int>(*ttl)};
     }
   }
   if (auto const it = default_ttl.find(std::string{name});
@@ -323,8 +324,7 @@ struct gbfs_update {
   void update_vehicle_count(gbfs_provider const& provider,
                             gbfs_provider const* prev_provider) {
     if (prev_provider != nullptr &&
-        (prev_provider->id_ != provider.id_ ||
-         prev_provider->group_id_ != provider.group_id_)) {
+        prev_provider->group_id_ != provider.group_id_) {
       reset_vehicle_count(*prev_provider);
     }
 
@@ -380,8 +380,7 @@ struct gbfs_update {
                     [&](auto const& id) {
                       auto const& feed = c_.feeds_.at(id);
                       auto const dir =
-                          feed.url_.starts_with("http:") ||
-                                  feed.url_.starts_with("https:")
+                          is_http_url(feed.url_)
                               ? std::nullopt
                               : std::optional<std::filesystem::path>{feed.url_};
 
@@ -436,7 +435,7 @@ struct gbfs_update {
            root.at("data").as_object().contains("datasets")) ||
           root.contains("systems")) {
         // file is not an individual feed, but a manifest.json / Lamassu file
-        co_return co_await init_aggregated_feed(id, config.url_, headers,
+        co_return co_await init_aggregated_feed(id, config.url_, headers, dir,
                                                 std::move(oauth), root,
                                                 default_ttl, overwrite_ttl);
       }
@@ -616,9 +615,18 @@ struct gbfs_update {
           || co_await update("free_bike_status", file_infos->vehicle_status_fi_,
                              load_vehicle_status,
                              vehicle_types_updated);  // 1.x / 2.x
+      auto const has_vehicle_status_feed =
+          file_infos->urls_.contains("vehicle_status") ||
+          file_infos->urls_.contains("free_bike_status");
+      auto vehicle_status_removed = false;
       if ((!vehicle_status_updated && !vehicle_types_updated) &&
           prev_provider != nullptr) {
-        provider.vehicle_status_ = prev_provider->vehicle_status_;
+        if (has_vehicle_status_feed) {
+          provider.vehicle_status_ = prev_provider->vehicle_status_;
+        } else {
+          provider.vehicle_status_.clear();
+          vehicle_status_removed = !prev_provider->vehicle_status_.empty();
+        }
       }
 
       if (!pf.ignore_geofencing_) {
@@ -674,7 +682,7 @@ struct gbfs_update {
 
       data_changed = vehicle_types_updated || stations_updated ||
                      station_status_updated || vehicle_status_updated ||
-                     geofencing_updated;
+                     vehicle_status_removed || geofencing_updated;
 
       metrics_->gbfs_last_update_timestamp_seconds_
           .Add({{"provider_id", pf.id_}})
@@ -923,6 +931,7 @@ struct gbfs_update {
       std::string const& prefix,
       std::string const& url,
       headers_t const& headers,
+      std::optional<std::filesystem::path> const& dir,
       std::shared_ptr<oauth_state>&& oauth,
       boost::json::object const& root,
       std::map<std::string, unsigned> const& default_ttl = {},
@@ -931,6 +940,7 @@ struct gbfs_update {
         .id_ = prefix,
         .url_ = url,
         .headers_ = headers,
+        .dir_ = dir,
         .expiry_ = get_expiry(root, std::chrono::hours{1}, default_ttl,
                               overwrite_ttl, "manifest"),
         .oauth_ = std::move(oauth),
@@ -945,9 +955,9 @@ struct gbfs_update {
   awaitable<void> update_aggregated_feed(aggregated_feed& af) {
     try {
       if (af.needs_update()) {
-        auto const file = co_await fetch_file(
-            "manifest", af.url_, af.headers_, af.oauth_, std::nullopt,
-            af.default_ttl_, af.overwrite_ttl_);
+        auto const file =
+            co_await fetch_file("manifest", af.url_, af.headers_, af.oauth_,
+                                af.dir_, af.default_ttl_, af.overwrite_ttl_);
         co_await process_aggregated_feed(af, file.json_.as_object());
       } else {
         co_await update_aggregated_feed_provider_feeds(af);
@@ -963,6 +973,16 @@ struct gbfs_update {
                                           boost::json::object const& root) {
     auto feeds = std::vector<provider_feed>{};
     auto skipped_entries = 0U;
+    auto const resolve_dir = [&](std::string const& url) {
+      if (is_http_url(url)) {
+        return std::optional<std::filesystem::path>{};
+      }
+      auto const p = std::filesystem::path{url};
+      if (!af.dir_.has_value() || p.is_absolute()) {
+        return std::optional<std::filesystem::path>{p};
+      }
+      return std::optional<std::filesystem::path>{*af.dir_ / p};
+    };
 
     if (root.contains("data") && root.at("data").is_object() &&
         root.at("data").as_object().contains("datasets") &&
@@ -997,6 +1017,7 @@ struct gbfs_update {
               .id_ = combined_id,
               .url_ = url,
               .headers_ = af.headers_,
+              .dir_ = resolve_dir(url),
               .default_restrictions_ =
                   lookup_default_restrictions(af.id_, combined_id),
               .default_return_constraint_ =
@@ -1034,6 +1055,7 @@ struct gbfs_update {
               .id_ = combined_id,
               .url_ = url,
               .headers_ = af.headers_,
+              .dir_ = resolve_dir(url),
               .default_restrictions_ =
                   lookup_default_restrictions(af.id_, combined_id),
               .default_return_constraint_ =

--- a/test/gbfs_parser_test.cc
+++ b/test/gbfs_parser_test.cc
@@ -1,0 +1,769 @@
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+#include "boost/json.hpp"
+
+#include "motis/gbfs/parser.h"
+
+namespace json = boost::json;
+
+using namespace motis::gbfs;
+
+TEST(motis, gbfs_parser_parse_discovery_v3_no_language_map) {
+  auto const urls = parse_discovery(json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "3.0",
+    "data": {
+      "feeds": [
+        {"name": "system_information", "url": "https://example.com/v3/system"},
+        {"name": "free_bike_status", "url": "https://example.com/v3/free_bikes"},
+        {"name": "station_information", "url": "https://example.com/v3/stations"}
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(3U, urls.size());
+  EXPECT_EQ("https://example.com/v3/system", urls.at("system_information"));
+  EXPECT_EQ("https://example.com/v3/free_bikes", urls.at("free_bike_status"));
+  EXPECT_EQ("https://example.com/v3/stations", urls.at("station_information"));
+}
+
+TEST(motis, gbfs_parser_parse_discovery_v2_language_map) {
+  auto const urls = parse_discovery(json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "data": {
+      "en": {
+        "feeds": [
+          {"name": "system_information", "url": "https://example.com/system"},
+          {"name": "free_bike_status", "url": "https://example.com/free_bikes"}
+        ]
+      }
+    }
+  })"));
+
+  ASSERT_EQ(2U, urls.size());
+  EXPECT_EQ("https://example.com/system", urls.at("system_information"));
+  EXPECT_EQ("https://example.com/free_bikes", urls.at("free_bike_status"));
+}
+
+TEST(motis, gbfs_parser_loads_v2_station_feed) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_system_information(provider, json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "2.3",
+    "data": {
+      "system_id": "sys",
+      "name": "Test Provider",
+      "brand_assets": {"color": "#123456"}
+    }
+  })"));
+
+  load_vehicle_types(provider, json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "2.3",
+    "data": {
+      "vehicle_types": [
+        {
+          "vehicle_type_id": "bike",
+          "form_factor": "bicycle",
+          "propulsion_type": "human"
+        }
+      ]
+    }
+  })"));
+
+  load_station_information(provider, json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "2.3",
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "name": "Main Station",
+          "lat": 48.1,
+          "lon": 11.5
+        }
+      ]
+    }
+  })"));
+
+  load_station_status(provider, json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "2.3",
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "num_bikes_available": 3,
+          "is_renting": true,
+          "is_returning": true,
+          "vehicle_types_available": [
+            {"vehicle_type_id": "bike", "count": 3}
+          ]
+        }
+      ]
+    }
+  })"));
+
+  EXPECT_EQ("sys", provider.sys_info_.id_);
+  EXPECT_EQ("Test Provider", provider.sys_info_.name_);
+  EXPECT_EQ("#123456", provider.sys_info_.color_);
+  ASSERT_EQ(1U, provider.vehicle_types_.size());
+  EXPECT_EQ(vehicle_form_factor::kBicycle,
+            provider.vehicle_types_.front().form_factor_);
+  ASSERT_EQ(1U, provider.stations_.size());
+
+  auto const& station = provider.stations_.at("station-1");
+  EXPECT_EQ("Main Station", station.info_.name_);
+  EXPECT_DOUBLE_EQ(48.1, station.info_.pos_.lat_);
+  EXPECT_DOUBLE_EQ(11.5, station.info_.pos_.lng_);
+  EXPECT_EQ(3U, station.status_.num_vehicles_available_);
+  EXPECT_TRUE(station.status_.is_renting_);
+  EXPECT_TRUE(station.status_.is_returning_);
+}
+
+TEST(motis, gbfs_parser_prefers_v3_vehicle_status_fields) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_types(provider, json::parse(R"({
+    "version": "3.0",
+    "data": {
+      "vehicle_types": [
+        {
+          "vehicle_type_id": "scooter",
+          "form_factor": "scooter_standing",
+          "propulsion_type": "electric",
+          "return_constraint": "free_floating"
+        }
+      ]
+    }
+  })"));
+
+  load_vehicle_status(provider, json::parse(R"({
+    "version": "2.3",
+    "data": {
+      "vehicles": [
+        {
+          "vehicle_id": "vehicle-v3",
+          "bike_id": "vehicle-v2",
+          "lat": 48.3,
+          "lon": 11.4,
+          "vehicle_type_id": "scooter",
+          "is_reserved": false,
+          "is_disabled": false
+        }
+      ],
+      "bikes": [
+        {
+          "bike_id": "bike-v2",
+          "lat": 1.0,
+          "lon": 2.0
+        }
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(1U, provider.vehicle_status_.size());
+  EXPECT_EQ("vehicle-v3", provider.vehicle_status_.front().id_);
+  EXPECT_DOUBLE_EQ(48.3, provider.vehicle_status_.front().pos_.lat_);
+  EXPECT_DOUBLE_EQ(11.4, provider.vehicle_status_.front().pos_.lng_);
+}
+
+TEST(motis, gbfs_parser_skips_bad_entries_and_accepts_lenient_values) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_station_information(provider, json::parse(R"({
+    "version": "2.3",
+    "data": {
+      "stations": [
+        "invalid",
+        {"station_id": "missing-position"},
+        {
+          "station_id": 42,
+          "name": [{"language": "en"}, {"language": "de", "text": 123}],
+          "lat": "48.5",
+          "lon": "11.6"
+        }
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(1U, provider.stations_.size());
+  auto const& station = provider.stations_.at("42");
+  EXPECT_EQ("123", station.info_.name_);
+  EXPECT_DOUBLE_EQ(48.5, station.info_.pos_.lat_);
+  EXPECT_DOUBLE_EQ(11.6, station.info_.pos_.lng_);
+  EXPECT_EQ(2U, provider.skipped_station_infos_);
+}
+
+TEST(motis, gbfs_parser_accepts_lenient_status_counts_and_booleans) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_station_information(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {"station_id": "station-1", "name": "Station", "lat": 1.0, "lon": 2.0}
+      ]
+    }
+  })"));
+
+  load_station_status(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "num_vehicles_available": "4",
+          "is_renting": "yes",
+          "is_returning": "0"
+        }
+      ]
+    }
+  })"));
+
+  auto const& status = provider.stations_.at("station-1").status_;
+  EXPECT_EQ(4U, status.num_vehicles_available_);
+  EXPECT_TRUE(status.is_renting_);
+  EXPECT_FALSE(status.is_returning_);
+}
+
+TEST(motis, gbfs_parser_ignores_unknown_station_status_vehicle_types) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_types(provider, json::parse(R"({
+    "data": {
+      "vehicle_types": [
+        {
+          "vehicle_type_id": "bike",
+          "form_factor": "bicycle",
+          "propulsion_type": "human",
+          "return_constraint": "any_station"
+        }
+      ]
+    }
+  })"));
+
+  load_station_information(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {"station_id": "station-1", "name": "Station", "lat": 1.0, "lon": 2.0}
+      ]
+    }
+  })"));
+
+  load_station_status(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "num_vehicles_available": 14,
+          "vehicle_types_available": [
+            {"vehicle_type_id": "unknown", "count": 9},
+            {"vehicle_type_id": "bike", "count": 5}
+          ]
+        }
+      ]
+    }
+  })"));
+
+  auto const& status = provider.stations_.at("station-1").status_;
+  EXPECT_EQ(5U, status.num_vehicles_available_);
+  ASSERT_EQ(1U, status.vehicle_types_available_.size());
+  EXPECT_EQ(5U, status.vehicle_types_available_.begin()->second);
+  EXPECT_EQ(1U, provider.skipped_station_status_);
+}
+
+TEST(motis, gbfs_parser_infers_return_constraint_by_start_type) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_types(provider, json::parse(R"({
+    "data": {
+      "vehicle_types": [
+        {
+          "vehicle_type_id": "bike",
+          "form_factor": "bicycle",
+          "propulsion_type": "human"
+        }
+      ]
+    }
+  })"));
+
+  load_station_information(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {"station_id": "station-1", "name": "Station", "lat": 1.0, "lon": 2.0}
+      ]
+    }
+  })"));
+
+  load_station_status(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "vehicle_types_available": [
+            {"vehicle_type_id": "bike", "count": 2}
+          ]
+        }
+      ]
+    }
+  })"));
+
+  load_vehicle_status(provider, json::parse(R"({
+    "data": {
+      "vehicles": [
+        {
+          "vehicle_id": "vehicle-1",
+          "lat": 1.1,
+          "lon": 2.1,
+          "vehicle_type_id": "bike"
+        }
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(2U, provider.vehicle_types_.size());
+  auto const station_type = provider.stations_.at("station-1")
+                                .status_.vehicle_types_available_.begin()
+                                ->first;
+  auto const free_floating_type =
+      provider.vehicle_status_.front().vehicle_type_idx_;
+  EXPECT_EQ(return_constraint::kAnyStation,
+            provider.vehicle_types_.at(station_type).return_constraint_);
+  EXPECT_EQ(return_constraint::kFreeFloating,
+            provider.vehicle_types_.at(free_floating_type).return_constraint_);
+}
+
+TEST(motis, gbfs_parser_vehicle_status_uses_station_position_when_missing) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_types(provider, json::parse(R"({
+    "data": {
+      "vehicle_types": [
+        {
+          "vehicle_type_id": "bike",
+          "form_factor": "bicycle",
+          "propulsion_type": "human",
+          "return_constraint": "any_station"
+        }
+      ]
+    }
+  })"));
+
+  load_station_information(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {"station_id": "station-1", "name": "Station", "lat": 48.1, "lon": 11.2}
+      ]
+    }
+  })"));
+
+  load_vehicle_status(provider, json::parse(R"({
+    "data": {
+      "vehicles": [
+        {
+          "vehicle_id": "vehicle-1",
+          "station_id": "station-1",
+          "vehicle_type_id": "bike"
+        },
+        {
+          "vehicle_id": "vehicle-2",
+          "station_id": "missing",
+          "vehicle_type_id": "bike"
+        }
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(1U, provider.vehicle_status_.size());
+  EXPECT_DOUBLE_EQ(48.1, provider.vehicle_status_.front().pos_.lat_);
+  EXPECT_DOUBLE_EQ(11.2, provider.vehicle_status_.front().pos_.lng_);
+  EXPECT_EQ(1U, provider.skipped_vehicle_status_);
+}
+
+TEST(motis, gbfs_parser_geofencing_accepts_v3_and_v2_rule_fields) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_types(provider, json::parse(R"({
+    "data": {
+      "vehicle_types": [
+        {
+          "vehicle_type_id": "bike",
+          "form_factor": "bicycle",
+          "propulsion_type": "human",
+          "return_constraint": "free_floating"
+        }
+      ]
+    }
+  })"));
+
+  load_geofencing_zones(provider, json::parse(R"({
+    "data": {
+      "geofencing_zones": {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "name": [{"text": "Zone"}],
+              "rules": [
+                {
+                  "vehicle_type_ids": ["bike"],
+                  "ride_allowed": false,
+                  "ride_start_allowed": true
+                },
+                {
+                  "vehicle_type_id": "bike",
+                  "ride_allowed": true
+                }
+              ]
+            },
+            "geometry": {
+              "type": "MultiPolygon",
+              "coordinates": [[[
+                [11.0, 48.0],
+                [11.1, 48.0],
+                [11.1, 48.1],
+                [11.0, 48.0]
+              ]]]
+            }
+          }
+        ]
+      },
+      "global_rules": [
+        {
+          "vehicle_type_id": "bike",
+          "ride_allowed": false,
+          "ride_through_allowed": true
+        }
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(1U, provider.geofencing_zones_.zones_.size());
+  auto const& rules = provider.geofencing_zones_.zones_.front().rules_;
+  ASSERT_EQ(2U, rules.size());
+  EXPECT_TRUE(rules[0].ride_start_allowed_);
+  EXPECT_FALSE(rules[0].ride_end_allowed_);
+  EXPECT_FALSE(rules[0].ride_through_allowed_);
+  EXPECT_TRUE(rules[1].ride_start_allowed_);
+  EXPECT_TRUE(rules[1].ride_end_allowed_);
+  EXPECT_TRUE(rules[1].ride_through_allowed_);
+
+  ASSERT_EQ(1U, provider.geofencing_zones_.global_rules_.size());
+  EXPECT_FALSE(
+      provider.geofencing_zones_.global_rules_.front().ride_start_allowed_);
+  EXPECT_FALSE(
+      provider.geofencing_zones_.global_rules_.front().ride_end_allowed_);
+  EXPECT_TRUE(
+      provider.geofencing_zones_.global_rules_.front().ride_through_allowed_);
+}
+
+TEST(motis, gbfs_parser_geofencing_skips_bad_parts_and_unknown_type_rules) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_types(provider, json::parse(R"({
+    "data": {
+      "vehicle_types": [
+        {
+          "vehicle_type_id": "bike",
+          "form_factor": "bicycle",
+          "propulsion_type": "human",
+          "return_constraint": "free_floating"
+        }
+      ]
+    }
+  })"));
+
+  load_geofencing_zones(provider, json::parse(R"({
+    "data": {
+      "geofencing_zones": {
+        "type": "FeatureCollection",
+        "features": [
+          "bad",
+          {
+            "type": "Feature",
+            "properties": {"name": "No Rules"},
+            "geometry": {"type": "MultiPolygon", "coordinates": []}
+          },
+          {
+            "type": "Feature",
+            "properties": {
+              "name": "Valid",
+              "rules": [
+                "bad rule",
+                {"vehicle_type_ids": ["unknown"], "ride_allowed": false},
+                {"vehicle_type_ids": ["bike"], "station_parking": true}
+              ]
+            },
+            "geometry": {
+              "type": "MultiPolygon",
+              "coordinates": [[[
+                [11.0, 48.0],
+                [11.1, 48.0],
+                [11.1, 48.1],
+                [11.0, 48.0]
+              ]]]
+            }
+          }
+        ]
+      }
+    }
+  })"));
+
+  ASSERT_EQ(1U, provider.geofencing_zones_.zones_.size());
+  auto const& rules = provider.geofencing_zones_.zones_.front().rules_;
+  ASSERT_EQ(2U, rules.size());
+  ASSERT_EQ(1U, rules[0].vehicle_type_idxs_.size());
+  EXPECT_TRUE(vehicle_type_idx_t::invalid() ==
+              rules[0].vehicle_type_idxs_.front());
+  ASSERT_TRUE(rules[1].station_parking_.has_value());
+  EXPECT_TRUE(*rules[1].station_parking_);
+  EXPECT_EQ(2U, provider.skipped_geofencing_zones_);
+  EXPECT_EQ(1U, provider.skipped_geofencing_rules_);
+}
+
+TEST(motis, gbfs_parser_parse_timestamp_supports_multiple_formats) {
+  auto const seconds =
+      [](std::optional<std::chrono::system_clock::time_point> const& tp) {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+                   tp->time_since_epoch())
+            .count();
+      };
+
+  // POSIX timestamp as integer (GBFS 1.x / 2.x)
+  auto const as_int = parse_timestamp(json::value{1700000000});
+  ASSERT_TRUE(as_int.has_value());
+  EXPECT_EQ(1700000000, seconds(as_int));
+
+  // POSIX timestamp as numeric string
+  auto const as_str = parse_timestamp(json::value{"1700000000"});
+  ASSERT_TRUE(as_str.has_value());
+  EXPECT_EQ(1700000000, seconds(as_str));
+
+  // RFC3339 / ISO 8601 timestamps (GBFS 3.x)
+  auto const utc = parse_timestamp(json::value{"2020-01-01T00:00:00Z"});
+  auto const naive = parse_timestamp(json::value{"2020-01-01T00:00:00"});
+  auto const offset = parse_timestamp(json::value{"2020-01-01T01:00:00+01:00"});
+  ASSERT_TRUE(utc.has_value());
+  ASSERT_TRUE(naive.has_value());
+  ASSERT_TRUE(offset.has_value());
+  EXPECT_TRUE(utc == naive);
+  EXPECT_TRUE(utc == offset);
+
+  // unparseable values
+  EXPECT_FALSE(parse_timestamp(json::value{"not-a-timestamp"}).has_value());
+  EXPECT_FALSE(parse_timestamp(json::value{}).has_value());
+  EXPECT_FALSE(parse_timestamp(json::value{true}).has_value());
+}
+
+TEST(motis, gbfs_parser_discovery_is_lenient_with_bad_feed_entries) {
+  auto const urls = parse_discovery(json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "3.0",
+    "data": {
+      "feeds": [
+        "not-an-object",
+        {"name": "system_information"},
+        {"url": "https://example.com/no-name"},
+        {"name": "station_information", "url": "https://example.com/stations"}
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(1U, urls.size());
+  EXPECT_EQ("https://example.com/stations", urls.at("station_information"));
+
+  EXPECT_TRUE(parse_discovery(json::parse(R"({"data": {}})")).empty());
+}
+
+TEST(motis, gbfs_parser_v1_free_bike_status_without_vehicle_types) {
+  // GBFS 1.x feeds have no vehicle_types and only free_bike_status with bikes
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_status(provider, json::parse(R"({
+    "last_updated": 1,
+    "ttl": 0,
+    "data": {
+      "bikes": [
+        {"bike_id": "bike-1", "lat": 48.1, "lon": 11.5},
+        {"bike_id": "bike-2", "lat": 48.2, "lon": 11.6}
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(2U, provider.vehicle_status_.size());
+  // a default bicycle vehicle type is created for untyped vehicles
+  auto const type_idx = provider.vehicle_status_.front().vehicle_type_idx_;
+  ASSERT_NE(vehicle_type_idx_t::invalid(), type_idx);
+  EXPECT_EQ(vehicle_form_factor::kBicycle,
+            provider.vehicle_types_.at(type_idx).form_factor_);
+  EXPECT_EQ(return_constraint::kFreeFloating,
+            provider.vehicle_types_.at(type_idx).return_constraint_);
+}
+
+TEST(motis, gbfs_parser_vehicle_types_cover_form_factors_and_propulsion) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_vehicle_types(provider, json::parse(R"({
+    "data": {
+      "vehicle_types": [
+        {"vehicle_type_id": "a", "form_factor": "bike",
+         "propulsion_type": "electric_assist", "return_constraint": "any_station"},
+        {"vehicle_type_id": "b", "form_factor": "cargo_bicycle",
+         "propulsion_type": "hybrid", "return_constraint": "roundtrip_station"},
+        {"vehicle_type_id": "c", "form_factor": "car",
+         "propulsion_type": "combustion", "return_constraint": "free_floating"},
+        {"vehicle_type_id": "d", "form_factor": "moped",
+         "propulsion_type": "electric", "return_constraint": "hybrid"},
+        {"vehicle_type_id": "e", "form_factor": "scooter",
+         "propulsion_type": "plug_in_hybrid", "return_constraint": "any_station"},
+        {"vehicle_type_id": "f", "form_factor": "spaceship",
+         "propulsion_type": "warp_drive", "return_constraint": "any_station"}
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(6U, provider.vehicle_types_.size());
+  auto const& vts = provider.vehicle_types_;
+  auto const vt = [&](unsigned const i) -> vehicle_type const& {
+    return vts.at(vehicle_type_idx_t{i});
+  };
+
+  // non-standard "bike" form factor maps to bicycle
+  EXPECT_EQ(vehicle_form_factor::kBicycle, vt(0).form_factor_);
+  EXPECT_EQ(propulsion_type::kElectricAssist, vt(0).propulsion_type_);
+  EXPECT_EQ(return_constraint::kAnyStation, vt(0).return_constraint_);
+
+  EXPECT_EQ(vehicle_form_factor::kCargoBicycle, vt(1).form_factor_);
+  EXPECT_EQ(propulsion_type::kHybrid, vt(1).propulsion_type_);
+  EXPECT_EQ(return_constraint::kRoundtripStation, vt(1).return_constraint_);
+
+  EXPECT_EQ(vehicle_form_factor::kCar, vt(2).form_factor_);
+  EXPECT_EQ(propulsion_type::kCombustion, vt(2).propulsion_type_);
+  EXPECT_EQ(return_constraint::kFreeFloating, vt(2).return_constraint_);
+
+  EXPECT_EQ(vehicle_form_factor::kMoped, vt(3).form_factor_);
+  EXPECT_EQ(propulsion_type::kElectric, vt(3).propulsion_type_);
+  // "hybrid" return constraint maps to free floating
+  EXPECT_EQ(return_constraint::kFreeFloating, vt(3).return_constraint_);
+
+  // pre-3.0 "scooter" form factor maps to standing scooter
+  EXPECT_EQ(vehicle_form_factor::kScooterStanding, vt(4).form_factor_);
+  EXPECT_EQ(propulsion_type::kPlugInHybrid, vt(4).propulsion_type_);
+
+  // unknown form factor / propulsion type fall back to defaults
+  EXPECT_EQ(vehicle_form_factor::kOther, vt(5).form_factor_);
+  EXPECT_EQ(propulsion_type::kHuman, vt(5).propulsion_type_);
+
+  // all of these have an explicit return constraint
+  EXPECT_TRUE(vt(0).known_return_constraint_);
+  EXPECT_TRUE(vt(1).known_return_constraint_);
+  EXPECT_TRUE(vt(2).known_return_constraint_);
+  EXPECT_TRUE(vt(3).known_return_constraint_);
+  EXPECT_TRUE(vt(4).known_return_constraint_);
+  EXPECT_TRUE(vt(5).known_return_constraint_);
+}
+
+TEST(motis, gbfs_parser_station_status_count_only_creates_default_type) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_station_information(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {"station_id": "station-1", "name": "Station", "lat": 1.0, "lon": 2.0}
+      ]
+    }
+  })"));
+
+  load_station_status(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {"station_id": "station-1", "num_bikes_available": 5}
+      ]
+    }
+  })"));
+
+  auto const& status = provider.stations_.at("station-1").status_;
+  EXPECT_EQ(5U, status.num_vehicles_available_);
+  ASSERT_EQ(1U, status.vehicle_types_available_.size());
+  EXPECT_EQ(5U, status.vehicle_types_available_.begin()->second);
+  // a default vehicle type was created for the untyped count
+  ASSERT_EQ(1U, provider.vehicle_types_.size());
+  EXPECT_EQ(vehicle_form_factor::kBicycle,
+            provider.vehicle_types_.front().form_factor_);
+}
+
+TEST(motis, gbfs_parser_system_information_localized_name_and_defaults) {
+  auto provider = gbfs_provider{.id_ = "fallback-id"};
+
+  load_system_information(provider, json::parse(R"({
+    "data": {
+      "name": [{"language": "en", "text": "Localized Bikes"}],
+      "name_short": [{"text": "LB"}]
+    }
+  })"));
+
+  // missing system_id falls back to the provider id
+  EXPECT_EQ("fallback-id", provider.sys_info_.id_);
+  EXPECT_EQ("Localized Bikes", provider.sys_info_.name_);
+  EXPECT_EQ("LB", provider.sys_info_.name_short_);
+  // no brand_assets -> empty color
+  EXPECT_TRUE(provider.sys_info_.color_.empty());
+}
+
+TEST(motis, gbfs_parser_invalid_station_area_is_ignored) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  // station_area has a degenerate ring (< 3 points) -> parsing fails, but the
+  // station itself must still be loaded
+  load_station_information(provider, json::parse(R"({
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "name": "Station",
+          "lat": 1.0,
+          "lon": 2.0,
+          "station_area": {
+            "type": "MultiPolygon",
+            "coordinates": [[[[1.0, 1.0], [2.0, 2.0]]]]
+          }
+        }
+      ]
+    }
+  })"));
+
+  ASSERT_EQ(1U, provider.stations_.size());
+  auto const& station = provider.stations_.at("station-1");
+  EXPECT_DOUBLE_EQ(1.0, station.info_.pos_.lat_);
+  EXPECT_EQ(nullptr, station.info_.station_area_.get());
+}
+
+TEST(motis, gbfs_parser_structurally_invalid_feeds_throw) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  // missing "data" object
+  EXPECT_ANY_THROW(
+      load_station_information(provider, json::parse(R"({"version": "2.3"})")));
+
+  // vehicle status without a vehicles/bikes array
+  EXPECT_ANY_THROW(load_vehicle_status(provider, json::parse(R"({
+    "data": {"foo": 1}
+  })")));
+
+  // geofencing zones that are not a FeatureCollection
+  EXPECT_ANY_THROW(load_geofencing_zones(provider, json::parse(R"({
+    "data": {"geofencing_zones": "not-an-object"}
+  })")));
+}

--- a/test/gbfs_partition_test.cc
+++ b/test/gbfs_partition_test.cc
@@ -5,6 +5,7 @@
 #include <set>
 #include <vector>
 
+#include "motis/gbfs/data.h"
 #include "motis/gbfs/partition.h"
 
 using namespace motis::gbfs;
@@ -95,5 +96,40 @@ TEST(motis, gbfs_partition_disjoint_refinements) {
   p.refine(std::array{4, 5});
 
   auto const expected = std::vector<std::vector<T>>{{0, 1}, {2, 3}, {4, 5}};
+  EXPECT_TRUE(compare_partitions(p.get_sets(), expected));
+}
+
+TEST(motis, gbfs_partition_ignores_out_of_range_elements) {
+  using T = int;
+  auto p = partition<T>{3};
+
+  p.refine(std::array{0, 100, 200});
+
+  auto const expected = std::vector<std::vector<T>>{{0}, {1, 2}};
+  EXPECT_TRUE(compare_partitions(p.get_sets(), expected));
+}
+
+TEST(motis, gbfs_partition_ignores_only_out_of_range) {
+  using T = int;
+  auto p = partition<T>{5};
+
+  p.refine(std::array{10, 20});
+
+  EXPECT_TRUE(compare_partitions(p.get_sets(),
+                                 std::vector<std::vector<T>>{{0, 1, 2, 3, 4}}));
+}
+
+TEST(motis, gbfs_partition_ignores_invalid_vehicle_type_idx) {
+  auto p = partition<vehicle_type_idx_t>{
+      vehicle_type_idx_t{3}};
+
+  p.refine(std::array{
+      vehicle_type_idx_t{0},
+      vehicle_type_idx_t::invalid()});
+
+  auto const expected =
+      std::vector<std::vector<vehicle_type_idx_t>>{{vehicle_type_idx_t{0}},
+                                                    {vehicle_type_idx_t{1},
+                                                     vehicle_type_idx_t{2}}};
   EXPECT_TRUE(compare_partitions(p.get_sets(), expected));
 }

--- a/test/gbfs_partition_test.cc
+++ b/test/gbfs_partition_test.cc
@@ -120,16 +120,11 @@ TEST(motis, gbfs_partition_ignores_only_out_of_range) {
 }
 
 TEST(motis, gbfs_partition_ignores_invalid_vehicle_type_idx) {
-  auto p = partition<vehicle_type_idx_t>{
-      vehicle_type_idx_t{3}};
+  auto p = partition<vehicle_type_idx_t>{vehicle_type_idx_t{3}};
 
-  p.refine(std::array{
-      vehicle_type_idx_t{0},
-      vehicle_type_idx_t::invalid()});
+  p.refine(std::array{vehicle_type_idx_t{0}, vehicle_type_idx_t::invalid()});
 
-  auto const expected =
-      std::vector<std::vector<vehicle_type_idx_t>>{{vehicle_type_idx_t{0}},
-                                                    {vehicle_type_idx_t{1},
-                                                     vehicle_type_idx_t{2}}};
+  auto const expected = std::vector<std::vector<vehicle_type_idx_t>>{
+      {vehicle_type_idx_t{0}}, {vehicle_type_idx_t{1}, vehicle_type_idx_t{2}}};
   EXPECT_TRUE(compare_partitions(p.get_sets(), expected));
 }

--- a/test/gbfs_update_test.cc
+++ b/test/gbfs_update_test.cc
@@ -394,12 +394,6 @@ void run_update(config const& c, std::shared_ptr<gbfs_data>& gbfs) {
   ioc.run();
 }
 
-gbfs_provider const& provider(gbfs_data const& data,
-                              std::string const& id = "test") {
-  auto const idx = data.provider_by_id_.at(id);
-  return *data.providers_.at(idx);
-}
-
 provider_routing_data const& routing_data_for(gbfs_data& gbfs,
                                               gbfs_provider const& p) {
   auto& d = street_data();
@@ -450,7 +444,7 @@ TEST(motis, gbfs_update_initial_file_feed_creates_provider_state) {
 
   ASSERT_NE(nullptr, gbfs);
   ASSERT_EQ(1U, gbfs->providers_.size());
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
 
   EXPECT_EQ("test", p.id_);
   EXPECT_EQ("test-system", p.sys_info_.id_);
@@ -476,13 +470,16 @@ TEST(motis, gbfs_update_reuses_provider_and_applies_status_update) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   auto const c = make_gbfs_config(dir);
   run_update(c, gbfs);
-  auto const first_provider_idx = provider(*gbfs).idx_;
-  auto const first_vehicle_type_count = provider(*gbfs).vehicle_types_.size();
+  auto const first_provider_idx =
+      gbfs->providers_.at(gbfs->provider_by_id_.at("test"))->idx_;
+  auto const first_vehicle_type_count =
+      gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+          ->vehicle_types_.size();
 
   write_station_status(dir, 7U);
   run_update(c, gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   EXPECT_TRUE(first_provider_idx == p.idx_);
   EXPECT_EQ(first_vehicle_type_count, p.vehicle_types_.size());
   EXPECT_EQ(
@@ -498,12 +495,14 @@ TEST(motis, gbfs_update_updates_free_floating_vehicles_on_second_run) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   auto const c = make_gbfs_config(dir);
   run_update(c, gbfs);
-  ASSERT_EQ("vehicle-1", provider(*gbfs).vehicle_status_.front().id_);
+  ASSERT_EQ("vehicle-1", gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+                             ->vehicle_status_.front()
+                             .id_);
 
   write_free_bike_status(dir, "vehicle-2", 49.8755, 8.6280);
   run_update(c, gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   ASSERT_EQ(1U, p.vehicle_status_.size());
   EXPECT_EQ("vehicle-2", p.vehicle_status_.front().id_);
   EXPECT_DOUBLE_EQ(49.8755, p.vehicle_status_.front().pos_.lat_);
@@ -518,7 +517,8 @@ TEST(motis, gbfs_update_ignores_timestamp_only_changes_for_routing_cache) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   auto const c = make_gbfs_config(dir);
   run_update(c, gbfs);
-  auto const provider_idx = provider(*gbfs).idx_;
+  auto const provider_idx =
+      gbfs->providers_.at(gbfs->provider_by_id_.at("test"))->idx_;
   auto const first_cached = gbfs->cache_.get(provider_idx);
   ASSERT_NE(nullptr, first_cached);
 
@@ -533,8 +533,8 @@ TEST(motis, gbfs_update_ignores_timestamp_only_changes_for_routing_cache) {
   auto const third_cached = gbfs->cache_.get(provider_idx);
   ASSERT_NE(nullptr, third_cached);
   EXPECT_NE(first_cached.get(), third_cached.get());
-  EXPECT_EQ(8U, provider(*gbfs)
-                    .stations_.at(std::string{kStation1})
+  EXPECT_EQ(8U, gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+                    ->stations_.at(std::string{kStation1})
                     .status_.num_vehicles_available_);
 }
 
@@ -550,8 +550,8 @@ TEST(motis, gbfs_update_ttl_controls_refresh_behavior) {
     write_station_status(dir, 9U, false, kBikeType, 41U, 3600U);
     run_update(c, gbfs);
 
-    EXPECT_EQ(3U, provider(*gbfs)
-                      .stations_.at(std::string{kStation1})
+    EXPECT_EQ(3U, gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+                      ->stations_.at(std::string{kStation1})
                       .status_.num_vehicles_available_);
   }
 
@@ -566,8 +566,8 @@ TEST(motis, gbfs_update_ttl_controls_refresh_behavior) {
     write_station_status(dir, 9U, false, kBikeType, 41U, 0U);
     run_update(c, gbfs);
 
-    EXPECT_EQ(9U, provider(*gbfs)
-                      .stations_.at(std::string{kStation1})
+    EXPECT_EQ(9U, gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+                      ->stations_.at(std::string{kStation1})
                       .status_.num_vehicles_available_);
   }
 }
@@ -585,7 +585,7 @@ TEST(motis, gbfs_update_station_move_updates_provider_rtree) {
   auto const c = make_gbfs_config(dir);
   run_update(c, gbfs);
 
-  auto const idx = provider(*gbfs).idx_;
+  auto const idx = gbfs->providers_.at(gbfs->provider_by_id_.at("test"))->idx_;
   auto const old_pos = geo::latlng{49.871651, 8.631084};
   auto const new_pos = geo::latlng{49.875309, 8.627667};
   EXPECT_TRUE(rtree_contains(*gbfs, old_pos, idx));
@@ -605,12 +605,13 @@ TEST(motis, gbfs_update_retains_previous_provider_on_malformed_refresh) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   auto const c = make_gbfs_config(dir);
   run_update(c, gbfs);
-  ASSERT_EQ(1U, provider(*gbfs).vehicle_status_.size());
+  ASSERT_EQ(1U, gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+                    ->vehicle_status_.size());
 
   write_file(dir / "station_information.json", R"({"data": {"stations": )");
   run_update(c, gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   ASSERT_EQ(1U, p.stations_.size());
   EXPECT_TRUE(p.stations_.contains(std::string{kStation1}));
   ASSERT_EQ(1U, p.vehicle_status_.size());
@@ -624,12 +625,13 @@ TEST(motis, gbfs_update_discovery_removes_stale_vehicle_feed_data) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   auto const c = make_gbfs_config(dir);
   run_update(c, gbfs);
-  ASSERT_EQ(1U, provider(*gbfs).vehicle_status_.size());
+  ASSERT_EQ(1U, gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+                    ->vehicle_status_.size());
 
   write_discovery(dir, "");
   run_update(c, gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   EXPECT_TRUE(p.vehicle_status_.empty());
   EXPECT_EQ(0U, count_additional_vehicle_nodes(routing_data_for(*gbfs, p)));
 }
@@ -641,7 +643,8 @@ TEST(motis, gbfs_update_recomputes_dependents_when_vehicle_types_change) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   auto const c = make_gbfs_config(dir);
   run_update(c, gbfs);
-  EXPECT_EQ(1U, provider(*gbfs).vehicle_types_.size());
+  EXPECT_EQ(1U, gbfs->providers_.at(gbfs->provider_by_id_.at("test"))
+                    ->vehicle_types_.size());
 
   write_vehicle_types(dir, true);
   write_station_status(dir, 4U, false, kScooterType);
@@ -649,7 +652,7 @@ TEST(motis, gbfs_update_recomputes_dependents_when_vehicle_types_change) {
                          kScooterType);
   run_update(c, gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   ASSERT_EQ(2U, p.vehicle_types_.size());
   ASSERT_EQ(2U, p.products_.size());
   ASSERT_EQ(1U, p.vehicle_status_.size());
@@ -671,7 +674,7 @@ TEST(motis, gbfs_update_handles_inconsistent_references) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   run_update(make_gbfs_config(dir), gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   ASSERT_EQ(1U, p.stations_.size());
   EXPECT_EQ(
       5U,
@@ -694,7 +697,7 @@ TEST(motis, gbfs_update_uses_station_coordinates_for_docked_vehicle_status) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   run_update(make_gbfs_config(dir), gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   ASSERT_EQ(1U, p.vehicle_status_.size());
   EXPECT_DOUBLE_EQ(p.stations_.at(std::string{kStation1}).info_.pos_.lat_,
                    p.vehicle_status_.front().pos_.lat_);
@@ -710,7 +713,7 @@ TEST(motis, gbfs_update_geofence_can_suppress_free_floating_start_node) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   run_update(make_gbfs_config(dir), gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   ASSERT_EQ(1U, p.vehicle_status_.size());
   EXPECT_EQ(0U, count_additional_vehicle_nodes(routing_data_for(*gbfs, p)));
 }
@@ -723,7 +726,7 @@ TEST(motis, gbfs_update_global_geofencing_rules) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   run_update(make_gbfs_config(dir), gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   auto const prod_rd = gbfs->get_products_routing_data(
       *street_data().w_, *street_data().l_,
       gbfs_products_ref{p.idx_, gbfs_products_idx_t{0}});
@@ -744,7 +747,7 @@ TEST(motis, gbfs_update_station_area_marks_base_nodes_return_allowed) {
   auto gbfs = std::shared_ptr<gbfs_data>{};
   run_update(make_gbfs_config(dir), gbfs);
 
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   auto const prod_rd = gbfs->get_products_routing_data(
       *street_data().w_, *street_data().l_,
       gbfs_products_ref{p.idx_, gbfs_products_idx_t{0}});
@@ -799,7 +802,8 @@ TEST(motis, gbfs_update_supports_local_gbfs_manifest_provider_dirs) {
   ASSERT_EQ(1U, gbfs->aggregated_feeds_->size());
   ASSERT_EQ(1U, gbfs->providers_.size());
   ASSERT_TRUE(gbfs->provider_by_id_.contains("agg:provider-a"));
-  auto const& p = provider(*gbfs, "agg:provider-a");
+  auto const& p =
+      *gbfs->providers_.at(gbfs->provider_by_id_.at("agg:provider-a"));
   EXPECT_EQ("agg:provider-a", p.id_);
   ASSERT_EQ(1U, p.stations_.size());
   EXPECT_EQ("Test Bikes", p.sys_info_.name_);
@@ -818,7 +822,9 @@ TEST(motis, gbfs_update_local_manifest_update_adds_and_removes_providers) {
 
   auto const provider_a_idx = gbfs->provider_by_id_.at("agg:provider-a");
   ASSERT_NE(nullptr, gbfs->providers_.at(provider_a_idx));
-  EXPECT_EQ("agg:provider-a", provider(*gbfs, "agg:provider-a").id_);
+  EXPECT_EQ(
+      "agg:provider-a",
+      gbfs->providers_.at(gbfs->provider_by_id_.at("agg:provider-a"))->id_);
 
   write_manifest(dir, {"provider-b"});
   run_update(c, gbfs);
@@ -829,7 +835,9 @@ TEST(motis, gbfs_update_local_manifest_update_adds_and_removes_providers) {
   auto const provider_b_idx = gbfs->provider_by_id_.at("agg:provider-b");
   ASSERT_NE(nullptr, gbfs->providers_.at(provider_b_idx));
   EXPECT_FALSE(provider_a_idx == provider_b_idx);
-  EXPECT_EQ("Provider B", provider(*gbfs, "agg:provider-b").sys_info_.name_);
+  EXPECT_EQ("Provider B",
+            gbfs->providers_.at(gbfs->provider_by_id_.at("agg:provider-b"))
+                ->sys_info_.name_);
 }
 
 TEST(motis, gbfs_update_supports_lamassu_systems_manifest) {
@@ -855,7 +863,8 @@ TEST(motis, gbfs_update_supports_lamassu_systems_manifest) {
   ASSERT_EQ(1U, gbfs->aggregated_feeds_->size());
   ASSERT_EQ(1U, gbfs->providers_.size());
   ASSERT_TRUE(gbfs->provider_by_id_.contains("agg:system-a"));
-  auto const& p = provider(*gbfs, "agg:system-a");
+  auto const& p =
+      *gbfs->providers_.at(gbfs->provider_by_id_.at("agg:system-a"));
   EXPECT_EQ("agg:system-a", p.id_);
   ASSERT_EQ(1U, p.stations_.size());
   EXPECT_EQ("Test Bikes", p.sys_info_.name_);
@@ -887,7 +896,7 @@ TEST(motis, gbfs_update_handles_v1_feed_without_vehicle_types) {
   run_update(make_gbfs_config(dir), gbfs);
 
   ASSERT_EQ(1U, gbfs->providers_.size());
-  auto const& p = provider(*gbfs);
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
   ASSERT_EQ(1U, p.stations_.size());
   EXPECT_EQ(
       3U,

--- a/test/gbfs_update_test.cc
+++ b/test/gbfs_update_test.cc
@@ -307,6 +307,43 @@ void write_geofencing_global_no_return(fs::path const& dir) {
   })");
 }
 
+void write_geofencing_unknown_type_ref(fs::path const& dir) {
+  write_file(dir / "geofencing_zones.json", R"({
+    "last_updated": 60,
+    "ttl": 0,
+    "version": "3.0",
+    "data": {
+      "geofencing_zones": {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "name": "Unknown Type Zone",
+              "rules": [
+                {
+                  "vehicle_type_ids": ["unknown-type"],
+                  "ride_allowed": false
+                }
+              ]
+            },
+            "geometry": {
+              "type": "MultiPolygon",
+              "coordinates": [[[
+                [8.62, 49.87],
+                [8.64, 49.87],
+                [8.64, 49.88],
+                [8.62, 49.88],
+                [8.62, 49.87]
+              ]]]
+            }
+          }
+        ]
+      }
+    }
+  })");
+}
+
 void write_default_feed(fs::path const& dir) {
   write_discovery(dir);
   write_system_information(dir);
@@ -868,6 +905,19 @@ TEST(motis, gbfs_update_supports_lamassu_systems_manifest) {
   EXPECT_EQ("agg:system-a", p.id_);
   ASSERT_EQ(1U, p.stations_.size());
   EXPECT_EQ("Test Bikes", p.sys_info_.name_);
+}
+
+TEST(motis, gbfs_update_geofencing_unknown_type_ref) {
+  auto const dir = make_temp_dir("unknown-type-geofence");
+  write_default_feed(dir);
+  write_geofencing_unknown_type_ref(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  auto const& p = *gbfs->providers_.at(gbfs->provider_by_id_.at("test"));
+  EXPECT_TRUE(p.has_vehicles_to_rent_);
+  EXPECT_FALSE(p.products_.empty());
 }
 
 TEST(motis, gbfs_update_handles_v1_feed_without_vehicle_types) {

--- a/test/gbfs_update_test.cc
+++ b/test/gbfs_update_test.cc
@@ -1,0 +1,900 @@
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include "boost/json.hpp"
+
+#include "boost/asio/co_spawn.hpp"
+#include "boost/asio/detached.hpp"
+#include "boost/asio/io_context.hpp"
+
+#include "fmt/format.h"
+
+#include "motis/config.h"
+#include "motis/data.h"
+#include "motis/gbfs/data.h"
+#include "motis/gbfs/update.h"
+#include "motis/import.h"
+#include "motis/metrics_registry.h"
+
+namespace fs = std::filesystem;
+namespace json = boost::json;
+using namespace motis;
+using namespace motis::gbfs;
+using namespace std::string_view_literals;
+
+namespace {
+
+constexpr auto const kBikeType = "bike"sv;
+constexpr auto const kScooterType = "scooter"sv;
+constexpr auto const kStation1 = "station-1"sv;
+
+fs::path make_temp_dir(std::string_view const name) {
+  auto dir = fs::temp_directory_path() / "motis-gbfs-tests" / name;
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  return dir;
+}
+
+void write_file(fs::path const& path, std::string_view const content) {
+  fs::create_directories(path.parent_path());
+  auto out = std::ofstream{path};
+  out << content;
+}
+
+void write_discovery(fs::path const& dir,
+                     std::string_view vehicle_feed = "free_bike_status",
+                     bool const include_geofencing = true,
+                     bool const include_vehicle_types = true) {
+  auto feeds = json::array{
+      {{"name", "system_information"}, {"url", "system_information"}},
+      {{"name", "station_information"}, {"url", "station_information"}},
+      {{"name", "station_status"}, {"url", "station_status"}},
+  };
+  if (include_vehicle_types) {
+    feeds.push_back({{"name", "vehicle_types"}, {"url", "vehicle_types"}});
+  }
+  if (!vehicle_feed.empty()) {
+    feeds.push_back({{"name", vehicle_feed}, {"url", vehicle_feed}});
+  }
+  if (include_geofencing) {
+    feeds.push_back(
+        {{"name", "geofencing_zones"}, {"url", "geofencing_zones"}});
+  }
+
+  write_file(dir / "gbfs.json", json::serialize(json::value{
+                                    {"last_updated", 1},
+                                    {"ttl", 0},
+                                    {"version", "2.3"},
+                                    {"data", {{"feeds", std::move(feeds)}}},
+                                }));
+}
+
+void write_system_information(fs::path const& dir,
+                              std::string_view const name = "Test Bikes",
+                              std::string_view const color = "#112233") {
+  write_file(dir / "system_information.json",
+             json::serialize(json::value{
+                 {"last_updated", 10},
+                 {"ttl", 0},
+                 {"version", "2.3"},
+                 {"data",
+                  {{"system_id", "test-system"},
+                   {"name", name},
+                   {"brand_assets", {{"color", color}}}}},
+             }));
+}
+
+void write_vehicle_types(
+    fs::path const& dir,
+    bool const include_scooter = false,
+    std::string_view const bike_return_constraint = "hybrid") {
+  auto types = json::array{};
+  types.push_back({{"vehicle_type_id", "bike"},
+                   {"form_factor", "bicycle"},
+                   {"propulsion_type", "human"},
+                   {"return_constraint", bike_return_constraint}});
+  if (include_scooter) {
+    types.push_back({{"vehicle_type_id", "scooter"},
+                     {"form_factor", "scooter_standing"},
+                     {"propulsion_type", "electric"},
+                     {"return_constraint", "free_floating"}});
+  }
+
+  write_file(dir / "vehicle_types.json",
+             json::serialize(json::value{
+                 {"last_updated", 20},
+                 {"ttl", 0},
+                 {"version", "3.0"},
+                 {"data", {{"vehicle_types", std::move(types)}}},
+             }));
+}
+
+void write_station_information(fs::path const& dir,
+                               double const station_1_lat = 49.871651,
+                               double const station_1_lon = 8.631084) {
+  write_file(dir / "station_information.json",
+             json::serialize(json::value{
+                 {"last_updated", 30},
+                 {"ttl", 0},
+                 {"version", "2.3"},
+                 {"data",
+                  {{"stations", json::array{{{"station_id", "station-1"},
+                                             {"name", "Main Station"},
+                                             {"lat", station_1_lat},
+                                             {"lon", station_1_lon}}}}}},
+             }));
+}
+
+void write_station_information_with_area(fs::path const& dir) {
+  write_file(dir / "station_information.json", R"({
+    "last_updated": 30,
+    "ttl": 0,
+    "version": "2.3",
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "name": "Main Station",
+          "lat": 49.871651,
+          "lon": 8.631084,
+          "station_area": {
+            "type": "MultiPolygon",
+            "coordinates": [[[
+              [8.626, 49.870],
+              [8.634, 49.870],
+              [8.634, 49.877],
+              [8.626, 49.877],
+              [8.626, 49.870]
+            ]]]
+          }
+        }
+      ]
+    }
+  })");
+}
+
+void write_station_status(fs::path const& dir,
+                          unsigned const bike_count = 3U,
+                          bool const include_bad_station = false,
+                          std::string_view const type_id = kBikeType,
+                          unsigned const last_updated = 40U,
+                          unsigned const ttl = 0U) {
+  auto stations = json::array{};
+  stations.push_back({{"station_id", "station-1"},
+                      {"num_bikes_available", bike_count},
+                      {"vehicle_types_available",
+                       {{{"vehicle_type_id", type_id}, {"count", bike_count}}}},
+                      {"vehicle_docks_available",
+                       {{{"vehicle_type_ids", {type_id}}, {"count", 2U}}}},
+                      {"is_renting", true},
+                      {"is_returning", true}});
+  if (include_bad_station) {
+    stations.push_back(
+        {{"station_id", "missing-station"}, {"num_bikes_available", 9U}});
+  }
+
+  write_file(dir / "station_status.json",
+             json::serialize(json::value{
+                 {"last_updated", last_updated},
+                 {"ttl", ttl},
+                 {"version", "2.3"},
+                 {"data", {{"stations", std::move(stations)}}},
+             }));
+}
+
+void write_free_bike_status(fs::path const& dir,
+                            std::string_view const vehicle_id = "vehicle-1",
+                            double const lat = 49.875309,
+                            double const lon = 8.627667,
+                            bool const reserved = false,
+                            bool const disabled = false,
+                            std::string_view const type_id = kBikeType) {
+  write_file(dir / "free_bike_status.json",
+             json::serialize(json::value{
+                 {"last_updated", 50},
+                 {"ttl", 0},
+                 {"version", "2.3"},
+                 {"data",
+                  {{"bikes", json::array{{{"bike_id", vehicle_id},
+                                          {"lat", lat},
+                                          {"lon", lon},
+                                          {"is_reserved", reserved},
+                                          {"is_disabled", disabled},
+                                          {"vehicle_type_id", type_id}}}}}},
+             }));
+}
+
+void write_vehicle_status_at_station(fs::path const& dir,
+                                     std::string_view const station_id,
+                                     std::string_view const type_id) {
+  write_file(dir / "vehicle_status.json",
+             json::serialize(json::value{
+                 {"last_updated", 50},
+                 {"ttl", 0},
+                 {"version", "3.0"},
+                 {"data",
+                  {{"vehicles", json::array{{{"vehicle_id", "docked-vehicle"},
+                                             {"station_id", station_id},
+                                             {"is_reserved", false},
+                                             {"is_disabled", false},
+                                             {"vehicle_type_id", type_id}}}}}},
+             }));
+}
+
+void write_empty_geofencing(fs::path const& dir) {
+  write_file(
+      dir / "geofencing_zones.json",
+      json::serialize(json::value{
+          {"last_updated", 60},
+          {"ttl", 0},
+          {"version", "2.3"},
+          {"data",
+           {{"geofencing_zones",
+             {{"type", "FeatureCollection"}, {"features", json::array{}}}}}},
+      }));
+}
+
+void write_geofencing_no_start_zone(fs::path const& dir) {
+  write_file(dir / "geofencing_zones.json", R"({
+    "last_updated": 60,
+    "ttl": 0,
+    "version": "3.0",
+    "data": {
+      "geofencing_zones": {
+        "type": "FeatureCollection",
+        "features": [
+          {
+            "type": "Feature",
+            "properties": {
+              "name": "No Start",
+              "rules": [
+                {
+                  "vehicle_type_ids": ["bike"],
+                  "ride_allowed": true,
+                  "ride_start_allowed": false
+                }
+              ]
+            },
+            "geometry": {
+              "type": "MultiPolygon",
+              "coordinates": [[[
+                [8.62, 49.87],
+                [8.64, 49.87],
+                [8.64, 49.88],
+                [8.62, 49.88],
+                [8.62, 49.87]
+              ]]]
+            }
+          }
+        ]
+      },
+      "global_rules": [
+        {"vehicle_type_ids": ["bike"], "ride_allowed": true}
+      ]
+    }
+  })");
+}
+
+void write_geofencing_global_no_return(fs::path const& dir) {
+  write_file(dir / "geofencing_zones.json", R"({
+    "last_updated": 60,
+    "ttl": 0,
+    "version": "3.0",
+    "data": {
+      "geofencing_zones": {
+        "type": "FeatureCollection",
+        "features": []
+      },
+      "global_rules": [
+        {
+          "vehicle_type_ids": ["bike"],
+          "ride_allowed": false,
+          "ride_through_allowed": true
+        }
+      ]
+    }
+  })");
+}
+
+void write_default_feed(fs::path const& dir) {
+  write_discovery(dir);
+  write_system_information(dir);
+  write_vehicle_types(dir);
+  write_station_information(dir);
+  write_station_status(dir);
+  write_free_bike_status(dir);
+  write_empty_geofencing(dir);
+}
+
+void write_manifest(fs::path const& dir,
+                    std::vector<std::string_view> const& provider_ids) {
+  auto datasets = json::array{};
+  for (auto const provider_id : provider_ids) {
+    datasets.push_back(
+        {{"system_id", provider_id},
+         {"versions", {{{"version", "2.3"}, {"url", provider_id}}}}});
+  }
+
+  auto const manifest = json::serialize(json::value{
+      {"last_updated", 1},
+      {"ttl", 0},
+      {"version", "3.0"},
+      {"data", {{"datasets", std::move(datasets)}}},
+  });
+  write_file(dir / "gbfs.json", manifest);
+  write_file(dir / "manifest.json", manifest);
+}
+
+data& street_data() {
+  static auto d = []() {
+    auto const path = fs::path{"test/data_gbfs_update_osm"};
+    auto ec = std::error_code{};
+    fs::remove_all(path, ec);
+    auto const c = config{.osm_ = {"test/resources/test_case.osm.pbf"},
+                          .street_routing_ = true};
+    import(c, path);
+    return std::make_unique<data>(path, c);
+  }();
+  return *d;
+}
+
+config make_gbfs_config(fs::path const& dir, std::string const& id = "test") {
+  auto c = config{};
+  c.gbfs_ = config::gbfs{
+      .feeds_ = {{id,
+                  config::gbfs::feed{
+                      .url_ = dir.string(),
+                      .ttl_ =
+                          config::gbfs::ttl{.overwrite_ =
+                                                std::map<std::string, unsigned>{
+                                                    {"gbfs", 0U},
+                                                    {"manifest", 0U},
+                                                    {"system_information", 0U},
+                                                    {"vehicle_types", 0U},
+                                                    {"station_information", 0U},
+                                                    {"station_status", 0U},
+                                                    {"vehicle_status", 0U},
+                                                    {"free_bike_status", 0U},
+                                                    {"geofencing_zones",
+                                                     0U}}}}}},
+      .cache_size_ = 20U};
+  return c;
+}
+
+config make_gbfs_config_without_ttl_overwrite(fs::path const& dir,
+                                              std::string const& id = "test") {
+  auto c = config{};
+  c.gbfs_ =
+      config::gbfs{.feeds_ = {{id, config::gbfs::feed{.url_ = dir.string()}}},
+                   .cache_size_ = 20U};
+  return c;
+}
+
+void run_update(config const& c, std::shared_ptr<gbfs_data>& gbfs) {
+  auto& d = street_data();
+  auto ioc = boost::asio::io_context{};
+  auto metrics = metrics_registry{};
+  boost::asio::co_spawn(
+      ioc,
+      [&]() -> boost::asio::awaitable<void> {
+        co_await update(c, *d.w_, *d.l_, gbfs, &metrics);
+      },
+      boost::asio::detached);
+  ioc.run();
+}
+
+gbfs_provider const& provider(gbfs_data const& data,
+                              std::string const& id = "test") {
+  auto const idx = data.provider_by_id_.at(id);
+  return *data.providers_.at(idx);
+}
+
+provider_routing_data const& routing_data_for(gbfs_data& gbfs,
+                                              gbfs_provider const& p) {
+  auto& d = street_data();
+  return *gbfs.get_products_routing_data(
+                  *d.w_, *d.l_,
+                  gbfs_products_ref{p.idx_, gbfs_products_idx_t{0}})
+              ->provider_routing_data_;
+}
+
+std::size_t additional_node_count(gbfs_data& gbfs, gbfs_provider const& p) {
+  auto const& prd = routing_data_for(gbfs, p);
+  if (prd.products_.empty()) {
+    return 0U;
+  }
+  return prd.products_.front().additional_nodes_.size();
+}
+
+bool rtree_contains(gbfs_data const& gbfs,
+                    geo::latlng const& pos,
+                    gbfs_provider_idx_t const idx,
+                    double const radius = 5.0) {
+  auto found = false;
+  gbfs.provider_rtree_.in_radius(pos, radius, [&](gbfs_provider_idx_t const x) {
+    found = found || x == idx;
+  });
+  return found;
+}
+
+std::size_t count_additional_vehicle_nodes(provider_routing_data const& prd) {
+  if (prd.products_.empty()) {
+    return 0U;
+  }
+  auto const& nodes = prd.products_.front().additional_nodes_;
+  return static_cast<std::size_t>(
+      std::count_if(begin(nodes), end(nodes), [](additional_node const& n) {
+        return std::holds_alternative<additional_node::vehicle>(n.data_);
+      }));
+}
+
+}  // namespace
+
+TEST(motis, gbfs_update_initial_file_feed_creates_provider_state) {
+  auto const dir = make_temp_dir("initial");
+  write_default_feed(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  ASSERT_NE(nullptr, gbfs);
+  ASSERT_EQ(1U, gbfs->providers_.size());
+  auto const& p = provider(*gbfs);
+
+  EXPECT_EQ("test", p.id_);
+  EXPECT_EQ("test-system", p.sys_info_.id_);
+  EXPECT_EQ("Test Bikes", p.sys_info_.name_);
+  ASSERT_TRUE(p.color_.has_value());
+  EXPECT_EQ("#112233", *p.color_);
+  ASSERT_EQ(1U, p.stations_.size());
+  EXPECT_EQ(
+      3U,
+      p.stations_.at(std::string{kStation1}).status_.num_vehicles_available_);
+  ASSERT_EQ(1U, p.vehicle_status_.size());
+  EXPECT_EQ("vehicle-1", p.vehicle_status_.front().id_);
+  ASSERT_EQ(1U, p.products_.size());
+  EXPECT_TRUE(p.has_vehicles_to_rent_);
+  EXPECT_TRUE(gbfs->cache_.contains(p.idx_));
+  EXPECT_GT(additional_node_count(*gbfs, p), 0U);
+}
+
+TEST(motis, gbfs_update_reuses_provider_and_applies_status_update) {
+  auto const dir = make_temp_dir("status-update");
+  write_default_feed(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir);
+  run_update(c, gbfs);
+  auto const first_provider_idx = provider(*gbfs).idx_;
+  auto const first_vehicle_type_count = provider(*gbfs).vehicle_types_.size();
+
+  write_station_status(dir, 7U);
+  run_update(c, gbfs);
+
+  auto const& p = provider(*gbfs);
+  EXPECT_TRUE(first_provider_idx == p.idx_);
+  EXPECT_EQ(first_vehicle_type_count, p.vehicle_types_.size());
+  EXPECT_EQ(
+      7U,
+      p.stations_.at(std::string{kStation1}).status_.num_vehicles_available_);
+  EXPECT_TRUE(p.has_vehicles_to_rent_);
+}
+
+TEST(motis, gbfs_update_updates_free_floating_vehicles_on_second_run) {
+  auto const dir = make_temp_dir("vehicle-update");
+  write_default_feed(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir);
+  run_update(c, gbfs);
+  ASSERT_EQ("vehicle-1", provider(*gbfs).vehicle_status_.front().id_);
+
+  write_free_bike_status(dir, "vehicle-2", 49.8755, 8.6280);
+  run_update(c, gbfs);
+
+  auto const& p = provider(*gbfs);
+  ASSERT_EQ(1U, p.vehicle_status_.size());
+  EXPECT_EQ("vehicle-2", p.vehicle_status_.front().id_);
+  EXPECT_DOUBLE_EQ(49.8755, p.vehicle_status_.front().pos_.lat_);
+  EXPECT_DOUBLE_EQ(8.6280, p.vehicle_status_.front().pos_.lng_);
+  EXPECT_TRUE(p.has_vehicles_to_rent_);
+}
+
+TEST(motis, gbfs_update_ignores_timestamp_only_changes_for_routing_cache) {
+  auto const dir = make_temp_dir("timestamp-hash");
+  write_default_feed(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir);
+  run_update(c, gbfs);
+  auto const provider_idx = provider(*gbfs).idx_;
+  auto const first_cached = gbfs->cache_.get(provider_idx);
+  ASSERT_NE(nullptr, first_cached);
+
+  write_station_status(dir, 3U, false, kBikeType, 41U);
+  run_update(c, gbfs);
+  auto const second_cached = gbfs->cache_.get(provider_idx);
+  ASSERT_NE(nullptr, second_cached);
+  EXPECT_EQ(first_cached.get(), second_cached.get());
+
+  write_station_status(dir, 8U, false, kBikeType, 42U);
+  run_update(c, gbfs);
+  auto const third_cached = gbfs->cache_.get(provider_idx);
+  ASSERT_NE(nullptr, third_cached);
+  EXPECT_NE(first_cached.get(), third_cached.get());
+  EXPECT_EQ(8U, provider(*gbfs)
+                    .stations_.at(std::string{kStation1})
+                    .status_.num_vehicles_available_);
+}
+
+TEST(motis, gbfs_update_ttl_controls_refresh_behavior) {
+  {
+    auto const dir = make_temp_dir("ttl-3600");
+    write_default_feed(dir);
+    write_station_status(dir, 3U, false, kBikeType, 40U, 3600U);
+
+    auto gbfs = std::shared_ptr<gbfs_data>{};
+    auto const c = make_gbfs_config_without_ttl_overwrite(dir);
+    run_update(c, gbfs);
+    write_station_status(dir, 9U, false, kBikeType, 41U, 3600U);
+    run_update(c, gbfs);
+
+    EXPECT_EQ(3U, provider(*gbfs)
+                      .stations_.at(std::string{kStation1})
+                      .status_.num_vehicles_available_);
+  }
+
+  {
+    auto const dir = make_temp_dir("ttl-0");
+    write_default_feed(dir);
+    write_station_status(dir, 3U, false, kBikeType, 40U, 0U);
+
+    auto gbfs = std::shared_ptr<gbfs_data>{};
+    auto const c = make_gbfs_config_without_ttl_overwrite(dir);
+    run_update(c, gbfs);
+    write_station_status(dir, 9U, false, kBikeType, 41U, 0U);
+    run_update(c, gbfs);
+
+    EXPECT_EQ(9U, provider(*gbfs)
+                      .stations_.at(std::string{kStation1})
+                      .status_.num_vehicles_available_);
+  }
+}
+
+TEST(motis, gbfs_update_station_move_updates_provider_rtree) {
+  auto const dir = make_temp_dir("station-rtree");
+  write_discovery(dir, "");
+  write_system_information(dir);
+  write_vehicle_types(dir);
+  write_station_information(dir);
+  write_station_status(dir);
+  write_empty_geofencing(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir);
+  run_update(c, gbfs);
+
+  auto const idx = provider(*gbfs).idx_;
+  auto const old_pos = geo::latlng{49.871651, 8.631084};
+  auto const new_pos = geo::latlng{49.875309, 8.627667};
+  EXPECT_TRUE(rtree_contains(*gbfs, old_pos, idx));
+  EXPECT_FALSE(rtree_contains(*gbfs, new_pos, idx));
+
+  write_station_information(dir, new_pos.lat_, new_pos.lng_);
+  run_update(c, gbfs);
+
+  EXPECT_FALSE(rtree_contains(*gbfs, old_pos, idx));
+  EXPECT_TRUE(rtree_contains(*gbfs, new_pos, idx));
+}
+
+TEST(motis, gbfs_update_retains_previous_provider_on_malformed_refresh) {
+  auto const dir = make_temp_dir("bad-refresh");
+  write_default_feed(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir);
+  run_update(c, gbfs);
+  ASSERT_EQ(1U, provider(*gbfs).vehicle_status_.size());
+
+  write_file(dir / "station_information.json", R"({"data": {"stations": )");
+  run_update(c, gbfs);
+
+  auto const& p = provider(*gbfs);
+  ASSERT_EQ(1U, p.stations_.size());
+  EXPECT_TRUE(p.stations_.contains(std::string{kStation1}));
+  ASSERT_EQ(1U, p.vehicle_status_.size());
+  EXPECT_EQ("vehicle-1", p.vehicle_status_.front().id_);
+}
+
+TEST(motis, gbfs_update_discovery_removes_stale_vehicle_feed_data) {
+  auto const dir = make_temp_dir("discovery-removes-vehicles");
+  write_default_feed(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir);
+  run_update(c, gbfs);
+  ASSERT_EQ(1U, provider(*gbfs).vehicle_status_.size());
+
+  write_discovery(dir, "");
+  run_update(c, gbfs);
+
+  auto const& p = provider(*gbfs);
+  EXPECT_TRUE(p.vehicle_status_.empty());
+  EXPECT_EQ(0U, count_additional_vehicle_nodes(routing_data_for(*gbfs, p)));
+}
+
+TEST(motis, gbfs_update_recomputes_dependents_when_vehicle_types_change) {
+  auto const dir = make_temp_dir("vehicle-types-update");
+  write_default_feed(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir);
+  run_update(c, gbfs);
+  EXPECT_EQ(1U, provider(*gbfs).vehicle_types_.size());
+
+  write_vehicle_types(dir, true);
+  write_station_status(dir, 4U, false, kScooterType);
+  write_free_bike_status(dir, "scooter-1", 49.875309, 8.627667, false, false,
+                         kScooterType);
+  run_update(c, gbfs);
+
+  auto const& p = provider(*gbfs);
+  ASSERT_EQ(2U, p.vehicle_types_.size());
+  ASSERT_EQ(2U, p.products_.size());
+  ASSERT_EQ(1U, p.vehicle_status_.size());
+  auto const scooter_idx = p.vehicle_status_.front().vehicle_type_idx_;
+  ASSERT_NE(vehicle_type_idx_t::invalid(), scooter_idx);
+  EXPECT_EQ("scooter", p.vehicle_types_.at(scooter_idx).id_);
+}
+
+TEST(motis, gbfs_update_handles_inconsistent_references) {
+  auto const dir = make_temp_dir("inconsistent");
+  write_discovery(dir, "vehicle_status");
+  write_system_information(dir);
+  write_vehicle_types(dir);
+  write_station_information(dir);
+  write_station_status(dir, 5U, true, "missing-type");
+  write_vehicle_status_at_station(dir, "missing-station", kBikeType);
+  write_empty_geofencing(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  auto const& p = provider(*gbfs);
+  ASSERT_EQ(1U, p.stations_.size());
+  EXPECT_EQ(
+      5U,
+      p.stations_.at(std::string{kStation1}).status_.num_vehicles_available_);
+  EXPECT_TRUE(p.vehicle_status_.empty());
+  EXPECT_GE(p.skipped_station_status_, 1U);
+  EXPECT_GE(p.skipped_vehicle_status_, 1U);
+}
+
+TEST(motis, gbfs_update_uses_station_coordinates_for_docked_vehicle_status) {
+  auto const dir = make_temp_dir("docked-vehicle");
+  write_discovery(dir, "vehicle_status");
+  write_system_information(dir);
+  write_vehicle_types(dir);
+  write_station_information(dir);
+  write_station_status(dir, 1U);
+  write_vehicle_status_at_station(dir, kStation1, kBikeType);
+  write_empty_geofencing(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  auto const& p = provider(*gbfs);
+  ASSERT_EQ(1U, p.vehicle_status_.size());
+  EXPECT_DOUBLE_EQ(p.stations_.at(std::string{kStation1}).info_.pos_.lat_,
+                   p.vehicle_status_.front().pos_.lat_);
+  EXPECT_DOUBLE_EQ(p.stations_.at(std::string{kStation1}).info_.pos_.lng_,
+                   p.vehicle_status_.front().pos_.lng_);
+}
+
+TEST(motis, gbfs_update_geofence_can_suppress_free_floating_start_node) {
+  auto const dir = make_temp_dir("geofence-no-start");
+  write_default_feed(dir);
+  write_geofencing_no_start_zone(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  auto const& p = provider(*gbfs);
+  ASSERT_EQ(1U, p.vehicle_status_.size());
+  EXPECT_EQ(0U, count_additional_vehicle_nodes(routing_data_for(*gbfs, p)));
+}
+
+TEST(motis, gbfs_update_global_geofencing_rules) {
+  auto const dir = make_temp_dir("global-geofence");
+  write_default_feed(dir);
+  write_geofencing_global_no_return(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  auto const& p = provider(*gbfs);
+  auto const prod_rd = gbfs->get_products_routing_data(
+      *street_data().w_, *street_data().l_,
+      gbfs_products_ref{p.idx_, gbfs_products_idx_t{0}});
+  auto const n = osr::node_idx_t{0U};
+  EXPECT_FALSE(prod_rd->end_allowed_.test(n));
+  EXPECT_TRUE(prod_rd->through_allowed_.test(n));
+}
+
+TEST(motis, gbfs_update_station_area_marks_base_nodes_return_allowed) {
+  auto const dir = make_temp_dir("station-area");
+  write_discovery(dir, "");
+  write_system_information(dir);
+  write_vehicle_types(dir, false, "any_station");
+  write_station_information_with_area(dir);
+  write_station_status(dir, 3U);
+  write_empty_geofencing(dir);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  auto const& p = provider(*gbfs);
+  auto const prod_rd = gbfs->get_products_routing_data(
+      *street_data().w_, *street_data().l_,
+      gbfs_products_ref{p.idx_, gbfs_products_idx_t{0}});
+  auto has_base_return_node = false;
+  for (auto i = 0U; i != street_data().w_->n_nodes(); ++i) {
+    has_base_return_node =
+        has_base_return_node || prod_rd->end_allowed_.test(osr::node_idx_t{i});
+  }
+  EXPECT_TRUE(has_base_return_node);
+}
+
+TEST(motis, gbfs_update_supports_local_gbfs_manifest_provider_dirs) {
+  auto const dir = make_temp_dir("manifest");
+  auto const provider_dir = dir / "provider-a";
+  write_default_feed(provider_dir);
+  write_file(dir / "gbfs.json", R"({
+    "last_updated": 1,
+    "ttl": 0,
+    "version": "3.0",
+    "data": {
+      "datasets": [
+        {
+          "system_id": "provider-a",
+          "versions": [
+            {"version": "2.3", "url": "provider-a"}
+          ]
+        },
+        "bad",
+        {"system_id": "missing-url", "versions": [{}]}
+      ]
+    }
+  })");
+  write_file(dir / "manifest.json", R"({
+    "last_updated": 1,
+    "ttl": 0,
+    "version": "3.0",
+    "data": {
+      "datasets": [
+        {
+          "system_id": "provider-a",
+          "versions": [
+            {"version": "2.3", "url": "provider-a"}
+          ]
+        }
+      ]
+    }
+  })");
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir, "agg"), gbfs);
+
+  ASSERT_EQ(1U, gbfs->aggregated_feeds_->size());
+  ASSERT_EQ(1U, gbfs->providers_.size());
+  ASSERT_TRUE(gbfs->provider_by_id_.contains("agg:provider-a"));
+  auto const& p = provider(*gbfs, "agg:provider-a");
+  EXPECT_EQ("agg:provider-a", p.id_);
+  ASSERT_EQ(1U, p.stations_.size());
+  EXPECT_EQ("Test Bikes", p.sys_info_.name_);
+}
+
+TEST(motis, gbfs_update_local_manifest_update_adds_and_removes_providers) {
+  auto const dir = make_temp_dir("manifest-update");
+  write_default_feed(dir / "provider-a");
+  write_default_feed(dir / "provider-b");
+  write_system_information(dir / "provider-b", "Provider B", "#445566");
+  write_manifest(dir, {"provider-a"});
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  auto const c = make_gbfs_config(dir, "agg");
+  run_update(c, gbfs);
+
+  auto const provider_a_idx = gbfs->provider_by_id_.at("agg:provider-a");
+  ASSERT_NE(nullptr, gbfs->providers_.at(provider_a_idx));
+  EXPECT_EQ("agg:provider-a", provider(*gbfs, "agg:provider-a").id_);
+
+  write_manifest(dir, {"provider-b"});
+  run_update(c, gbfs);
+
+  ASSERT_TRUE(gbfs->provider_by_id_.contains("agg:provider-a"));
+  ASSERT_TRUE(gbfs->provider_by_id_.contains("agg:provider-b"));
+  EXPECT_EQ(nullptr, gbfs->providers_.at(provider_a_idx));
+  auto const provider_b_idx = gbfs->provider_by_id_.at("agg:provider-b");
+  ASSERT_NE(nullptr, gbfs->providers_.at(provider_b_idx));
+  EXPECT_FALSE(provider_a_idx == provider_b_idx);
+  EXPECT_EQ("Provider B", provider(*gbfs, "agg:provider-b").sys_info_.name_);
+}
+
+TEST(motis, gbfs_update_supports_lamassu_systems_manifest) {
+  auto const dir = make_temp_dir("lamassu");
+  write_default_feed(dir / "system-a");
+
+  // Lamassu 2.3 aggregation format using a top-level "systems" array, mixed
+  // with invalid entries that must be skipped
+  auto const manifest = json::serialize(json::value{
+      {"last_updated", 1},
+      {"ttl", 0},
+      {"version", "2.3"},
+      {"systems",
+       json::array{json::value{{"id", "system-a"}, {"url", "system-a"}},
+                   json::value{{"id", ""}, {"url", "bad"}}, "not-an-object"}},
+  });
+  write_file(dir / "gbfs.json", manifest);
+  write_file(dir / "manifest.json", manifest);
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir, "agg"), gbfs);
+
+  ASSERT_EQ(1U, gbfs->aggregated_feeds_->size());
+  ASSERT_EQ(1U, gbfs->providers_.size());
+  ASSERT_TRUE(gbfs->provider_by_id_.contains("agg:system-a"));
+  auto const& p = provider(*gbfs, "agg:system-a");
+  EXPECT_EQ("agg:system-a", p.id_);
+  ASSERT_EQ(1U, p.stations_.size());
+  EXPECT_EQ("Test Bikes", p.sys_info_.name_);
+}
+
+TEST(motis, gbfs_update_handles_v1_feed_without_vehicle_types) {
+  // GBFS 1.x style feed: no vehicle_types feed, count-only station status and
+  // untyped free-floating bikes
+  auto const dir = make_temp_dir("v1-feed");
+  write_discovery(dir, "free_bike_status", /*include_geofencing=*/false,
+                  /*include_vehicle_types=*/false);
+  write_system_information(dir);
+  write_station_information(dir);
+  write_file(dir / "station_status.json", json::serialize(json::value{
+                                              {"last_updated", 40},
+                                              {"ttl", 0},
+                                              {"version", "1.0"},
+                                              {"data",
+                                               {{"stations",
+                                                 {{{"station_id", "station-1"},
+                                                   {"num_bikes_available", 3},
+                                                   {"is_renting", true},
+                                                   {"is_returning", true}}}}}},
+                                          }));
+  // untyped bike (no vehicle_type_id) -> synthesized default bicycle type
+  write_free_bike_status(dir, "bike-1", 49.875309, 8.627667, false, false, "");
+
+  auto gbfs = std::shared_ptr<gbfs_data>{};
+  run_update(make_gbfs_config(dir), gbfs);
+
+  ASSERT_EQ(1U, gbfs->providers_.size());
+  auto const& p = provider(*gbfs);
+  ASSERT_EQ(1U, p.stations_.size());
+  EXPECT_EQ(
+      3U,
+      p.stations_.at(std::string{kStation1}).status_.num_vehicles_available_);
+  ASSERT_EQ(1U, p.vehicle_status_.size());
+  EXPECT_EQ("bike-1", p.vehicle_status_.front().id_);
+  EXPECT_FALSE(p.products_.empty());
+  EXPECT_TRUE(p.has_vehicles_to_rent_);
+  EXPECT_GT(additional_node_count(*gbfs, p), 0U);
+}


### PR DESCRIPTION
Some GBFS parser + update handling tests

Also adds support for loading aggregated feeds from the file system + fixes a bug with TTL handling (`ttl` should be a top-level field, not inside the data object).