### PR TITLE
ui: Dynamic theme change

### DIFF
--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -44,7 +44,7 @@
 	import ItineraryGeoJson from '$lib/map/itineraries/ItineraryGeoJSON.svelte';
 	import maplibregl from 'maplibre-gl';
 	import { browser } from '$app/environment';
-	import { cn, getUrlArray, onClickStop, onClickTrip, pushStateWithQueryString } from '$lib/utils';
+	import { getUrlArray, onClickStop, onClickTrip, pushStateWithQueryString } from '$lib/utils';
 	import Debug from '$lib/Debug.svelte';
 	import Marker from '$lib/map/Marker.svelte';
 	import Popup from '$lib/map/Popup.svelte';
@@ -1154,7 +1154,7 @@
 		bind:zoom
 		bind:center
 		bind:bearing
-		class={cn('h-dvh pt-2 overflow-clip', theme)}
+		class="h-dvh pt-2 overflow-clip"
 		style={showMap ? style : undefined}
 		attribution={false}
 	>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -123,14 +123,18 @@
 		}
 	});
 
-	let theme: 'light' | 'dark' =
-		(hasDark ? 'dark' : hasLight ? 'light' : undefined) ??
-		(browser && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-			? 'dark'
-			: 'light');
-	if (theme === 'dark') {
-		document.documentElement.classList.add('dark');
-	}
+	let theme: 'light' | 'dark' = $derived.by(() => {
+		if (hasDark) return 'dark';
+		if (hasLight) return 'light';
+		return new MediaQuery('(prefers-color-scheme: dark)').current ? 'dark' : 'light';
+	});
+	$effect(() => {
+		if (theme === 'dark') {
+			document.documentElement.classList.add('dark');
+		} else {
+			document.documentElement.classList.remove('dark');
+		}
+	});
 
 	let withHillshades = $state(false);
 	let center = $state.raw<[number, number]>([2.258882912876089, 48.72559118651327]);


### PR DESCRIPTION
Similar to #1466

Works as is on the new/experimental shortbread profile.
The main profile however, should have the layers with conditional fill-color separated to prevent flickering (partial work done in https://github.com/krkk/motis/commit/f789ec06a520825e79c87b5ad36581b4ae1e0dc2)

not sure if we need to check theme from urlParams anymore