### PR TITLE
gbfs: read num_docks_available, the conditionally required free dock count

### DIFF
--- a/include/motis/gbfs/data.h
+++ b/include/motis/gbfs/data.h
@@ -124,6 +124,9 @@ struct station_information {
   std::string address_{};
   std::string cross_street_{};
   rental_uris rental_uris_{};
+  // Number of physical docks. Absent for virtual/free-floating stations,
+  // where a free dock count of 0 does not mean the station is full.
+  std::optional<unsigned> capacity_{};
 
   std::shared_ptr<tg_geom> station_area_{};
 
@@ -142,6 +145,9 @@ struct station_status {
   unsigned num_vehicles_available_{};
   hash_map<vehicle_type_idx_t, unsigned> vehicle_types_available_{};
   hash_map<vehicle_type_idx_t, unsigned> vehicle_docks_available_{};
+  // Total number of free docks for feeds that publish the total instead of
+  // per vehicle type counts. std::nullopt if the feed publishes neither.
+  std::optional<unsigned> num_docks_available_{};
   bool is_renting_{true};
   bool is_returning_{true};
 };

--- a/include/motis/gbfs/data.h
+++ b/include/motis/gbfs/data.h
@@ -124,8 +124,9 @@ struct station_information {
   std::string address_{};
   std::string cross_street_{};
   rental_uris rental_uris_{};
-  // Number of physical docks. Absent for virtual/free-floating stations,
-  // where a free dock count of 0 does not mean the station is full.
+  // Number of docks or parking spots, if published by the feed. Gates the
+  // num_docks_available fallback: stations that declare no capacity report
+  // 0 free docks without being full.
   std::optional<unsigned> capacity_{};
 
   std::shared_ptr<tg_geom> station_area_{};
@@ -146,7 +147,8 @@ struct station_status {
   hash_map<vehicle_type_idx_t, unsigned> vehicle_types_available_{};
   hash_map<vehicle_type_idx_t, unsigned> vehicle_docks_available_{};
   // Total number of free docks for feeds that publish the total instead of
-  // per vehicle type counts. std::nullopt if the feed publishes neither.
+  // per vehicle type counts. std::nullopt if the feed does not publish
+  // num_docks_available; not computed from vehicle_docks_available.
   std::optional<unsigned> num_docks_available_{};
   bool is_renting_{true};
   bool is_returning_{true};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5086,14 +5086,13 @@ components:
         capacity:
           type: integer
           description: |
-            Number of physical docks at this station. Absent for virtual or
-            free-floating stations that do not have docks.
+            Number of docks or parking spots at this station.
         numDocksAvailable:
           type: integer
           description: |
             Total number of free docks at this station, for feeds that publish
             the total instead of per vehicle type counts. Absent if the feed
-            publishes neither.
+            does not publish num_docks_available.
         stationArea:
           $ref: '#/components/schemas/MultiPolygon'
         bbox:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5083,6 +5083,17 @@ components:
           description: List of vehicle docks currently available at this station (vehicle type ID -> count)
           additionalProperties:
             type: integer
+        capacity:
+          type: integer
+          description: |
+            Number of physical docks at this station. Absent for virtual or
+            free-floating stations that do not have docks.
+        numDocksAvailable:
+          type: integer
+          description: |
+            Total number of free docks at this station, for feeds that publish
+            the total instead of per vehicle type counts. Absent if the feed
+            publishes neither.
         stationArea:
           $ref: '#/components/schemas/MultiPolygon'
         bbox:

--- a/src/endpoints/map/rental.cc
+++ b/src/endpoints/map/rental.cc
@@ -390,6 +390,8 @@ api::rentals_response rental::operator()(
             .formFactors_ = sorted_form_factors,
             .vehicleTypesAvailable_ = std::move(types_available),
             .vehicleDocksAvailable_ = std::move(docks_available),
+            .capacity_ = st.info_.capacity_,
+            .numDocksAvailable_ = st.status_.num_docks_available_,
             .stationArea_ = st.info_.station_area_ != nullptr
                                 ? std::optional{multipoly_to_api(
                                       st.info_.station_area_.get())}

--- a/src/gbfs/osr_mapping.cc
+++ b/src/gbfs/osr_mapping.cc
@@ -243,6 +243,11 @@ struct osr_mapping {
               st.status_.vehicle_docks_available_, [&](auto const& vt) {
                 return vt.second != 0 && prod.includes_vehicle_type(vt.first);
               });
+        } else if (is_returning && st.status_.num_docks_available_ &&
+                   st.info_.capacity_.value_or(0U) > 0U) {
+          // no counts per vehicle type: fall back to the published total,
+          // but only for stations that declare physical docks
+          is_returning = *st.status_.num_docks_available_ != 0;
         }
 
         if (!is_renting && !is_returning) {

--- a/src/gbfs/parser.cc
+++ b/src/gbfs/parser.cc
@@ -378,6 +378,9 @@ void load_station_information(gbfs_provider& provider,
                   .address_ = optional_str(station_obj, "address"),
                   .cross_street_ = optional_str(station_obj, "cross_street"),
                   .rental_uris_ = parse_rental_uris(station_obj),
+                  .capacity_ = station_obj.contains("capacity")
+                                   ? as_count(station_obj.at("capacity"))
+                                   : std::nullopt,
                   .station_area_ =
                       std::shared_ptr<tg_geom>(area, tg_geom_deleter{})}};
   }
@@ -498,6 +501,13 @@ void load_station_status(gbfs_provider& provider, json::value const& root) {
           }
         }
       }
+    }
+
+    // Feeds that do not break down free docks by vehicle type may still
+    // publish the total (GBFS 2.x and 3.x).
+    if (auto const it = station_obj.find("num_docks_available");
+        it != station_obj.end()) {
+      station.status_.num_docks_available_ = as_count(it->value());
     }
   }
 }

--- a/src/gbfs/update.cc
+++ b/src/gbfs/update.cc
@@ -250,6 +250,11 @@ bool station_relevant_for_product(station const& st,
         utl::any_of(st.status_.vehicle_docks_available_, [&](auto const& vt) {
           return vt.second != 0 && prod.includes_vehicle_type(vt.first);
         });
+  } else if (is_returning && st.status_.num_docks_available_ &&
+             st.info_.capacity_.value_or(0U) > 0U) {
+    // no counts per vehicle type: fall back to the published total, but
+    // only for stations that declare physical docks
+    is_returning = *st.status_.num_docks_available_ != 0;
   }
   return is_renting || is_returning;
 }

--- a/test/gbfs_parser_test.cc
+++ b/test/gbfs_parser_test.cc
@@ -772,6 +772,90 @@ TEST(motis, gbfs_parser_station_status_count_only_creates_default_type) {
             provider.vehicle_types_.front().form_factor_);
 }
 
+TEST(motis, gbfs_parser_station_status_total_docks_fallback) {
+  auto provider = gbfs_provider{.id_ = "provider"};
+
+  load_station_information(provider, json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "2.3",
+    "data": {
+      "stations": [
+        {"station_id": "station-1", "name": "A", "lat": 48.1, "lon": 11.5,
+         "capacity": 20},
+        {"station_id": "station-2", "name": "B", "lat": 48.2, "lon": 11.6,
+         "capacity": 25},
+        {"station_id": "station-3", "name": "C", "lat": 48.3, "lon": 11.7,
+         "capacity": 10},
+        {"station_id": "station-4", "name": "D", "lat": 48.4, "lon": 11.8}
+      ]
+    }
+  })"));
+
+  // station-1: docked feed publishing only the total (e.g. Velib Paris),
+  // full station. station-2: same layout with free docks. station-3: no dock
+  // information at all.
+  load_station_status(provider, json::parse(R"({
+    "last_updated": 1,
+    "ttl": 60,
+    "version": "2.3",
+    "data": {
+      "stations": [
+        {
+          "station_id": "station-1",
+          "num_bikes_available": 30,
+          "num_docks_available": 0,
+          "is_renting": true,
+          "is_returning": true
+        },
+        {
+          "station_id": "station-2",
+          "num_bikes_available": 3,
+          "num_docks_available": 22,
+          "is_renting": true,
+          "is_returning": true
+        },
+        {
+          "station_id": "station-3",
+          "num_bikes_available": 5,
+          "is_renting": true,
+          "is_returning": true
+        },
+        {
+          "station_id": "station-4",
+          "num_bikes_available": 6,
+          "num_docks_available": 0,
+          "is_renting": true,
+          "is_returning": true
+        }
+      ]
+    }
+  })"));
+
+  auto const& full = provider.stations_.at("station-1").status_;
+  ASSERT_TRUE(full.num_docks_available_.has_value());
+  EXPECT_EQ(0U, *full.num_docks_available_);
+  EXPECT_TRUE(full.vehicle_docks_available_.empty());
+
+  auto const& free = provider.stations_.at("station-2").status_;
+  ASSERT_TRUE(free.num_docks_available_.has_value());
+  EXPECT_EQ(22U, *free.num_docks_available_);
+
+  auto const& unknown = provider.stations_.at("station-3").status_;
+  EXPECT_FALSE(unknown.num_docks_available_.has_value());
+
+  // capacity is parsed and distinguishes docked stations from virtual ones
+  EXPECT_EQ(20U,
+            provider.stations_.at("station-1").info_.capacity_.value_or(0U));
+  EXPECT_FALSE(provider.stations_.at("station-4").info_.capacity_.has_value());
+
+  // station-4 reports 0 free docks but declares no capacity: it is a virtual
+  // station, so the total must not be treated as "full"
+  auto const& virt = provider.stations_.at("station-4").status_;
+  ASSERT_TRUE(virt.num_docks_available_.has_value());
+  EXPECT_EQ(0U, *virt.num_docks_available_);
+}
+
 TEST(motis, gbfs_parser_system_information_localized_name_and_defaults) {
   auto provider = gbfs_provider{.id_ = "fallback-id"};
 

--- a/ui/api/openapi/schemas.gen.ts
+++ b/ui/api/openapi/schemas.gen.ts
@@ -1399,6 +1399,18 @@ export const RentalStationSchema = {
                 type: 'integer'
             }
         },
+        capacity: {
+            type: 'integer',
+            description: `Number of docks or parking spots at this station.
+`
+        },
+        numDocksAvailable: {
+            type: 'integer',
+            description: `Total number of free docks at this station, for feeds that publish
+the total instead of per vehicle type counts. Absent if the feed
+does not publish num_docks_available.
+`
+        },
         stationArea: {
             '$ref': '#/components/schemas/MultiPolygon'
         },

--- a/ui/api/openapi/types.gen.ts
+++ b/ui/api/openapi/types.gen.ts
@@ -1139,6 +1139,18 @@ export type RentalStation = {
     vehicleDocksAvailable: {
         [key: string]: (number);
     };
+    /**
+     * Number of docks or parking spots at this station.
+     *
+     */
+    capacity?: number;
+    /**
+     * Total number of free docks at this station, for feeds that publish
+     * the total instead of per vehicle type counts. Absent if the feed
+     * does not publish num_docks_available.
+     *
+     */
+    numDocksAvailable?: number;
     stationArea?: MultiPolygon;
     /**
      * Bounding box of the area covered by this station,


### PR DESCRIPTION
## Problem

`load_station_status()` only reads `vehicle_docks_available` (free docks broken down per vehicle type). Feeds that publish only the plain `num_docks_available` total lose their free dock count entirely.

Per the GBFS spec this is backwards. `num_docks_available` is conditionally REQUIRED ("REQUIRED except for stations that have unlimited docking capacity"), while `vehicle_docks_available` is only REQUIRED "in feeds where vehicle_types.json is defined and certain docks accept only specific vehicle types". A docked network that does not restrict docks by vehicle type is conformant when it publishes the total alone, so the parser is currently reading the optional refinement and ignoring the required field.

This is not an edge case. I could not find a single deployed feed on Transitous that publishes the typed variant. Checked directly against the live feeds:

| feed | stations | `vehicle_docks_available` | `num_docks_available` |
|---|---|---|---|
| Velib Paris | 1519 | 0 | 1519 |
| WienMobil Rad (`nextbike_wr`) | 267 | 0 | 267 |
| nextbike `bn` | 1050 | 0 | 1050 |

`/api/v1/rentals` accordingly returns `vehicleDocksAvailable: {}` for every station of these providers, in Paris, Vienna and Berlin alike.

Two consequences:

1. **Routing**: the return checks in `station_relevant_for_product()` (update.cc) and `osr_mapping::map_stations()` fall through to the bare `is_returning` flag, so a full station still advertising `is_returning: true` is proposed as a drop-off target. Measured on the live feeds: 24 such stations in Paris, 62 in Vienna (e.g. Julius-Raab-Platz, capacity 17, 32 bikes parked, 0 free docks).
2. **Display**: clients cannot show free dock counts for any of these feeds.

## Change

* `station_status` gains `std::optional<unsigned> num_docks_available_`, parsed from `num_docks_available` (same field name in GBFS 2.x and 3.x).
* The two return checks use it as a fallback **only when `vehicle_docks_available` is absent**. Typed counts keep precedence.
* `station_information` gains `std::optional<unsigned> capacity_`, parsed from `capacity`.
* Both are exposed on `RentalStation` as optional `numDocksAvailable` and `capacity`.

## Why the capacity guard matters

Virtual and free-floating stations legitimately report `num_docks_available: 0` while still accepting returns, so treating 0 as "full" would wrongly block them. `capacity` separates the two cases: in WienMobil Rad, 68 of the 130 stations reporting 0 free docks declare no capacity at all, and stay returnable. The remaining 62 declare physical docks and are genuinely over capacity.

One deliberate limitation: `capacity` is OPTIONAL in `station_information.json`, so a docked station that omits it will not get the new return check. That keeps the change strictly non-regressive, at the cost of not covering feeds that publish dock counts without declaring capacity.

`std::optional` likewise keeps "feed does not publish dock counts" distinct from "0 free docks", so providers publishing neither field keep the current behavior.

## Testing

* Parser test `gbfs_parser_station_status_total_docks_fallback` covers: total-only full station, total-only with free docks, no dock info at all (`nullopt`), and a capacity-less station reporting 0 docks.
* Full suite green locally, 170/170 (macOS arm64, Apple clang 21, Release).
* clang-format clean on all touched files.

Happy to adjust the guard if you would rather key it on something other than `capacity`, or to split the API additions into a separate PR.

Disclosure: this change was written with AI assistance (Claude). The measurements above were taken against the live feeds, and the code was built and tested locally before submitting.
