### PR TITLE
ui: Don't flip the order of earlier alternatives after selecting one

### DIFF
--- a/ui/src/lib/ConnectionDetail.svelte
+++ b/ui/src/lib/ConnectionDetail.svelte
@@ -94,7 +94,9 @@
 		const transitStart = (entry: Leg[]) => entry.find(isTransitLeg)?.startTime ?? '';
 		const remainingAlts = (target.alternatives ?? []).filter((a) => a !== alt);
 		const newAlternatives = [...remainingAlts, oldEntry].sort((a, b) =>
-			transitStart(a).localeCompare(transitStart(b))
+			!hasPrevTransit && hasNextTransit
+				? transitStart(b).localeCompare(transitStart(a))
+				: transitStart(a).localeCompare(transitStart(b))
 		);
 
 		const newTransit: Leg = {


### PR DESCRIPTION
The server returns a list in which the first alternative connection is the closest to the original time.

However, after selecting an earlier alternative connection, the list would get sorted lexicographically, reversing the list.

[recording of a bug](https://github.com/user-attachments/assets/743a4d4d-8e2b-4b18-a9b9-01c16c3e49e1)
