### PR TITLE
ui: fix mismatching accessibility labels

### DIFF
--- a/ui/src/lib/AdvancedOptions.svelte
+++ b/ui/src/lib/AdvancedOptions.svelte
@@ -265,6 +265,7 @@
 		<!-- First mile -->
 		<StreetModes
 			label={t.routingSegments.firstMile}
+            ariaLabel={t.routingSegments.maxPreTransitTime}
 			disabled={!allowStreetRouting}
 			bind:modes={preTransitModes}
 			bind:maxTransitTime={maxPreTransitTime}
@@ -277,6 +278,7 @@
 		<!-- Last mile -->
 		<StreetModes
 			label={t.routingSegments.lastMile}
+            ariaLabel={t.routingSegments.maxPostTransitTime}
 			disabled={!allowStreetRouting}
 			bind:modes={postTransitModes}
 			bind:maxTransitTime={maxPostTransitTime}
@@ -290,6 +292,7 @@
 		{#if directModes !== undefined && maxDirectTime !== undefined && ignoreDirectRentalReturnConstraints !== undefined}
 			<StreetModes
 				label={t.routingSegments.direct}
+                ariaLabel={t.routingSegments.maxDirectTime}
 				disabled={!allowStreetRouting}
 				bind:modes={directModes}
 				bind:maxTransitTime={maxDirectTime}

--- a/ui/src/lib/StreetModes.svelte
+++ b/ui/src/lib/StreetModes.svelte
@@ -12,6 +12,7 @@
 
 	let {
 		label,
+		ariaLabel,
 		disabled,
 		modes = $bindable(),
 		maxTransitTime = $bindable(),
@@ -21,6 +22,7 @@
 		providerGroups = $bindable()
 	}: {
 		label: string;
+		ariaLabel: string,
 		disabled?: boolean;
 		modes: PrePostDirectMode[];
 		maxTransitTime: number;
@@ -143,7 +145,7 @@
 	>
 		<Select.Trigger
 			class="flex items-center w-full overflow-hidden"
-			aria-label={t.routingSegments.maxPreTransitTime}
+			aria-label={ariaLabel}
 		>
 			{formatDurationSec(maxTransitTime)}
 		</Select.Trigger>


### PR DESCRIPTION
The `maxPreTransitTime` aria-label was used for all three `StreetModes, including `maxPostTransitTime` and `maxDirectTime`