### PR TITLE
default crow-fly duration for radius offsets

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -77,7 +77,9 @@ paths:
           description: |
             Experimental. Search radius in meters around the `fromPlace` / `toPlace` coordinates.
             When set and the place is given as coordinates, all transit stops within
-            this radius are used as start/end points with zero pre-transit/post-transit time.
+            this radius are used as start/end points. The pre-transit/post-transit time
+            for each of them is estimated from the crow-fly distance to the coordinate
+            at walking speed (1.5 m/s), rounded down to whole minutes.
             Works without OSM/street routing data loaded.
           schema:
             type: number

--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -26,6 +26,7 @@
 #include "osr/types.h"
 
 #include "nigiri/common/interval.h"
+#include "nigiri/constants.h"
 #include "nigiri/location_match_mode.h"
 #include "nigiri/routing/limits.h"
 #include "nigiri/routing/pareto_set.h"
@@ -84,8 +85,17 @@ std::vector<n::routing::offset> radius_offsets(
     geo::latlng const& pos,
     double const radius_meters) {
   auto offsets = std::vector<n::routing::offset>{};
-  loc_tree.in_radius(pos, radius_meters, [&](n::location_idx_t const l) {
-    offsets.push_back({l, n::duration_t{0U}, 0U});
+  loc_tree.find(geo::box{pos, radius_meters}, [&](geo::latlng const& stop_pos,
+                                                  n::location_idx_t const l) {
+    auto const dist = geo::distance(pos, stop_pos);
+    if (dist >= radius_meters) {
+      return;
+    }
+    offsets.push_back(
+        {l,
+         std::chrono::duration_cast<n::duration_t>(
+             std::chrono::seconds{static_cast<int>(dist / n::kWalkSpeed)}),
+         0U});
   });
   return offsets;
 }

--- a/src/journey_to_response.cc
+++ b/src/journey_to_response.cc
@@ -815,6 +815,14 @@ api::Itinerary journey_to_response(
                                            api_version));
             },
             [&](n::routing::offset const x) {
+              if (w == nullptr || l == nullptr) {
+                // no OSM data loaded (e.g. `radius` offsets) -> crow-fly leg
+                append(dummy_itinerary(from, to, to_mode(x.transport_mode_id_),
+                                       j_leg.dep_time_, j_leg.arr_time_,
+                                       api_version));
+                return;
+              }
+
               auto out = std::unique_ptr<output>{};
               if (flex::mode_id::is_flex(x.transport_mode_id_)) {
                 out = std::make_unique<flex::flex_output>(

--- a/test/routing_test.cc
+++ b/test/routing_test.cc
@@ -325,6 +325,44 @@ TEST(motis, routing_osm_only_direct_walk) {
   EXPECT_EQ(api::ModeEnum::WALK, res.direct_.front().legs_.front().mode_);
 }
 
+TEST(motis, routing_radius_without_osm) {
+  auto ec = std::error_code{};
+  std::filesystem::remove_all("test/data_radius", ec);
+
+  auto const c =
+      config{.server_ = {{.web_folder_ = "ui/build", .n_threads_ = 1U}},
+             .timetable_ = config::timetable{
+                 .first_day_ = "2019-05-01",
+                 .num_days_ = 2,
+                 .extend_missing_footpaths_ = false,
+                 .datasets_ = {{"test", {.path_ = std::string{kGTFS}}}}}};
+  import(c, "test/data_radius");
+  auto d = data{"test/data_radius", c};
+
+  auto const routing = utl::init_from<ep::routing>(d).value();
+
+  // fromPlace is ~1962m from DA_10, toPlace is ~1994m from FFM_10.
+  // Without street routing data the offsets are rendered as crow-fly legs.
+  auto const res = routing(
+      "?fromPlace=49.89100,8.62900"
+      "&toPlace=50.08800,8.66100"
+      "&time=2019-05-01T01:30Z"
+      "&radius=5000"
+      "&timetableView=false"
+      "&numLegAlternatives=3");
+
+  ASSERT_FALSE(res.itineraries_.empty());
+  auto const& j = res.itineraries_.front();
+  ASSERT_EQ(3U, j.legs_.size());
+  EXPECT_EQ(api::ModeEnum::WALK, j.legs_.front().mode_);
+  EXPECT_EQ(api::ModeEnum::WALK, j.legs_.back().mode_);
+  EXPECT_EQ("ICE", j.legs_[1].routeShortName_.value_or("-"));
+  // dist / kWalkSpeed, truncated to whole minutes: 1962m -> 21min,
+  // 1994m -> 22min.
+  EXPECT_EQ(21 * 60, j.legs_.front().duration_);
+  EXPECT_EQ(22 * 60, j.legs_.back().duration_);
+}
+
 TEST(motis, routing) {
   auto ec = std::error_code{};
   std::filesystem::remove_all("test/data", ec);
@@ -764,9 +802,16 @@ TEST(motis, routing) {
         "&timetableView=false"
         "&numLegAlternatives=3");
     ASSERT_FALSE(res.itineraries_.empty());
-    EXPECT_TRUE(utl::any_of(res.itineraries_.front().legs_, [](auto const& l) {
+    auto const& j = res.itineraries_.front();
+    EXPECT_TRUE(utl::any_of(j.legs_, [](auto const& l) {
       return l.routeShortName_.has_value() && *l.routeShortName_ == "ICE";
     }));
+    // The stops are not free anymore: reaching them costs the crow-fly
+    // distance walked at kWalkSpeed.
+    EXPECT_EQ(api::ModeEnum::WALK, j.legs_.front().mode_);
+    EXPECT_EQ(api::ModeEnum::WALK, j.legs_.back().mode_);
+    EXPECT_GT(j.legs_.front().duration_, 0);
+    EXPECT_GT(j.legs_.back().duration_, 0);
   }
 
   // Route using radius on origin coordinate, station ID as destination.

--- a/ui/api/openapi/types.gen.ts
+++ b/ui/api/openapi/types.gen.ts
@@ -2496,7 +2496,9 @@ export type PlanData = {
         /**
          * Experimental. Search radius in meters around the `fromPlace` / `toPlace` coordinates.
          * When set and the place is given as coordinates, all transit stops within
-         * this radius are used as start/end points with zero pre-transit/post-transit time.
+         * this radius are used as start/end points. The pre-transit/post-transit time
+         * for each of them is estimated from the crow-fly distance to the coordinate
+         * at walking speed (1.5 m/s), rounded down to whole minutes.
          * Works without OSM/street routing data loaded.
          *
          */


### PR DESCRIPTION
Hello !

Follow-up to #1360 and this [comment](https://github.com/motis-project/motis/pull/1360#issuecomment-4182494340) : offsets created by the radius parameter previously had a zero duration, so a stop 50 m from the coordinate and one 20 km away were equally attractive to the router : journeys could start/end at arbitrarily distant stops and the reported start/end times didn't account for reaching them. This PR gives each radius offset a duration derived from the crow-fly distance to the stop, at walking speed (1.5 m/s, kWalkSpeed) by default. Since the appropriate access speed depends on the deployment (walking vs. some faster feeder mode further out), it can optionally be configured per distance band with a new timetable.radius_speeds config option (e.g. 2 m/s up to 5 km, faster beyond); when unset, behavior is plain walking speed. The config is validated on startup (ascending bands, positive speeds).

Since the offset legs now have a non-zero duration, they are no longer removed as zero-duration legs in journey_to_response, which would dereference the OSR data unconditionally. With no OSM data loaded (the main use case for radius), this crashed. Offset legs now fall back to a plain crow-fly leg when street routing data is unavailable, mirroring the existing footpath fallback. Includes tests for the speed bands, config parsing/validation, and an end-to-end routing test without OSM data, plus documentation updates in docs/setup.md and openapi.yaml.

The speed bands are one of many possible ways to configure this. I chose this shape to match our use case (legacy matching oblige), but I'm open to other options. Thank you :)