### PR TITLE
feature: resolve all codes before throwing not_found_exception with unknownCodes array

### DIFF
--- a/include/motis/place.h
+++ b/include/motis/place.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <optional>
+#include <string_view>
+#include <vector>
 
 #include "osr/location.h"
 
@@ -82,6 +84,15 @@ osr::location get_location(nigiri::timetable const*,
 place_t get_place(nigiri::timetable const*,
                   tag_lookup const*,
                   std::string_view user_input);
+
+// Checks all codes with the tag_lookup and throws a single
+// net::not_found_exception listing every unknown code in its "unknownCodes"
+// payload instead of failing at the first unknown one. Inputs in
+// `may_be_coords` may alternatively be "lat,lng[,level]" coordinates.
+void verify_locations_exist(nigiri::timetable const*,
+                            tag_lookup const*,
+                            std::vector<std::string_view> const& may_be_coords,
+                            std::vector<std::string_view> const& codes);
 
 api::Place bwd_compat_lvl_adjust(api::Place&& pl, unsigned api_version);
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6190,6 +6190,14 @@ components:
         error:
           type: string
           description: error message
+        unknownCodes:
+          type: array
+          description: |
+            Set if the error was caused by unknown timetable location IDs.
+            Contains all unknown IDs from the request
+            (e.g. fromPlace, toPlace, via, offset stopId).
+          items:
+            type: string
 
     RouteSegment:
       description: Route segment between two stops to show a route on a map

--- a/src/endpoints/one_to_many_post.cc
+++ b/src/endpoints/one_to_many_post.cc
@@ -17,6 +17,10 @@ api::oneToManyPost_response one_to_many_post::operator()(
 
 api::OneToManyIntermodalResponse one_to_many_intermodal_post::operator()(
     api::OneToManyIntermodalParams const& query) const {
+  auto places = std::vector<std::string_view>{query.one_};
+  places.insert(end(places), begin(query.many_), end(query.many_));
+  verify_locations_exist(&tt_, &tags_, places, {});
+
   auto const one = get_place(&tt_, &tags_, query.one_);
   auto const many =
       utl::to_vec(query.many_, [&](std::string_view place) -> place_t {

--- a/src/endpoints/routing.cc
+++ b/src/endpoints/routing.cc
@@ -810,6 +810,22 @@ api::plan_response routing::route(api::plan_params const& query,
   auto const pre_transit_modes = deduplicate(query.preTransitModes_);
   auto const post_transit_modes = deduplicate(query.postTransitModes_);
   auto const direct_modes = deduplicate(query.directModes_);
+  auto codes = std::vector<std::string_view>{};
+  if (query.via_.has_value()) {
+    codes.assign(begin(*query.via_), end(*query.via_));
+  }
+  if (post_body != nullptr) {
+    for (auto const* offsets :
+         {&post_body->fromOffsets_, &post_body->toOffsets_}) {
+      if (offsets->has_value()) {
+        for (auto const& o : **offsets) {
+          codes.push_back(o.stopId_);
+        }
+      }
+    }
+  }
+  verify_locations_exist(tt_, tags_, {query.fromPlace_, query.toPlace_}, codes);
+
   auto const from = get_place(tt_, tags_, query.fromPlace_);
   auto const to = get_place(tt_, tags_, query.toPlace_);
   auto from_p = to_place(tt_, tags_, w_, pl_, matches_, ae_, tz_, lang, from);

--- a/src/endpoints/stop.cc
+++ b/src/endpoints/stop.cc
@@ -26,8 +26,8 @@ api::stopInfo_response stop::operator()(
   auto const query = api::stopInfo_params{url.params()};
   auto const& lang = query.language_;
 
-  auto const query_stop = query.stopId_.and_then(
-      [&](std::string const& x) { return tags_.find_location(tt_, x); });
+  auto const query_stop = query.stopId_.transform(
+      [&](std::string const& x) { return tags_.get_location(tt_, x); });
   auto const query_center = query.center_.and_then(
       [&](std::string const& x) { return parse_location(x); });
 

--- a/src/endpoints/stop_times.cc
+++ b/src/endpoints/stop_times.cc
@@ -515,8 +515,8 @@ api::stoptimes_response stop_times::operator()(
   auto const base_ev_type = is_arr ? n::event_type::kArr : n::event_type::kDep;
   auto const api_version = get_api_version(url);
   auto const& lang = query.language_;
-  auto const query_stop = query.stopId_.and_then(
-      [&](std::string const& x) { return tags_.find_location(tt_, x); });
+  auto const query_stop = query.stopId_.transform(
+      [&](std::string const& x) { return tags_.get_location(tt_, x); });
   auto const query_center = query.center_.and_then(
       [&](std::string const& x) { return parse_location(x); });
 

--- a/src/place.cc
+++ b/src/place.cc
@@ -2,6 +2,13 @@
 
 #include <variant>
 
+#include "boost/json/value_from.hpp"
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+
+#include "net/not_found_exception.h"
+
 #include "utl/verify.h"
 
 #include "osr/location.h"
@@ -231,6 +238,41 @@ place_t get_place(n::timetable const* tt,
   utl::verify(tt != nullptr && tags != nullptr,
               R"(could not parse location (no timetable loaded): "{}")", input);
   return tt_location{tags->get_location(*tt, input)};
+}
+
+void verify_locations_exist(n::timetable const* tt,
+                            tag_lookup const* tags,
+                            std::vector<std::string_view> const& may_be_coords,
+                            std::vector<std::string_view> const& codes) {
+  if (tt == nullptr || tags == nullptr) {
+    return;  // get_place reports the missing timetable with a precise message
+  }
+
+  auto unknown = std::vector<std::string>{};
+  auto const check = [&](std::string_view const code) {
+    try {
+      if (!tags->find_location(*tt, code).has_value()) {
+        unknown.emplace_back(code);
+      }
+    } catch (net::not_found_exception const&) {  // unknown feed id
+      unknown.emplace_back(code);
+    }
+  };
+  for (auto const code : may_be_coords) {
+    if (!parse_location(code).has_value()) {
+      check(code);
+    }
+  }
+  for (auto const code : codes) {
+    check(code);
+  }
+
+  if (!unknown.empty()) {
+    throw net::not_found_exception{
+        fmt::format("Could not find timetable locations: {:?}",
+                    fmt::join(unknown, ", ")),
+        {{"unknownCodes", boost::json::value_from(unknown)}}};
+  }
 }
 
 api::Place bwd_compat_lvl_adjust(api::Place&& pl, unsigned const api_version) {

--- a/src/tag_lookup.cc
+++ b/src/tag_lookup.cc
@@ -2,6 +2,8 @@
 
 #include <ctime>
 
+#include "boost/json/array.hpp"
+
 #include "fmt/chrono.h"
 #include "fmt/core.h"
 
@@ -160,8 +162,9 @@ n::location_idx_t tag_lookup::get_location(n::timetable const& tt,
   if (auto const res = find_location(tt, s); res.has_value()) {
     return *res;
   }
-  throw utl::fail<net::not_found_exception>(
-      "Could not find timetable location {:?}", s);
+  throw net::not_found_exception{
+      fmt::format("Could not find timetable location {:?}", s),
+      {{"unknownCodes", boost::json::array{s}}}};
 }
 
 std::optional<n::location_idx_t> tag_lookup::find_location(
@@ -169,8 +172,10 @@ std::optional<n::location_idx_t> tag_lookup::find_location(
   auto const [tag, id] = split_tag_id(s);
 
   auto const src = get_src(tag);
-  utl::verify<net::not_found_exception>(src != n::source_idx_t::invalid(),
-                                        "unknown feed id {:?}", tag);
+  if (src == n::source_idx_t::invalid()) {
+    throw net::not_found_exception{fmt::format("unknown feed id {:?}", tag),
+                                   {{"unknownCodes", boost::json::array{s}}}};
+  }
 
   auto const it = tt.locations_.location_id_to_idx_.find({id, src});
   if (it == end(tt.locations_.location_id_to_idx_)) {

--- a/test/routing_test.cc
+++ b/test/routing_test.cc
@@ -387,6 +387,21 @@ TEST(motis, routing_unknown_feed_id) {
                        "&time=2019-05-01T01:30Z"
                        "&timetableView=false"),
                net::not_found_exception);
+
+  // all unknown location codes are collected and reported at once
+  try {
+    routing(
+        "?fromPlace=unknown_DA_10"
+        "&toPlace=test_UNKNOWN"
+        "&via=test_ALSO_UNKNOWN"
+        "&time=2019-05-01T01:30Z"
+        "&timetableView=false");
+    FAIL() << "expected net::not_found_exception";
+  } catch (net::not_found_exception const& e) {
+    EXPECT_EQ(
+        (json::array{"unknown_DA_10", "test_UNKNOWN", "test_ALSO_UNKNOWN"}),
+        e.payload_.at("unknownCodes").as_array());
+  }
 }
 
 TEST(motis, routing_post_client_offsets) {
@@ -434,6 +449,20 @@ TEST(motis, routing_post_client_offsets) {
     EXPECT_EQ("ICE", j.legs_[1].routeShortName_.value_or("-"));
     EXPECT_EQ(21 * 60, j.legs_.front().duration_);
     EXPECT_EQ(22 * 60, j.legs_.back().duration_);
+  }
+
+  // unknown offset stop ids are collected and reported at once
+  {
+    auto const body = to_body(api::PlanPostBody{
+        .fromOffsets_ = {{{.stopId_ = "test_UNKNOWN", .duration_ = 60}}},
+        .toOffsets_ = {{{.stopId_ = "test_ALSO_UNKNOWN", .duration_ = 60}}}});
+    try {
+      post(kUrl, body);
+      FAIL() << "expected net::not_found_exception";
+    } catch (net::not_found_exception const& e) {
+      EXPECT_EQ((json::array{"test_UNKNOWN", "test_ALSO_UNKNOWN"}),
+                e.payload_.at("unknownCodes").as_array());
+    }
   }
 
   // arriveBy=true: fromOffsets still attach to the fromPlace side (the

--- a/test/tag_lookup_test.cc
+++ b/test/tag_lookup_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 
+#include "boost/json.hpp"
 #include "boost/url/url.hpp"
 
 #include "nigiri/types.h"
@@ -94,6 +95,15 @@ TEST(motis, tag_lookup) {
                net::not_found_exception);
   EXPECT_THROW(d.tags_->find_location(*d.tt_, "unknown_DA 10"),
                net::not_found_exception);
+
+  // unknown codes are reported in the exception payload
+  try {
+    d.tags_->get_location(*d.tt_, "test_UNKNOWN");
+    FAIL() << "expected net::not_found_exception";
+  } catch (net::not_found_exception const& e) {
+    EXPECT_EQ((boost::json::array{"test_UNKNOWN"}),
+              e.payload_.at("unknownCodes").as_array());
+  }
 
   auto u = boost::urls::url{
       "/api",

--- a/ui/api/openapi/schemas.gen.ts
+++ b/ui/api/openapi/schemas.gen.ts
@@ -2620,6 +2620,13 @@ export const ErrorSchema = {
         error: {
             type: 'string',
             description: 'error message'
+        },
+        unknownCodes: {
+            type: 'array',
+            description: 'Set if the error was caused by unknown timetable location IDs. Contains all unknown IDs from the request (e.g. fromPlace, toPlace, via, offset stopId).',
+            items: {
+                type: 'string'
+            }
         }
     }
 } as const;

--- a/ui/api/openapi/types.gen.ts
+++ b/ui/api/openapi/types.gen.ts
@@ -2077,6 +2077,10 @@ export type Error = {
      * error message
      */
     error: string;
+    /**
+     * Set if the error was caused by unknown timetable location IDs. Contains all unknown IDs from the request (e.g. fromPlace, toPlace, via, offset stopId).
+     */
+    unknownCodes?: Array<(string)>;
 };
 
 /**


### PR DESCRIPTION
Hello,
Like discussed last weekend, here is the PR for unknown codes resolution.

`/plan` currently fails fast on the first unknown timetable location ID, so clients fix`fromPlace`/`toPlace`/`via` one at a time and have to parse the ID out of the message string. This PR validates all location IDs of a request up front (also POST offset `stopId`s and `one`/`many` in POST one-to-many) and reports every unknown one at once in a new optional `unknownCodes` array on the `Error` schema : not a breaking change, existing error responses stay identical. 

`/stoptimes` and `/stop` with an unknown `stopId` now return 404 with `unknownCodes` instead of silently ignoring the parameter. **would you be ok with this?**

Requires motis-project/net#35, which lets `net::not_found_exception` carry an optional JSON payload that the query router merges into the error body.