### PR TITLE
Add /route-search endpoint

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -128,6 +128,7 @@ limits:
   street_routing_max_direct_seconds: 21600 # limit for maxDirectTime API param, high values can lead to long-running, RAM-hungry queries 
   geocode_max_suggestions: 512    # maximum requestable results for /geocode
   reverse_geocode_max_results: 512 # maximum requestable results for /reverse-geocode
+  route_search_max_results: 512   # maximum requestable results for /map/route-search
   max_max_matching_distance: 250  # upper bound (meters) for the maxMatchingDistance API param, larger values are capped to this limit
 logging:
   log_level: debug                # log-level (default = debug; Supported log-levels: error, info, debug)

--- a/include/motis/config.h
+++ b/include/motis/config.h
@@ -268,6 +268,7 @@ struct config {
     unsigned street_routing_max_direct_seconds_{21600U};
     unsigned geocode_max_suggestions_{512U};
     unsigned reverse_geocode_max_results_{512U};
+    unsigned route_search_max_results_{512U};
     double max_max_matching_distance_{250.0};
   };
   limits get_limits() const { return limits_.value_or(limits{}); }

--- a/include/motis/endpoints/map/route_search.h
+++ b/include/motis/endpoints/map/route_search.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "motis-api/motis-api.h"
+#include "motis/fwd.h"
+
+namespace motis::ep {
+
+struct route_search {
+  api::routeSearch_response operator()(boost::urls::url_view const&) const;
+
+  config const& config_;
+  nigiri::timetable const& tt_;
+  nigiri::shapes_storage const* shapes_;
+};
+
+}  // namespace motis::ep

--- a/include/motis/motis_instance.h
+++ b/include/motis/motis_instance.h
@@ -18,6 +18,7 @@
 #include "motis/endpoints/map/flex_locations.h"
 #include "motis/endpoints/map/rental.h"
 #include "motis/endpoints/map/route_details.h"
+#include "motis/endpoints/map/route_search.h"
 #include "motis/endpoints/map/routes.h"
 #include "motis/endpoints/map/shapes_debug.h"
 #include "motis/endpoints/map/stops.h"
@@ -126,6 +127,7 @@ struct motis_instance {
     GET<ep::stops>("/api/v1/map/stops", d);
     GET<ep::stops>("/api/v6/map/stops", d);
     GET<ep::route_details>("/api/experimental/map/route-details", d);
+    GET<ep::route_search>("/api/experimental/map/route-search", d);
     GET<ep::routes>("/api/experimental/map/routes", d);
     GET<ep::rental>("/api/v1/map/rentals", d);
     GET<ep::rental>("/api/v1/rentals", d);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3543,6 +3543,88 @@ paths:
                     type: boolean
                     description: Always false for this endpoint.
 
+  /api/experimental/map/route-search:
+    get:
+      tags:
+        - map
+      operationId: routeSearch
+      summary: |
+        Search transit routes (lines) by name.
+        The text is matched case- and accent-insensitively against the short name
+        and long name. Exact matches rank above prefix matches, which rank above
+        substring matches, and short name matches above long name matches.
+      parameters:
+        - name: text
+          in: query
+          required: true
+          description: the (potentially partially typed) route name to search for
+          schema:
+            type: string
+        - name: place
+          in: query
+          required: false
+          description: |
+            Optional. Used for biasing results towards the coordinate.
+
+            Format: latitude,longitude in degrees
+          schema:
+            type: string
+        - name: placeBias
+          in: query
+          required: false
+          description: |
+            Optional. Used for biasing results towards the coordinate. Higher number = higher bias.
+          schema:
+            type: number
+            default: 1
+        - name: numResults
+          in: query
+          required: false
+          description: |
+            Optional. Number of transit routes to return.
+            If omitted, 10 are returned by default.
+            Must be <= server config variable `route_search_max_results`.
+          schema:
+            type: integer
+            minimum: 1
+        - name: language
+          in: query
+          required: false
+          description: |
+            language tags as used in OpenStreetMap / GTFS
+            (usually BCP-47 / ISO 639-1, or ISO 639-2 if there's no ISO 639-1)
+          schema:
+            type: array
+            items:
+              type: string
+          explode: false
+      responses:
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '200':
+          description: transit routes matching the search text, best match first
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - routes
+                properties:
+                  routes:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/RouteMatch'
+
   /api/v1/rentals:
     get:
       tags:
@@ -6196,6 +6278,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RouteSegment'
+
+    RouteMatch:
+      type: object
+      description: |
+        A transit route (line) matching a name search.
+      required:
+        - mode
+        - transitRoute
+        - routeIndexes
+        - score
+      properties:
+        mode:
+          $ref: '#/components/schemas/Mode'
+          description: Transport mode for this transit route
+        transitRoute:
+          $ref: '#/components/schemas/TransitRouteInfo'
+        agencyName:
+          type: string
+          description: Name of the agency operating this transit route
+        routeIndexes:
+          type: array
+          items:
+            type: integer
+          description: |
+            Internal route indexes this transit route is operated on, one per
+            stop sequence variant. Pass any of them as `routeIdx` to
+            `/api/experimental/map/route-details` to get stops and shapes.
+        score:
+          type: number
+          description: |
+            Match score. Higher is better, results are sorted descending.
+            Only meaningful relative to the other results of the same query.
 
     HealthResponse:
       type: object

--- a/src/config.cc
+++ b/src/config.cc
@@ -152,6 +152,8 @@ void config::verify() const {
               "geocode_max_suggestions must be >= 1");
   utl::verify(limits_.value().reverse_geocode_max_results_ >= 1U,
               "reverse_geocode_max_results must be >= 1");
+  utl::verify(limits_.value().route_search_max_results_ >= 1U,
+              "route_search_max_results must be >= 1");
   utl::verify(!server_ || server_->gpu_states_ >= 1U,
               "server.gpu_states must be >= 1");
 

--- a/src/endpoints/map/route_search.cc
+++ b/src/endpoints/map/route_search.cc
@@ -1,0 +1,265 @@
+#include "motis/endpoints/map/route_search.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "net/bad_request_exception.h"
+
+#include "utl/enumerate.h"
+#include "utl/erase_duplicates.h"
+#include "utl/to_vec.h"
+#include "utl/verify.h"
+
+#include "geo/box.h"
+#include "geo/latlng.h"
+
+#include "adr/normalize.h"
+
+#include "nigiri/shapes_storage.h"
+#include "nigiri/timetable.h"
+#include "nigiri/types.h"
+
+#include "motis/config.h"
+#include "motis/parse_location.h"
+#include "motis/timetable/clasz_to_mode.h"
+
+namespace n = nigiri;
+
+namespace motis::ep {
+
+namespace {
+
+constexpr auto const kDefaultNumResults = std::int64_t{10};
+constexpr auto const kApiVersion = 5U;
+
+constexpr auto const kExactScore = 300.F;
+constexpr auto const kPrefixScore = 200.F;
+constexpr auto const kSubstringScore = 100.F;
+constexpr auto const kLengthBonus = 50.F;
+constexpr auto const kLongNamePenalty = 25.F;
+constexpr auto const kDistancePenalty = 20.F;
+
+std::optional<float> match(std::string_view const name,
+                           std::string_view const text) {
+  if (name.empty()) {
+    return std::nullopt;
+  }
+
+  auto const base = [&]() -> std::optional<float> {
+    if (name == text) {
+      return kExactScore;
+    } else if (name.starts_with(text)) {
+      return kPrefixScore;
+    } else if (name.find(text) != std::string_view::npos) {
+      return kSubstringScore;
+    }
+    return std::nullopt;
+  }();
+
+  return base.transform([&](float const b) {
+    auto const coverage =
+        static_cast<float>(text.size()) / static_cast<float>(name.size());
+    return b + kLengthBonus * coverage;
+  });
+}
+
+std::optional<float> name_score(std::string_view const short_name,
+                                std::string_view const long_name,
+                                std::string_view const text,
+                                adr::utf8_normalize_buf_t& buf) {
+  auto best = match(adr::normalize(short_name, buf), text);
+  auto const long_score =
+      match(adr::normalize(long_name, buf), text).transform([](float const s) {
+        return s - kLongNamePenalty;
+      });
+  if (long_score.has_value() && (!best.has_value() || *long_score > *best)) {
+    best = long_score;
+  }
+  return best;
+}
+
+double distance_to(geo::box const& b, geo::latlng const& p) {
+  if (b.empty()) {
+    return 0.0;
+  }
+  return geo::distance(
+      geo::latlng{std::clamp(p.lat_, b.min_.lat_, b.max_.lat_),
+                  std::clamp(p.lng_, b.min_.lng_, b.max_.lng_)},
+      p);
+}
+
+geo::box route_box(n::timetable const& tt,
+                   n::shapes_storage const* shapes,
+                   n::route_idx_t const r) {
+  if (shapes != nullptr) {
+    return shapes->get_bounding_box(r);
+  }
+  auto b = geo::box{};
+  for (auto const s : tt.route_location_seq_[r]) {
+    b.extend(tt.locations_.coordinates_.at(n::stop{s}.location_idx()));
+  }
+  return b;
+}
+
+std::optional<n::route_idx_t> first_route(n::timetable const& tt,
+                                          n::timetable::route_ids const& rids,
+                                          n::route_id_idx_t const r_id) {
+  for (auto const trip : rids.route_id_trips_[r_id]) {
+    auto const transports = tt.trip_transport_ranges_[trip];
+    if (!transports.empty()) {
+      return tt.transport_route_[transports.front().first];
+    }
+  }
+  return std::nullopt;
+}
+
+std::vector<n::route_idx_t> get_routes(n::timetable const& tt,
+                                       n::timetable::route_ids const& rids,
+                                       n::route_id_idx_t const r_id) {
+  auto routes = std::vector<n::route_idx_t>{};
+  for (auto const trip : rids.route_id_trips_[r_id]) {
+    for (auto const& [t, _] : tt.trip_transport_ranges_[trip]) {
+      routes.emplace_back(tt.transport_route_[t]);
+    }
+  }
+  utl::erase_duplicates(routes);
+  return routes;
+}
+
+struct candidate {
+  n::source_idx_t src_;
+  n::route_id_idx_t r_id_;
+  n::route_idx_t rep_;
+  float score_;
+  std::vector<n::route_idx_t> routes_;
+};
+
+bool better(candidate const& a, candidate const& b) {
+  if (a.score_ != b.score_) {
+    return a.score_ > b.score_;
+  }
+  return a.src_ != b.src_ ? a.src_ < b.src_ : a.r_id_ < b.r_id_;
+}
+
+void truncate(std::vector<candidate>& candidates, std::size_t const n) {
+  if (candidates.size() <= n) {
+    std::ranges::sort(candidates, better);
+    return;
+  }
+  std::ranges::partial_sort(
+      candidates, begin(candidates) + static_cast<std::ptrdiff_t>(n), better);
+  candidates.resize(n);
+}
+
+std::vector<candidate> collect_candidates(n::timetable const& tt,
+                                          std::string_view const text,
+                                          n::lang_t const& lang,
+                                          adr::utf8_normalize_buf_t& buf) {
+  auto candidates = std::vector<candidate>{};
+  for (auto const [s, rids] : utl::enumerate(tt.route_ids_)) {
+    auto const src = n::source_idx_t{s};
+    for (auto const [i, short_name] :
+         utl::enumerate(rids.route_id_short_names_)) {
+      auto const r_id = n::route_id_idx_t{i};
+      auto const rep = first_route(tt, rids, r_id);
+      if (!rep.has_value()) {
+        continue;
+      }
+      auto const score =
+          name_score(tt.translate(lang, short_name),
+                     tt.translate(lang, rids.route_id_long_names_[r_id]), text,
+                     buf);
+      if (score.has_value()) {
+        candidates.emplace_back(candidate{src, r_id, *rep, *score, {}});
+      }
+    }
+  }
+  return candidates;
+}
+
+api::routeSearch_response to_response(n::timetable const& tt,
+                                      std::vector<candidate> const& candidates,
+                                      n::lang_t const& lang) {
+  return api::routeSearch_response{
+      .routes_ = utl::to_vec(candidates, [&](candidate const& c) {
+        auto const& rids = tt.route_ids_[c.src_];
+        auto const color = rids.route_id_colors_[c.r_id_];
+        auto const provider = rids.route_id_provider_[c.r_id_];
+        return api::RouteMatch{
+            .mode_ = to_mode(tt.route_clasz_[c.rep_], kApiVersion),
+            .transitRoute_ =
+                api::TransitRouteInfo{
+                    .id_ = std::string{rids.ids_.get(c.r_id_)},
+                    .shortName_ = std::string{tt.translate(
+                        lang, rids.route_id_short_names_[c.r_id_])},
+                    .longName_ = std::string{tt.translate(
+                        lang, rids.route_id_long_names_[c.r_id_])},
+                    .color_ = n::to_str(color.color_),
+                    .textColor_ = n::to_str(color.text_color_)},
+            .agencyName_ =
+                provider == n::provider_idx_t::invalid()
+                    ? std::nullopt
+                    : std::optional{std::string{
+                          tt.translate(lang, tt.providers_[provider].name_)}},
+            .routeIndexes_ =
+                utl::to_vec(c.routes_,
+                            [](n::route_idx_t const r) {
+                              return static_cast<std::int64_t>(to_idx(r));
+                            }),
+            .score_ = static_cast<double>(c.score_)};
+      })};
+}
+
+}  // namespace
+
+api::routeSearch_response route_search::operator()(
+    boost::urls::url_view const& url) const {
+  auto const params = api::routeSearch_params{url.params()};
+
+  auto buf = adr::utf8_normalize_buf_t{};
+  auto const text = std::string{adr::normalize(params.text_, buf)};
+  utl::verify<net::bad_request_exception>(!text.empty(),
+                                          "text must not be empty");
+
+  auto const place = params.place_.and_then([](std::string const& s) {
+    auto const parsed = parse_location(s);
+    utl::verify<net::bad_request_exception>(parsed.has_value(),
+                                            "could not parse place {}", s);
+    return std::optional{parsed.value().pos_};
+  });
+
+  auto const config_limit =
+      static_cast<std::int64_t>(config_.get_limits().route_search_max_results_);
+  auto const num_results =
+      std::min(params.numResults_.value_or(kDefaultNumResults), config_limit);
+  utl::verify<net::bad_request_exception>(num_results >= 1,
+                                          "numResults must be >= 1");
+
+  auto candidates = collect_candidates(tt_, text, params.language_, buf);
+
+  auto const place_bias = static_cast<float>(params.placeBias_);
+  if (place.has_value() && place_bias != 0.F) {
+    for (auto& c : candidates) {
+      auto const dist_km =
+          distance_to(route_box(tt_, shapes_, c.rep_), *place) / 1000.0;
+      c.score_ -= place_bias * kDistancePenalty *
+                  static_cast<float>(std::log1p(dist_km));
+    }
+  }
+
+  truncate(candidates, static_cast<std::size_t>(num_results));
+
+  for (auto& c : candidates) {
+    c.routes_ = get_routes(tt_, tt_.route_ids_[c.src_], c.r_id_);
+  }
+
+  return to_response(tt_, candidates, params.language_);
+}
+
+}  // namespace motis::ep

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -112,6 +112,7 @@ limits:
   street_routing_max_direct_seconds: 21600
   geocode_max_suggestions: 512
   reverse_geocode_max_results: 512
+  route_search_max_results: 512
   max_max_matching_distance: 250.000000
 osr_footpath: true
 geocoding: true

--- a/test/endpoints/map_route_search_test.cc
+++ b/test/endpoints/map_route_search_test.cc
@@ -1,0 +1,180 @@
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "net/bad_request_exception.h"
+
+#include "utl/init_from.h"
+#include "utl/to_vec.h"
+
+#include "motis-api/motis-api.h"
+#include "motis/config.h"
+#include "motis/data.h"
+#include "motis/endpoints/map/route_search.h"
+#include "motis/import.h"
+
+using namespace motis;
+using namespace testing;
+
+constexpr auto const kGTFS = R"(
+# agency.txt
+agency_id,agency_name,agency_url,agency_timezone
+Test,Test Agency,https://example.com,Europe/Berlin
+
+# stops.txt
+stop_id,stop_name,stop_lat,stop_lon
+DA_1,DA Hbf,49.8724891,8.6281994
+DA_2,DA Sued,49.8750407,8.6312172
+DA_3,DA Ost,49.8742551,8.6321063
+HH_1,HH Hbf,53.5528000,10.0067000
+HH_2,HH Altona,53.5575000,10.0150000
+
+# routes.txt
+route_id,agency_id,route_short_name,route_long_name,route_type
+L9_DA,Test,L9,Línia 9,1
+L9_HH,Test,L9,Línia 9,1
+L91,Test,L91,Línia 91,3
+N9,Test,N9,Bus L9 Nit,3
+L9X,Test,L9X,Línia 9 hivern,3
+
+# trips.txt
+route_id,service_id,trip_id,trip_headsign
+L9_DA,S1,T_L9_DA,Nord
+L9_HH,S1,T_L9_HH,Nord
+L91,S1,T_L91,Nord
+N9,S1,T_N9,Nord
+L9X,S_OLD,T_L9X,Nord
+
+# stop_times.txt
+trip_id,arrival_time,departure_time,stop_id,stop_sequence
+T_L9_DA,01:00:00,01:00:00,DA_1,1
+T_L9_DA,01:10:00,01:10:00,DA_2,2
+T_L9_HH,01:00:00,01:00:00,HH_1,1
+T_L9_HH,01:10:00,01:10:00,HH_2,2
+T_L91,01:00:00,01:00:00,DA_2,1
+T_L91,01:10:00,01:10:00,DA_3,2
+T_N9,01:00:00,01:00:00,DA_3,1
+T_N9,01:10:00,01:10:00,DA_1,2
+T_L9X,01:00:00,01:00:00,DA_1,1
+T_L9X,01:10:00,01:10:00,DA_3,2
+
+# calendar_dates.txt
+service_id,date,exception_type
+S1,20190501,1
+S_OLD,20190401,1
+)";
+
+namespace {
+
+std::vector<std::string> ids(api::routeSearch_response const& res) {
+  return utl::to_vec(res.routes_,
+                     [](api::RouteMatch const& m) { return m.transitRoute_.id_; });
+}
+
+}  // namespace
+
+TEST(motis, map_route_search) {
+  auto ec = std::error_code{};
+  std::filesystem::remove_all("test/data", ec);
+
+  auto const c = config{.timetable_ = config::timetable{
+                            .first_day_ = "2019-05-01",
+                            .num_days_ = 2,
+                            .datasets_ = {{"test", {.path_ = kGTFS}}}}};
+  import(c, "test/data");
+  auto d = data{"test/data", c};
+
+  auto const search = utl::init_from<ep::route_search>(d).value();
+
+  {
+    auto const res =
+        search("/api/experimental/map/route-search?text=L9");
+
+    EXPECT_THAT(ids(res), ElementsAre("L9_DA", "L9_HH", "L91", "N9"));
+    EXPECT_THAT(ids(res), Not(Contains("L9X")));
+
+    EXPECT_EQ(res.routes_[0].mode_, api::ModeEnum::SUBWAY);
+    EXPECT_EQ(res.routes_[3].mode_, api::ModeEnum::BUS);
+    EXPECT_THAT(res.routes_[0].agencyName_,
+                Optional(std::string{"Test Agency"}));
+    EXPECT_FALSE(res.routes_[0].routeIndexes_.empty());
+    EXPECT_THAT(res.routes_[0].transitRoute_.shortName_, Eq("L9"));
+    EXPECT_THAT(res.routes_[0].transitRoute_.longName_, Eq("Línia 9"));
+  }
+
+  {
+    auto const res = search(
+        "/api/experimental/map/route-search?text=L9&place=49.87,8.63"
+        "&placeBias=5");
+
+    EXPECT_THAT(ids(res), ElementsAre("L9_DA", "L91", "N9", "L9_HH"));
+  }
+
+  {
+    auto const unbiased =
+        search("/api/experimental/map/route-search?text=L9");
+    auto const zero_bias = search(
+        "/api/experimental/map/route-search?text=L9&place=53.55,10.0"
+        "&placeBias=0");
+
+    EXPECT_EQ(ids(unbiased), ids(zero_bias));
+  }
+
+  {
+    auto const res = search("/api/experimental/map/route-search?text=L");
+
+    EXPECT_THAT(ids(res), Contains("L9_DA"));
+    EXPECT_THAT(ids(res), Not(Contains("L9X")));
+  }
+
+  {
+    auto const res =
+        search("/api/experimental/map/route-search?text=linia%209");
+
+    EXPECT_THAT(ids(res), Contains("L9_DA"));
+  }
+
+  {
+    auto const res =
+        search("/api/experimental/map/route-search?text=L9&numResults=2");
+
+    EXPECT_EQ(res.routes_.size(), 2U);
+  }
+
+  {
+    auto const limited =
+        config{.limits_ = config::limits{.route_search_max_results_ = 1}};
+    auto const capped = ep::route_search{limited, *d.tt_, d.shapes_.get()};
+
+    auto const res =
+        capped("/api/experimental/map/route-search?text=L9&numResults=5");
+
+    EXPECT_EQ(res.routes_.size(), 1U);
+    EXPECT_THAT(ids(res), ElementsAre("L9_DA"));
+  }
+
+  {
+    auto const no_shapes = ep::route_search{d.config_, *d.tt_, nullptr};
+
+    auto const res = no_shapes(
+        "/api/experimental/map/route-search?text=L9&place=49.87,8.63"
+        "&placeBias=5");
+
+    EXPECT_THAT(ids(res), ElementsAre("L9_DA", "L91", "N9", "L9_HH"));
+  }
+
+  {
+    EXPECT_THROW(search("/api/experimental/map/route-search?text="),
+                 net::bad_request_exception);
+    EXPECT_THROW(
+        search("/api/experimental/map/route-search?text=L9&numResults=0"),
+        net::bad_request_exception);
+    EXPECT_THROW(
+        search("/api/experimental/map/route-search?text=L9&place=nonsense"),
+        net::bad_request_exception);
+  }
+}


### PR DESCRIPTION
This PR adds a new endpoint, `experimental/map/route-search`, to search for routes (transit lines) by their name. Currently, the existing `experimental/map/routes` endpoint returns routes in a given area frame but one cannot just simply search for a line given its name.

The endpoint takes both `place` and `placeBias` (akin to `v1/geocode`), in order to give more weight to closer lines.
It's aimed at looking for a route when one does not know the name of a given stop or the exact shape to pinpoint it via a map. It implies the subsequent usage of `experimental/map/route-details` to look up any of the route indexes for a given line. For this reason the endpoint doesn't return geometry data.

### Parameters
| Name | Type | Required | Default | Description |
|------|------|----------|-----|------------|
| `text` | `string` | yes | - | The (potentially partially typed) route name to search for |
| `place` | `string` | no | - |`latitude,longitude` pair used for biasing results towards the coordinate |
| `placeBias` | `number` | no | 1 |  Used for biasing results towards the coordinate. Higher number = higher bias. 0 disables the bias |
| `numResults` | `integer` | no | 10 | Number of transit routes to return. Capped by `route_search_max_results` |
| `language` | `string[]` | no | - | Language preference for translated names (BCP-47, e.g. `en`, `fr`, `de`) |

### Response
A JSON with a single field, `routes`, consisting of an array of matches, ordered by score. Each match has the following structure:

- mode: `Mode`
- transitRoute: `TransitRouteInfo`
- agencyName: `string` (optional)
- routeIndexes: `integer[]`
- score: `number`

### Example
```http
GET /api/experimental/map/route-search?text=v23
GET /api/experimental/map/route-search?text=L9&place=41.3874,2.1686&placeBias=2
GET /api/experimental/map/route-search?text=catalunya&place=41.3874,2.1686&placeBias=2&numResults=5
```

### Config 
Adds a route_search_max_results limit (default 512), bounding numResults, following the existing geocode_max_suggestions pattern.

The reason to add it to experimental is that it's related and implies the usage of two other experimental endpoints. Moreover, the weights for the search score should probably be refined and the existing ones are just what "felt right".