### PR TITLE
ui: Split map layers for smoother theme switching

### DIFF
--- a/ui/src/lib/map/Map.svelte
+++ b/ui/src/lib/map/Map.svelte
@@ -11,6 +11,8 @@
 		center = $bindable(),
 		bearing = $bindable(),
 		style,
+		shieldFill,
+		shieldStroke,
 		attribution,
 		transformRequest,
 		children,
@@ -18,6 +20,8 @@
 	}: {
 		map?: maplibregl.Map;
 		style: maplibregl.StyleSpecification | undefined;
+		shieldFill: string;
+		shieldStroke: string;
 		attribution: string | undefined | false;
 		transformRequest?: maplibregl.RequestTransformFunction;
 		center: maplibregl.LngLatLike;
@@ -39,6 +43,7 @@
 				createMap(el);
 			} else if (ctx.map) {
 				ctx.map.setStyle(style || null);
+				ctx.map.updateImage('shield', createShield({ fill: shieldFill, stroke: shieldStroke })[0]);
 			}
 			currStyle = style;
 		}
@@ -64,21 +69,7 @@
 						? attribution
 						: { customAttribution: attribution }
 			});
-			tmp.addImage(
-				'shield',
-				...createShield({
-					fill: 'hsl(0, 0%, 98%)',
-					stroke: 'hsl(0, 0%, 75%)'
-				})
-			);
-
-			tmp.addImage(
-				'shield-dark',
-				...createShield({
-					fill: 'hsl(0, 0%, 16%)',
-					stroke: 'hsl(0, 0%, 30%)'
-				})
-			);
+			tmp.addImage('shield', ...createShield({ fill: shieldFill, stroke: shieldStroke }));
 
 			const scale = new maplibregl.ScaleControl({
 				maxWidth: 100,

--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -1,4 +1,5 @@
 import type {
+	ExpressionSpecification,
 	HillshadeLayerSpecification,
 	LayerSpecification,
 	RasterDEMSourceSpecification,
@@ -178,6 +179,22 @@ function landuseLayer(id: string, color: string, kind: string[]): LayerSpecifica
 		}
 	};
 }
+
+const roadWidthInterpolation: ExpressionSpecification = [
+	'interpolate',
+	['linear'],
+	['zoom'],
+	5,
+	['*', ['var', 'base'], 0.5],
+	9,
+	['*', ['var', 'base'], 1],
+	12,
+	['*', ['var', 'base'], 2],
+	16,
+	['*', ['var', 'base'], 2.5],
+	20,
+	['*', ['var', 'base'], 3]
+];
 
 function getUrlBase(url: string): string {
 	const { origin, pathname } = new URL(url);
@@ -843,7 +860,7 @@ export const getStyle = (
 				}
 			},
 			{
-				id: 'road',
+				id: 'road-motorway',
 				type: 'line',
 				source: 'osm',
 				'source-layer': 'streets',
@@ -860,6 +877,170 @@ export const getStyle = (
 					'all',
 					['has', 'ref'],
 					['==', ['get', 'rail'], false],
+					['==', ['get', 'kind'], 'motorway'],
+					['any', ['!', ['to-boolean', ['get', 'link']]], ['>=', ['get', 'zoom'], 12]]
+				],
+				paint: {
+					// dimmed in tunnels
+					'line-opacity': ['case', ['==', ['get', 'tunnel'], true], 0.5, 1],
+					// like VersaTiles: links get the same color as their parent kind
+					// (motorway_link = motorway, ...), only the width is reduced
+					'line-color': c.motorway,
+					'line-width': [
+						'let',
+						'base',
+						['case', ['to-boolean', ['get', 'link']], 3, 3.5],
+						roadWidthInterpolation
+					]
+				}
+			},
+			{
+				id: 'road-trunk',
+				type: 'line',
+				source: 'osm',
+				'source-layer': 'streets',
+				layout: {
+					'line-cap': 'round'
+				},
+				// like the old release: only roads with a ref get the full-width
+				// opaque body here; everything else is carried by the faint back
+				// layers (thin at overview zooms) and the minor-way layers.
+				// minzoom 6: rail comes first, motorway/trunk one zoom later (only
+				// those two kinds exist below z6 in the tiles).
+				minzoom: 6,
+				filter: [
+					'all',
+					['has', 'ref'],
+					['==', ['get', 'rail'], false],
+					['==', ['get', 'kind'], 'trunk'],
+					['any', ['!', ['to-boolean', ['get', 'link']]], ['>=', ['get', 'zoom'], 12]]
+				],
+				paint: {
+					// dimmed in tunnels
+					'line-opacity': ['case', ['==', ['get', 'tunnel'], true], 0.5, 1],
+					// like VersaTiles: links get the same color as their parent kind
+					// (motorway_link = motorway, ...), only the width is reduced
+					'line-color': c.motorwayLink,
+					'line-width': [
+						'let',
+						'base',
+						['case', ['to-boolean', ['get', 'link']], 2.5, 3],
+						roadWidthInterpolation
+					]
+				}
+			},
+			{
+				id: 'road-primary-secondary',
+				type: 'line',
+				source: 'osm',
+				'source-layer': 'streets',
+				layout: {
+					'line-cap': 'round'
+				},
+				// like the old release: only roads with a ref get the full-width
+				// opaque body here; everything else is carried by the faint back
+				// layers (thin at overview zooms) and the minor-way layers.
+				// minzoom 6: rail comes first, motorway/trunk one zoom later (only
+				// those two kinds exist below z6 in the tiles).
+				minzoom: 6,
+				filter: [
+					'all',
+					['has', 'ref'],
+					['==', ['get', 'rail'], false],
+					['in', ['get', 'kind'], ['literal', ['primary', 'secondary', 'runway', 'taxiway']]],
+					['any', ['!', ['to-boolean', ['get', 'link']]], ['>=', ['zoom'], 13]],
+					['any', ['==', ['get', 'kind'], 'secondary'], ['>', ['zoom'], 11]]
+				],
+				paint: {
+					// dimmed in tunnels
+					'line-opacity': ['case', ['==', ['get', 'tunnel'], true], 0.5, 1],
+					// like VersaTiles: links get the same color as their parent kind
+					// (motorway_link = motorway, ...), only the width is reduced
+					'line-color': c.primarySecondary,
+					'line-width': [
+						'let',
+						'base',
+						[
+							'case',
+							['to-boolean', ['get', 'link']],
+							['match', ['get', 'kind'], ['primary', 'secondary'], 1.75, 0.75],
+							['literal', 2.5]
+						],
+						roadWidthInterpolation
+					]
+				}
+			},
+			{
+				id: 'road-tertiary',
+				type: 'line',
+				source: 'osm',
+				'source-layer': 'streets',
+				layout: {
+					'line-cap': 'round'
+				},
+				// like the old release: only roads with a ref get the full-width
+				// opaque body here; everything else is carried by the faint back
+				// layers (thin at overview zooms) and the minor-way layers.
+				// minzoom 6: rail comes first, motorway/trunk one zoom later (only
+				// those two kinds exist below z6 in the tiles).
+				minzoom: 6,
+				filter: [
+					'all',
+					['has', 'ref'],
+					['==', ['get', 'rail'], false],
+					['==', ['get', 'kind'], 'tertiary'],
+					['any', ['!', ['to-boolean', ['get', 'link']]], ['>=', ['zoom'], 13]],
+					['>', ['zoom'], 11]
+				],
+				paint: {
+					// dimmed in tunnels
+					'line-opacity': ['case', ['==', ['get', 'tunnel'], true], 0.5, 1],
+					// like VersaTiles: links get the same color as their parent kind
+					// (motorway_link = motorway, ...), only the width is reduced
+					'line-color': c.linkTertiary,
+					'line-width': [
+						'let',
+						'base',
+						['case', ['to-boolean', ['get', 'link']], 0.75, 1.75],
+						roadWidthInterpolation
+					]
+				}
+			},
+			{
+				id: 'road-residential',
+				type: 'line',
+				source: 'osm',
+				'source-layer': 'streets',
+				layout: {
+					'line-cap': 'round'
+				},
+				minzoom: 11,
+				filter: [
+					'all',
+					['has', 'ref'],
+					['==', ['get', 'rail'], false],
+					['==', ['get', 'kind'], 'residential']
+				],
+				paint: {
+					// dimmed in tunnels
+					'line-opacity': ['case', ['==', ['get', 'tunnel'], true], 0.5, 1],
+					'line-color': c.residential,
+					'line-width': ['let', 'base', 1.5, roadWidthInterpolation]
+				}
+			},
+			{
+				id: 'road',
+				type: 'line',
+				source: 'osm',
+				'source-layer': 'streets',
+				layout: {
+					'line-cap': 'round'
+				},
+				minzoom: 11,
+				filter: [
+					'all',
+					['has', 'ref'],
+					['==', ['get', 'rail'], false],
 					[
 						'!',
 						[
@@ -868,6 +1049,14 @@ export const getStyle = (
 							[
 								'literal',
 								[
+									'motorway',
+									'trunk',
+									'primary',
+									'secondary',
+									'runway',
+									'taxiway',
+									'tertiary',
+									'residential',
 									'footway',
 									'track',
 									'steps',
@@ -879,90 +1068,13 @@ export const getStyle = (
 								]
 							]
 						]
-					],
-					[
-						'any',
-						['!', ['to-boolean', ['get', 'link']]],
-						['all', ['==', ['get', 'kind'], 'motorway'], ['>=', ['zoom'], 12]],
-						['>=', ['zoom'], 13]
-					],
-					[
-						'any',
-						['==', ['get', 'kind'], 'motorway'],
-						['==', ['get', 'kind'], 'trunk'],
-						['==', ['get', 'kind'], 'secondary'],
-						['>', ['zoom'], 11]
 					]
 				],
 				paint: {
 					// dimmed in tunnels
 					'line-opacity': ['case', ['==', ['get', 'tunnel'], true], 0.5, 1],
-					// like VersaTiles: links get the same color as their parent kind
-					// (motorway_link = motorway, ...), only the width is reduced
-					'line-color': [
-						'match',
-						['get', 'kind'],
-						'motorway',
-						c.motorway,
-						'trunk',
-						c.motorwayLink,
-						['primary', 'secondary', 'runway', 'taxiway'],
-						c.primarySecondary,
-						'tertiary',
-						c.linkTertiary,
-						'residential',
-						c.residential,
-						c.road
-					],
-					'line-width': [
-						'let',
-						'base',
-						[
-							'case',
-							['to-boolean', ['get', 'link']],
-							[
-								'match',
-								['get', 'kind'],
-								'motorway',
-								3,
-								'trunk',
-								2.5,
-								['primary', 'secondary', 'tertiary'],
-								1.75,
-								0.75
-							],
-							[
-								'match',
-								['get', 'kind'],
-								'motorway',
-								3.5,
-								'trunk',
-								3,
-								['primary', 'secondary', 'runway', 'taxiway'],
-								2.5,
-								'tertiary',
-								1.75,
-								'residential',
-								1.5,
-								0.75
-							]
-						],
-						[
-							'interpolate',
-							['linear'],
-							['zoom'],
-							5,
-							['*', ['var', 'base'], 0.5],
-							9,
-							['*', ['var', 'base'], 1],
-							12,
-							['*', ['var', 'base'], 2],
-							16,
-							['*', ['var', 'base'], 2.5],
-							20,
-							['*', ['var', 'base'], 3]
-						]
-					]
+					'line-color': c.road,
+					'line-width': ['let', 'base', 0.75, roadWidthInterpolation]
 				}
 			},
 			// streets with designated bicycle infrastructure, tinted like VersaTiles

--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -1553,12 +1553,12 @@ export const getStyle = (
 				'source-layer': 'streets',
 				filter: [
 					'all',
-					['in', 'kind', 'footway', 'path', 'pedestrian', 'cycleway'],
+					['in', 'kind', 'footway', 'path', 'pedestrian'],
 					level === 0 ? ['any', ['!has', 'level'], ['==', 'level', level]] : ['==', 'level', level]
 				],
 				minzoom: 12,
 				paint: {
-					'line-color': ['match', ['get', 'kind'], 'cycleway', c.cycleway, c.footpath],
+					'line-color': c.footpath,
 					'line-dasharray': [2, 1],
 					'line-opacity': [
 						'interpolate',
@@ -1571,6 +1571,24 @@ export const getStyle = (
 						14,
 						1
 					],
+					'line-width': ['interpolate', ['linear'], ['zoom'], 12, 0.3, 14, 0.6, 17, 1.8]
+				}
+			},
+			{
+				id: 'cycleway',
+				type: 'line',
+				source: 'osm',
+				'source-layer': 'streets',
+				filter: [
+					'all',
+					['==', 'kind', 'cycleway'],
+					level === 0 ? ['any', ['!has', 'level'], ['==', 'level', level]] : ['==', 'level', level]
+				],
+				minzoom: 12,
+				paint: {
+					'line-color': c.cycleway,
+					'line-dasharray': [2, 1],
+					'line-opacity': ['interpolate', ['linear'], ['zoom'], 12, 0, 13, 0, 14, 1],
 					'line-width': ['interpolate', ['linear'], ['zoom'], 12, 0.3, 14, 0.6, 17, 1.8]
 				}
 			},

--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -81,9 +81,7 @@ export const colors = {
 		text: '#333333',
 		textHalo: 'rgba(255, 255, 255, 0.8)',
 		citiesText: 'hsl(0, 0%, 20%)',
-		citiesTextHalo: 'rgba(255, 255, 255, 0.8)',
-
-		shield: 'shield'
+		citiesTextHalo: 'rgba(255, 255, 255, 0.8)'
 	},
 	dark: {
 		background: '#292929',
@@ -159,9 +157,7 @@ export const colors = {
 		townText: '#bebebe',
 		townTextHalo: 'rgba(0, 0, 0, 0.8)',
 		citiesText: '#bebebe',
-		citiesTextHalo: 'rgba(0, 0, 0, 0.8)',
-
-		shield: 'shield-dark'
+		citiesTextHalo: 'rgba(0, 0, 0, 0.8)'
 	}
 };
 
@@ -1745,7 +1741,7 @@ export const getStyle = (
 					'text-justify': 'center',
 					'text-rotation-alignment': 'viewport',
 					'text-pitch-alignment': 'viewport',
-					'icon-image': c.shield,
+					'icon-image': 'shield',
 					'icon-text-fit': 'both',
 					'icon-text-fit-padding': [0.5, 4, 0.5, 4],
 					'icon-rotation-alignment': 'viewport',

--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -1,5 +1,6 @@
 import type {
 	HillshadeLayerSpecification,
+	LayerSpecification,
 	RasterDEMSourceSpecification,
 	StyleSpecification
 } from 'maplibre-gl';
@@ -163,6 +164,21 @@ export const colors = {
 	}
 };
 
+function landuseLayer(id: string, color: string, kind: string[]): LayerSpecification {
+	return {
+		id: id,
+		type: 'fill',
+		source: 'osm',
+		'source-layer': 'land',
+		filter: ['in', 'kind', ...kind],
+		paint: {
+			'fill-color': color,
+			// soft fade-in like VersaTiles land layers
+			'fill-opacity': ['interpolate', ['linear'], ['zoom'], 8, 0.6, 10, 1]
+		}
+	};
+}
+
 function getUrlBase(url: string): string {
 	const { origin, pathname } = new URL(url);
 	return origin + pathname.slice(0, pathname.lastIndexOf('/') + 1);
@@ -239,95 +255,52 @@ export const getStyle = (
 				'source-layer': 'coastline',
 				paint: { 'fill-color': c.water }
 			},
-			{
-				id: 'landuse_park',
-				type: 'fill',
-				source: 'osm',
-				'source-layer': 'land',
-				filter: [
-					'in',
-					'kind',
-					'park',
-					'garden',
-					'playground',
-					'miniature_golf',
-					'golf_course',
-					'village_green',
-					'recreation_ground',
-					'greenhouse_horticulture',
-					'allotments'
-				],
-				paint: {
-					'fill-color': c.landusePark,
-					'fill-opacity': ['interpolate', ['linear'], ['zoom'], 8, 0.6, 10, 1]
-				}
-			},
-			{
-				id: 'landuse',
-				type: 'fill',
-				source: 'osm',
-				'source-layer': 'land',
-				filter: [
-					'!in',
-					'kind',
-					'park',
-					'garden',
-					'playground',
-					'miniature_golf',
-					'golf_course',
-					'village_green',
-					'recreation_ground',
-					'greenhouse_horticulture',
-					'allotments',
-					'public_transport'
-				],
-				paint: {
-					'fill-color': [
-						'match',
-						['get', 'kind'],
-						'commercial',
-						c.landuseCommercial,
-						['industrial', 'railway', 'quarry', 'farmyard', 'landfill', 'garages'],
-						c.landuseIndustrial,
-						'residential',
-						c.landuseResidential,
-						'retail',
-						c.landuseRetail,
-						// agriculture group in the VersaTiles Shortbread style
-						['brownfield', 'greenfield'],
-						c.landuseAgriculture,
-						['bare_rock', 'scree', 'shingle'],
-						c.landuseConstruction,
-
-						[
-							'farmland',
-							'vineyard',
-							'plant_nursery',
-							'orchard',
-							'meadow',
-							'grassland',
-							'grass',
-							'heath',
-							'swamp',
-							'bog',
-							'string_bog',
-							'wet_meadow',
-							'marsh'
-						],
-						c.landuseNatureLight,
-						['forest', 'scrub'],
-						c.landuseNatureHeavy,
-						['cemetery', 'grave_yard'],
-						c.landuseCemetery,
-						['beach', 'sand'],
-						c.landuseBeach,
-
-						'magenta'
-					],
-					// soft fade-in like VersaTiles land layers
-					'fill-opacity': ['interpolate', ['linear'], ['zoom'], 8, 0.6, 10, 1]
-				}
-			},
+			landuseLayer('landuse-park', c.landusePark, [
+				'park',
+				'garden',
+				'playground',
+				'miniature_golf',
+				'golf_course',
+				'village_green',
+				'recreation_ground',
+				'greenhouse_horticulture',
+				'allotments'
+			]),
+			landuseLayer('landuse-commercial', c.landuseCommercial, ['commercial']),
+			landuseLayer('landuse-industrial', c.landuseIndustrial, [
+				'industrial',
+				'railway',
+				'quarry',
+				'farmyard',
+				'landfill',
+				'garages'
+			]),
+			landuseLayer('landuse-residential', c.landuseResidential, ['residential']),
+			landuseLayer('landuse-retail', c.landuseRetail, ['retail']),
+			landuseLayer('landuse-agriculture', c.landuseAgriculture, ['brownfield', 'greenfield']), // agriculture group in the VersaTiles Shortbread style
+			landuseLayer('landuse-construction', c.landuseConstruction, [
+				'bare_rock',
+				'scree',
+				'shingle'
+			]),
+			landuseLayer('landuse-nature_light', c.landuseNatureLight, [
+				'farmland',
+				'vineyard',
+				'plant_nursery',
+				'orchard',
+				'meadow',
+				'grassland',
+				'grass',
+				'heath',
+				'swamp',
+				'bog',
+				'string_bog',
+				'wet_meadow',
+				'marsh'
+			]),
+			landuseLayer('landuse-nature_heavy', c.landuseNatureHeavy, ['forest', 'scrub']),
+			landuseLayer('landuse-cemetery', c.landuseCemetery, ['cemetery', 'grave_yard']),
+			landuseLayer('landuse-beach', c.landuseBeach, ['beach', 'sand']),
 			{
 				id: 'sites',
 				type: 'fill',

--- a/ui/src/lib/map/style.ts
+++ b/ui/src/lib/map/style.ts
@@ -302,31 +302,56 @@ export const getStyle = (
 			landuseLayer('landuse-cemetery', c.landuseCemetery, ['cemetery', 'grave_yard']),
 			landuseLayer('landuse-beach', c.landuseBeach, ['beach', 'sand']),
 			{
-				id: 'sites',
+				id: 'sites-complex',
 				type: 'fill',
 				source: 'osm',
 				'source-layer': 'sites',
 				// construction is rendered by its own pattern layer below
-				filter: ['!=', 'kind', 'construction'],
+				filter: ['in', 'kind', 'university', 'school', 'college', 'prison'],
 				paint: {
-					'fill-color': [
-						'match',
-						['get', 'kind'],
-						['university', 'school', 'college', 'prison'],
-						c.landuseComplex,
-						// like VersaTiles: translucent red
-						'hospital',
-						c.siteHospital,
-						'sports_center',
-						c.sport,
-						'danger_area',
-						c.landuseConstruction,
-						['parking', 'bicycle_parking'],
-						c.pedestrian,
-
-						'magenta'
-					],
-					'fill-opacity': ['match', ['get', 'kind'], 'hospital', 0.1, 1]
+					'fill-color': c.landuseComplex
+				}
+			},
+			{
+				id: 'sites-hospital',
+				type: 'fill',
+				source: 'osm',
+				'source-layer': 'sites',
+				filter: ['==', 'kind', 'hospital'],
+				paint: {
+					// like VersaTiles: translucent red
+					'fill-color': c.siteHospital,
+					'fill-opacity': 0.1
+				}
+			},
+			{
+				id: 'sites-sport',
+				type: 'fill',
+				source: 'osm',
+				'source-layer': 'sites',
+				filter: ['==', 'kind', 'sports_center'],
+				paint: {
+					'fill-color': c.sport
+				}
+			},
+			{
+				id: 'sites-pedestrian',
+				type: 'fill',
+				source: 'osm',
+				'source-layer': 'sites',
+				filter: ['in', 'kind', 'parking', 'bicycle_parking'],
+				paint: {
+					'fill-color': c.pedestrian
+				}
+			},
+			{
+				id: 'sites-danger',
+				type: 'fill',
+				source: 'osm',
+				'source-layer': 'sites',
+				filter: ['==', 'kind', 'danger_area'],
+				paint: {
+					'fill-color': c.landuseConstruction
 				}
 			},
 			{
@@ -343,13 +368,24 @@ export const getStyle = (
 				}
 			},
 			{
+				id: 'water-glacier',
+				type: 'fill',
+				source: 'osm',
+				'source-layer': 'water_polygons',
+				filter: ['==', 'kind', 'glacier'],
+				paint: {
+					// glaciers white like in VersaTiles
+					'fill-color': c.glacier
+				}
+			},
+			{
 				id: 'water',
 				type: 'fill',
 				source: 'osm',
 				'source-layer': 'water_polygons',
+				filter: ['!=', 'kind', 'glacier'],
 				paint: {
-					// glaciers white like in VersaTiles
-					'fill-color': ['match', ['get', 'kind'], 'glacier', c.glacier, c.water]
+					'fill-color': c.water
 				}
 			},
 			// dams and piers like in VersaTiles

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1333,6 +1333,8 @@
 		bind:bearing
 		class="h-dvh pt-2 overflow-clip"
 		style={showMap ? style : undefined}
+		shieldFill={theme === 'dark' ? 'hsl(0, 0%, 16%)' : 'hsl(0, 0%, 98%)'}
+		shieldStroke={theme === 'dark' ? 'hsl(0, 0%, 30%)' : 'hsl(0, 0%, 75%)'}
 		attribution={false}
 	>
 		{#if hasDebug}


### PR DESCRIPTION
An attempt to fix a regression from #1395. That PR reverted the temporary VersaTiles map styles, which by doing so introduced some artefacts when changing themes.

Maplibregl seems to struggle with smooth transitions when fill-color is an expression (related?: https://github.com/mapbox/mapbox-gl-js/issues/3170. different project, but it's a pre-fork issue and I couldn't find similar issue in the maplibre repo)

before | this pr
---|---
![image](https://github.com/user-attachments/assets/8726f76b-8719-4d60-a3bb-c423f9f18324) | ![image](https://github.com/user-attachments/assets/438c66c2-dcd7-4046-ad94-4720d6c676ca)